### PR TITLE
Force deployment refresh for custom domain

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>HumpDay: Pure Python and JavaScript Derivative-Free Optimization</title>
+    <!-- Force deployment refresh -->
     <meta name="description" content="A collection of 22 derivative-free optimization algorithms implemented in pure Python and JavaScript with comprehensive validation.">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" crossorigin="anonymous">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
- Add comment to trigger GitHub Pages redeploy
- Investigate why humpday.microprediction.org shows old content
- All recent changes should be visible on custom domain