### PR TITLE
release: 0.9.0; add humpday.__version__ and unbreak publish workflow

### DIFF
--- a/humpday/__init__.py
+++ b/humpday/__init__.py
@@ -3,6 +3,18 @@ Humpday: Lightweight derivative-free optimization
 Pure Python implementations with no external dependencies (beyond numpy/scipy)
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("humpday")
+except PackageNotFoundError:
+    # Running from a source checkout without `pip install` — fall back so
+    # `humpday.__version__` is always a string. The CI publish workflow's
+    # `python -c "import humpday; print(humpday.__version__)"` step relies on
+    # this attribute existing.
+    __version__ = "0.0.0+source"
+
 from humpday.optimizers.adaptive_optimizer import (
     EloRatingSystem,
     adaptive_optimize,
@@ -93,6 +105,8 @@ def minimize_unit_cube(
 recommend = suggest
 
 __all__ = [
+    # Package metadata
+    "__version__",
     # Core interface
     "OPTIMIZERS",
     "PURE_OPTIMIZERS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "humpday"
-version = "0.8.0"
+version = "0.9.0"
 description = "Taking the pain out of choosing a Python global optimizer"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_version_attribute.py
+++ b/tests/test_version_attribute.py
@@ -1,0 +1,49 @@
+"""
+Regression tests for the `humpday.__version__` attribute.
+
+The publish workflow (.github/workflows/publish.yml, `test-install` job)
+runs:
+
+    python -c "import humpday; print(f'humpday {humpday.__version__} \
+installed successfully')"
+
+If `__version__` is missing or unparseable, the publish workflow fails
+*after* the wheel has already been built and uploaded as an artifact —
+a noisy, hard-to-diagnose failure mode. These tests catch it locally.
+"""
+
+from __future__ import annotations
+
+import re
+
+import humpday
+
+
+def test_version_attribute_exists():
+    """humpday.__version__ must be a non-empty string."""
+    assert hasattr(humpday, "__version__"), "humpday.__version__ is not defined"
+    assert isinstance(humpday.__version__, str), (
+        f"__version__ must be str, got {type(humpday.__version__).__name__}"
+    )
+    assert humpday.__version__, "__version__ must not be empty"
+
+
+def test_version_looks_like_pep_440():
+    """When running against an installed wheel, the version should look like
+    a PEP 440 release version (e.g. '0.9.0'). The source-checkout fallback
+    is '0.0.0+source', which is also a valid PEP 440 local version segment."""
+    pep440_loose = re.compile(
+        r"^\d+(\.\d+)*"  # release segment
+        r"((a|b|rc)\d+)?"  # pre-release
+        r"(\.post\d+)?"  # post-release
+        r"(\.dev\d+)?"  # dev release
+        r"(\+[A-Za-z0-9.]+)?$"  # local version (e.g. '+source')
+    )
+    assert pep440_loose.match(humpday.__version__), (
+        f"__version__={humpday.__version__!r} does not look like PEP 440"
+    )
+
+
+def test_version_in_dunder_all():
+    """__version__ is part of the documented public surface."""
+    assert "__version__" in humpday.__all__


### PR DESCRIPTION
## What

Release-prep PR that unblocks publishing the next PyPI version. Two coupled changes:

1. **Bump version** `0.8.0 → 0.9.0` in `pyproject.toml`.
2. **Add `humpday.__version__`** — sourced from `importlib.metadata` so it stays auto-synced.
3. **Tests** that lock both invariants in place.

## Why now

The publish workflow's `test-install` job runs:

```python
python -c "import humpday; print(f'humpday {humpday.__version__} installed successfully')"
```

`__version__` was not defined anywhere in the package. The first time the publish workflow ran for real, that step would have failed with `AttributeError` *after* the wheel had already been built and uploaded as an artifact — a noisy and hard-to-diagnose mode. Fixed now, before it bites.

The `0.8.0 → 0.9.0` bump marks the smart-default change in PR #45 cleanly. 0.8.0 was never released on PyPI; current PyPI latest is 0.7.1.

## Implementation

```python
# humpday/__init__.py
from importlib.metadata import PackageNotFoundError
from importlib.metadata import version as _pkg_version

try:
    __version__ = _pkg_version("humpday")
except PackageNotFoundError:
    __version__ = "0.0.0+source"
```

Source-checkout (no `pip install`) gets the sentinel `"0.0.0+source"`. Installed wheels get the real version from package metadata. Single source of truth: `pyproject.toml`.

## End-to-end verification

| Check | Result |
|---|---|
| Source-checkout `humpday.__version__` | `"0.0.0+source"` |
| `python -m build --wheel` | Built `humpday-0.9.0-py3-none-any.whl` (hatchling, isolated) |
| Clean venv install + workflow's one-liner | `humpday 0.9.0 installed successfully` |
| `twine check dist/*` | `PASSED` |
| New tests | 3 passed |
| Full suite | 187 passed, 21 skipped (pre-existing skips), no regressions |
| `ruff check` + `ruff format --check` | clean |

## New tests (`tests/test_version_attribute.py`)

- `test_version_attribute_exists` — attribute is present and non-empty
- `test_version_looks_like_pep_440` — parses as a PEP 440 version (incl. the `+source` local segment fallback)
- `test_version_in_dunder_all` — `__version__` is in `humpday.__all__`

## Release sequence after this merges

1. Merge PR #45 (smart-default) into main.
2. Merge this PR into main.
3. `gh release create v0.9.0 --generate-notes` (or via GitHub UI).
4. The publish workflow fires on `release: published` and pushes 0.9.0 to PyPI via OIDC trusted publishing.

Optional dry-run first: **Actions → "Publish to PyPI" → Run workflow** with `test_pypi=true` to push to TestPyPI before the real release.

## Out of scope

- Publishing itself (waits on PR #45 merge and your release tag).
- Trusted-publisher config on PyPI's side (lives outside the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)