### PR TITLE
docs: add Python + JavaScript source links to index page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -115,7 +115,8 @@
 
         <div style="text-align: center; margin: 8px 0; padding: 4px;">
             <a href="contest.html" class="btn" style="margin: 0 10px; padding: 6px 12px;">Run Algorithm Contest</a>
-            <a href="https://github.com/microprediction/humpday/tree/main/docs/js/modules" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;" target="_blank">JavaScript Modular Source</a>
+            <a href="https://github.com/microprediction/humpday/tree/main/humpday" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;" target="_blank" rel="noopener">Python Source</a>
+            <a href="https://github.com/microprediction/humpday/tree/main/docs/js/modules" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;" target="_blank" rel="noopener">JavaScript Source</a>
             <a href="test-modular.html" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;">Test All Algorithms</a>
         </div>
 


### PR DESCRIPTION
Replace the single "JavaScript Modular Source" button with a symmetric pair pointing at both language source trees:

- Python Source     -> tree/main/humpday
- JavaScript Source -> tree/main/docs/js/modules

Drop the "Modular" qualifier (redundant — there is only one JS source tree to link to). Add rel="noopener" to external-target links for the usual tabnabbing-mitigation reason.