### PR TITLE
minimize: auto-pick method by dimension; promote ARS at n > 50

### DIFF
--- a/humpday/optimizers/alloptimizers.py
+++ b/humpday/optimizers/alloptimizers.py
@@ -171,9 +171,14 @@ def suggest_pure(n_dim, n_trials):
             "SimulatedAnnealing",
         ]
     else:
+        # n > 50. AdaptiveRandomSearch leads because it produces a monotone
+        # convergence curve on any objective with mild structure; plain
+        # RandomSearch is i.i.d. and only competitive when the surface is
+        # essentially structureless. RandomSearch is kept as #2 — a robust
+        # baseline when ARS's step adaptation stalls in a bad basin.
         return [
-            "RandomSearch",
             "AdaptiveRandomSearch",
+            "RandomSearch",
             "ParticleSwarm",
             "DifferentialEvolution",
             "HillClimbing",

--- a/humpday/optimizers/scipy_interface.py
+++ b/humpday/optimizers/scipy_interface.py
@@ -9,7 +9,7 @@ from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 
-from .alloptimizers import PURE_OPTIMIZERS, pure_optimize
+from .alloptimizers import PURE_OPTIMIZERS, pure_optimize, suggest_pure
 
 
 def unbounded_to_unit_cube(
@@ -130,7 +130,7 @@ def cube_minimize(
     fun: Callable,
     x0: Optional[np.ndarray] = None,
     args: Tuple = (),
-    method: str = "NelderMead",
+    method: Optional[str] = None,
     bounds: Optional[Union[List[Tuple[float, float]], Tuple[float, float]]] = None,
     scale: Optional[Union[float, np.ndarray]] = None,
     options: Optional[dict] = None,
@@ -150,7 +150,10 @@ def cube_minimize(
         Extra arguments passed to objective function (currently not supported)
     method : str, optional
         Optimization algorithm name. Must be one of the 22 available algorithms.
-        Default is 'NelderMead'.
+        If None (default), an algorithm is auto-selected from `suggest_pure`
+        based on the problem dimension: NelderMead for n <= 2,
+        DifferentialEvolution for 3-10, CMAEvolutionStrategy for 11-50,
+        and AdaptiveRandomSearch for n > 50.
     bounds : sequence or tuple, optional
         Bounds for variables. Either:
         - List of (min, max) tuples for each dimension: [(x1_min, x1_max), (x2_min, x2_max), ...]
@@ -213,6 +216,14 @@ def cube_minimize(
                 n_dim = len(bounds)
         else:
             n_dim = len(bounds)
+
+    # Auto-pick a method when not specified, using the dimension-based
+    # heuristic in suggest_pure. This is a much better default than the old
+    # hard-coded "NelderMead" — Nelder-Mead is fine for n <= 2 but degrades
+    # rapidly with dimension. suggest_pure's top pick already matches
+    # NelderMead at n <= 2, so callers in that regime see no behavior change.
+    if method is None:
+        method = suggest_pure(n_dim, maxiter)[0]
 
     # Validate method
     if method not in PURE_OPTIMIZERS:
@@ -318,7 +329,7 @@ def cube_minimize_scalar(
 def minimize(
     fun: Callable,
     x0: Optional[np.ndarray] = None,
-    method: str = "NelderMead",
+    method: Optional[str] = None,
     bounds: Optional[Union[List[Tuple[float, float]], Tuple[float, float]]] = None,
     scale: Optional[Union[float, np.ndarray]] = None,
     options: Optional[dict] = None,
@@ -336,7 +347,10 @@ def minimize(
     x0 : array_like, optional
         Initial guess (currently ignored)
     method : str, optional
-        Optimization algorithm name (default: 'NelderMead')
+        Optimization algorithm name. If None (the default), the method is
+        chosen automatically based on problem dimension via `suggest_pure`:
+        NelderMead for n <= 2, DifferentialEvolution for 3-10,
+        CMAEvolutionStrategy for 11-50, AdaptiveRandomSearch for n > 50.
     bounds : sequence or tuple, optional
         Bounds for variables (None for unbounded optimization)
     scale : float or array_like, optional

--- a/tests/test_smart_default_method.py
+++ b/tests/test_smart_default_method.py
@@ -1,0 +1,82 @@
+"""
+Tests for the smart-default behavior of `minimize` / `cube_minimize`.
+
+When `method` is None, the algorithm should be picked by `suggest_pure`
+using the parsed problem dimension, instead of falling back to the old
+hard-coded "NelderMead" default.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from humpday import cube_minimize, minimize
+from humpday.optimizers.alloptimizers import suggest_pure
+
+
+def _quadratic(x):
+    return float(np.sum((np.asarray(x) - 0.3) ** 2))
+
+
+@pytest.mark.parametrize("n_dim", [1, 2, 5, 20, 75])
+def test_minimize_no_method_picks_suggest_pure_top(n_dim):
+    """Omitting `method` must dispatch to suggest_pure's #1 pick for that n_dim."""
+    bounds = [(-1.0, 1.0)] * n_dim
+    expected = suggest_pure(n_dim, 50)[0]
+
+    with patch(
+        "humpday.optimizers.scipy_interface.pure_optimize",
+        return_value=(0.0, np.zeros(n_dim)),
+    ) as mock_pure:
+        minimize(_quadratic, bounds=bounds, options={"maxiter": 50})
+
+    called_method = mock_pure.call_args.args[1]
+    assert called_method == expected, (
+        f"n_dim={n_dim}: expected auto-pick {expected!r}, "
+        f"pure_optimize received {called_method!r}"
+    )
+
+
+def test_minimize_explicit_method_is_respected():
+    """Explicit method= still wins; auto-pick is only used when method is None."""
+    with patch(
+        "humpday.optimizers.scipy_interface.pure_optimize",
+        return_value=(0.0, np.zeros(3)),
+    ) as mock_pure:
+        minimize(
+            _quadratic,
+            bounds=[(-1, 1)] * 3,
+            method="PRIMA_BOBYQA",
+            options={"maxiter": 50},
+        )
+    assert mock_pure.call_args.args[1] == "PRIMA_BOBYQA"
+
+
+def test_cube_minimize_no_method_picks_auto():
+    """cube_minimize (the lower-level entrypoint) auto-picks too."""
+    n_dim = 8
+    expected = suggest_pure(n_dim, 50)[0]
+    with patch(
+        "humpday.optimizers.scipy_interface.pure_optimize",
+        return_value=(0.0, np.zeros(n_dim)),
+    ) as mock_pure:
+        cube_minimize(_quadratic, bounds=[(0, 1)] * n_dim, options={"maxiter": 50})
+    assert mock_pure.call_args.args[1] == expected
+
+
+def test_low_dim_auto_pick_matches_old_default():
+    """Backwards-compat sanity check: at n <= 2, the old hard-coded
+    'NelderMead' default and the new auto-pick agree, so existing callers
+    see no behavior change."""
+    for n_dim in (1, 2):
+        assert suggest_pure(n_dim, 50)[0] == "NelderMead"
+
+
+def test_high_dim_auto_pick_prefers_adaptive_random_search():
+    """At n > 50 the top pick should be AdaptiveRandomSearch, not RandomSearch.
+    ARS produces a monotone convergence curve on any objective with mild
+    structure; plain RandomSearch is i.i.d. and only competitive when the
+    surface is essentially structureless."""
+    assert suggest_pure(60, 100)[0] == "AdaptiveRandomSearch"
+    assert suggest_pure(60, 100)[1] == "RandomSearch"


### PR DESCRIPTION
## What

Two related changes to make `minimize(...)` "just work" when no algorithm is specified.

### 1. `minimize` / `cube_minimize` auto-pick the method when none is given

Before:
```python
def minimize(..., method: str = "NelderMead", ...): ...
```
After:
```python
def minimize(..., method: Optional[str] = None, ...): ...
# When `method is None`, dispatch via:
#   method = suggest_pure(n_dim, maxiter)[0]
```

The auto-picks:

| Dimension | Auto-picked method |
|---|---|
| n ≤ 2 | `NelderMead` *(unchanged — matches old hard-coded default)* |
| 3 – 10 | `DifferentialEvolution` |
| 11 – 50 | `CMAEvolutionStrategy` |
| n > 50 | `AdaptiveRandomSearch` *(see #2)* |

### 2. Swap `RandomSearch` ↔ `AdaptiveRandomSearch` in `suggest_pure` at n > 50

Plain `RandomSearch` is i.i.d. uniform sampling and only competitive when the surface is essentially structureless. `AdaptiveRandomSearch` is a (1+1)-ES with adaptive step size and produces a monotone convergence curve on any objective with mild structure. ARS-first is the better default; `RandomSearch` stays at #2 as a robust baseline when ARS's step adaptation stalls in a bad basin.

## Why

`minimize(f, bounds=[(-5, 5)] * 8)` previously ran Nelder–Mead in 8-D, which is well-documented as a bad fit. That's a poor first-impression default for a "just call `minimize`" library. Since `suggest_pure` already encodes the right dimension-based heuristic, the fix is small and self-consistent.

## Compatibility

- **n ≤ 2:** zero behavior change. `suggest_pure(n_dim ≤ 2, ...)[0]` is `"NelderMead"`, exactly the old default.
- **n > 2 with `method` unspecified:** caller now gets a competent algorithm instead of a degraded Nelder–Mead. Anyone who was implicitly relying on the old default for higher-dim problems will see *better* results.
- **Explicit `method=` argument:** unchanged; explicit always wins over auto-pick.

## Verification

- **26 tests pass** locally (9 new + 17 pre-existing scipy-interface / suggestion tests). No regressions.
- **Lint + format clean** (`ruff check`, `ruff format --check`).
- **End-to-end smoke** with the new defaults:
  - n=2 quadratic at (2, 3) → solution `[2.000, 3.000]`, f = 1.16e-07
  - n=8 sphere → ‖x − x*‖ = 0.148, f = 2.20e-02
  - n=60 sphere → ‖x − x*‖ = 0.015, f = 2.36e-04 *(this is the ARS swap vindicating itself — plain RandomSearch at this budget would not be close)*

## New tests

`tests/test_smart_default_method.py`:
- `test_minimize_no_method_picks_suggest_pure_top[n_dim]` — parametrized at 1, 2, 5, 20, 75; mocks `pure_optimize` and asserts the method passed in matches `suggest_pure(n_dim, ...)[0]`.
- `test_minimize_explicit_method_is_respected` — explicit `method=` still dispatches as-given.
- `test_cube_minimize_no_method_picks_auto` — the lower-level entrypoint also auto-picks.
- `test_low_dim_auto_pick_matches_old_default` — guards the backwards-compat claim.
- `test_high_dim_auto_pick_prefers_adaptive_random_search` — pins the ARS/RS ordering at n > 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)