### PR TITLE
docs(index): list all 22 algorithms in Algorithm Categories

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -380,29 +380,47 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
             <p>Model-based algorithms using quadratic approximations:</p>
             <ul>
                 <li><strong>PRIMA UOBYQA:</strong> Unconstrained optimization by quadratic approximation</li>
-                <li><strong>PRIMA NEWUOA:</strong> Powell's method without derivatives</li>
-                <li><strong>PRIMA BOBYQA:</strong> Bound constrained optimization</li>
+                <li><strong>PRIMA NEWUOA:</strong> Derivative-free trust-region method (improved UOBYQA)</li>
+                <li><strong>PRIMA BOBYQA:</strong> Bound-constrained derivative-free optimization</li>
+            </ul>
+
+            <h3>Classic Numerical Methods</h3>
+            <p>Workhorse non-derivative-free methods, ported to pure Python:</p>
+            <ul>
                 <li><strong>Nelder-Mead:</strong> Simplex-based direct search</li>
                 <li><strong>Powell:</strong> Conjugate direction method</li>
+                <li><strong>LBFGSB:</strong> Limited-memory quasi-Newton with box bounds</li>
             </ul>
 
-            <h3>Evolutionary Algorithms</h3>
-            <p>Population-based stochastic optimization methods:</p>
+            <h3>Evolutionary &amp; Swarm</h3>
+            <p>Population-based stochastic methods:</p>
             <ul>
-                <li><strong>Differential Evolution:</strong> Vector-based evolutionary strategy</li>
-                <li><strong>Particle Swarm:</strong> Swarm intelligence optimization</li>
+                <li><strong>Differential Evolution:</strong> Vector-difference mutation with crossover</li>
+                <li><strong>Particle Swarm:</strong> Swarm intelligence with velocity updates</li>
                 <li><strong>CMA Evolution Strategy:</strong> Covariance matrix adaptation</li>
+                <li><strong>Evolution Strategy:</strong> (μ/λ) population search with self-adaptation</li>
                 <li><strong>Genetic Algorithm:</strong> Selection, crossover, and mutation operators</li>
+                <li><strong>Firefly Algorithm:</strong> Bioluminescence-attraction swarm method</li>
+                <li><strong>Ant Colony Optimization:</strong> Pheromone-based pathfinding</li>
             </ul>
 
-            <h3>Metaheuristic Methods</h3>
-            <p>Nature-inspired and local search algorithms:</p>
+            <h3>Metaheuristics</h3>
+            <p>Acceptance-rule and memory-based search:</p>
             <ul>
                 <li><strong>Simulated Annealing:</strong> Probabilistic acceptance with cooling schedule</li>
                 <li><strong>Tabu Search:</strong> Memory-based local search with prohibition</li>
-                <li><strong>Harmony Search:</strong> Music-inspired optimization</li>
-                <li><strong>Firefly Algorithm:</strong> Bioluminescence-based swarm method</li>
-                <li><strong>Ant Colony:</strong> Pheromone-based pathfinding optimization</li>
+                <li><strong>Harmony Search:</strong> Music-inspired pitch-adjustment optimization</li>
+                <li><strong>Bayesian Optimization:</strong> Gaussian-process surrogate with expected improvement</li>
+            </ul>
+
+            <h3>Local &amp; Pattern Search</h3>
+            <p>Lightweight baselines and direct-search workhorses:</p>
+            <ul>
+                <li><strong>Hill Climbing:</strong> Greedy steepest-ascent local search</li>
+                <li><strong>Random Search:</strong> Uniform i.i.d. sampling baseline</li>
+                <li><strong>Adaptive Random Search:</strong> (1+1)-ES with adaptive step size</li>
+                <li><strong>Coordinate Descent:</strong> Axis-aligned line search</li>
+                <li><strong>Pattern Search:</strong> Mesh-based direct search without derivatives</li>
             </ul>
         </section>
     </div>


### PR DESCRIPTION
## What

The \"Algorithm Categories\" section on <https://humpday.microprediction.org/> listed **14 of the 22 algorithms** humpday actually ships. The reference table higher on the same page lists all 22 correctly, so a reader skimming the bottom of the page would see eight algorithms quietly missing:

- `LBFGSB`
- `BayesianOpt`
- `EvolutionStrategy`
- `RandomSearch`
- `AdaptiveRandomSearch`
- `HillClimbing`
- `CoordinateDescent`
- `PatternSearch`

## Fix

Restructure the section to mirror the actual code-level grouping in `humpday/optimizers/alloptimizers.py` and the algorithm-taxonomy graphic — five families instead of three:

| Family | Count | Algorithms |
|---|---|---|
| Trust Region Methods | 3 | PRIMA UOBYQA / NEWUOA / BOBYQA |
| Classic Numerical Methods | 3 | Nelder-Mead, Powell, LBFGSB |
| Evolutionary & Swarm | 7 | DE, PSO, CMA-ES, ES, GA, Firefly, ACO |
| Metaheuristics | 4 | SA, Tabu, Harmony, Bayesian Opt |
| Local & Pattern Search | 5 | Hill Climb, RS, ARS, Coord Desc, Pattern Search |
| **Total** | **22** | |

## Verification

```
$ sed -n '/<h2>Algorithm Categories<\/h2>/,/<\/section>/p' docs/index.html | grep -c '<li>'
22

$ python -c "from humpday import ALGORITHM_NAMES; print(len(ALGORITHM_NAMES))"
22
```

- ✅ `<li>` count matches `len(humpday.ALGORITHM_NAMES)`.
- ✅ HTML parses cleanly via `html.parser`.
- ✅ Pure docs change, no Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)