### PR TITLE
port 5 more algorithms to humpday._array — trivial / 1-D set

### DIFF
--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -119,10 +119,13 @@ class ParticleSwarm(BaseOptimizer):
 
 
 class SimulatedAnnealing(BaseOptimizer):
-    """Simulated Annealing algorithm."""
+    """Simulated Annealing with multi-restart.
 
-    def optimize(self) -> Tuple[float, np.ndarray]:
-        # Multi-restart approach
+    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    """
+
+    def optimize(self):
+        # Multi-restart approach.
         num_restarts = max(3, self.n_trials // 30)
         trials_per_restart = self.n_trials // num_restarts
 
@@ -130,42 +133,44 @@ class SimulatedAnnealing(BaseOptimizer):
             if self.evaluations >= self.n_trials:
                 break
 
-            # Initialize
+            # Warm-start the first restart near the centre of the cube;
+            # subsequent restarts roll the dice anywhere.
             if restart == 0:
-                x = 0.5 + (np.random.random(self.n_dim) - 0.5) * 0.4
+                x = 0.5 + (_A.random_uniform(self.n_dim) - 0.5) * 0.4
             else:
-                x = np.random.random(self.n_dim)
+                x = _A.random_uniform(self.n_dim)
 
             fx = self.evaluate(x)
             best_x, best_fx = x.copy(), fx
 
-            # Temperature schedule
+            # Temperature schedule.
             temp = max(1.0, best_fx * 2)
             final_temp = 1e-8
 
-            for iteration in range(trials_per_restart):
+            for _iteration in range(trials_per_restart):
                 if self.evaluations >= self.n_trials:
                     break
 
-                # Generate neighbor
+                # Generate neighbor.
                 step_size = 0.3 * (temp / max(1.0, best_fx * 2))
-                new_x = x + (np.random.random(self.n_dim) - 0.5) * 2 * step_size
-                new_x = np.clip(new_x, 0, 1)
+                new_x = _A.clip(
+                    x + (_A.random_uniform(self.n_dim) - 0.5) * 2 * step_size, 0, 1
+                )
 
                 new_fx = self.evaluate(new_x)
 
-                # Update best
+                # Update best.
                 if new_fx < best_fx:
                     best_x, best_fx = new_x.copy(), new_fx
 
-                # Metropolis criterion
+                # Metropolis criterion.
                 delta = new_fx - fx
                 if delta < 0 or (
-                    temp > final_temp and np.random.random() < np.exp(-delta / temp)
+                    temp > final_temp and _A.random_scalar() < _A.exp(-delta / temp)
                 ):
                     x, fx = new_x, new_fx
 
-                # Cool down
+                # Cool down.
                 temp *= 0.99
                 temp = max(temp, final_temp)
 
@@ -484,10 +489,15 @@ class CMAEvolutionStrategy(BaseOptimizer):
 
 
 class TabuSearch(BaseOptimizer):
-    """Tabu Search algorithm."""
+    """Tabu Search algorithm.
 
-    def optimize(self) -> Tuple[float, np.ndarray]:
-        x = np.random.random(self.n_dim)
+    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    Maintains a small FIFO list of recently-visited points and rejects
+    neighbours that are within 0.05 (L2) of any of them.
+    """
+
+    def optimize(self):
+        x = _A.random_uniform(self.n_dim)
         f = self.evaluate(x)
 
         tabu_list = []
@@ -498,19 +508,16 @@ class TabuSearch(BaseOptimizer):
             best_neighbor = None
             best_neighbor_f = float("inf")
 
-            # Generate neighbors
+            # Generate neighbours and accept the best non-tabu one.
             for _ in range(min(10, self.n_trials - self.evaluations)):
                 if self.evaluations >= self.n_trials:
                     break
 
-                # Random neighbor
-                neighbor = x + np.random.normal(0, step_size, self.n_dim)
-                neighbor = np.clip(neighbor, 0, 1)
+                # Random neighbour with sigma = step_size.
+                neighbor = _A.clip(x + step_size * _A.random_normal(self.n_dim), 0, 1)
 
-                # Check if tabu
-                is_tabu = any(
-                    np.linalg.norm(neighbor - tabu_x) < 0.05 for tabu_x in tabu_list
-                )
+                # Check tabu: reject if too close to any recently-visited point.
+                is_tabu = any(_A.norm(neighbor - tabu_x) < 0.05 for tabu_x in tabu_list)
 
                 if not is_tabu:
                     neighbor_f = self.evaluate(neighbor)
@@ -522,7 +529,7 @@ class TabuSearch(BaseOptimizer):
                 x = best_neighbor
                 f = best_neighbor_f
 
-                # Update tabu list
+                # Update tabu list (FIFO).
                 tabu_list.append(x.copy())
                 if len(tabu_list) > tabu_tenure:
                     tabu_list.pop(0)
@@ -531,16 +538,22 @@ class TabuSearch(BaseOptimizer):
 
 
 class FireflyAlgorithm(BaseOptimizer):
-    """Firefly Algorithm."""
+    """Firefly Algorithm.
 
-    def optimize(self) -> Tuple[float, np.ndarray]:
+    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    Population stored as a Python list of 1-D vectors (numpy.ndarray or
+    `_Vec` depending on the active backend); all pairwise operations are
+    elementwise.
+    """
+
+    def optimize(self):
         n_fireflies = min(15, self.n_trials // 5)
-        alpha = 0.2  # Randomness
-        beta0 = 1.0  # Attractiveness
-        gamma = 1.0  # Absorption
+        alpha = 0.2  # Randomness coefficient.
+        beta0 = 1.0  # Attractiveness at zero distance.
+        gamma = 1.0  # Light-absorption coefficient.
 
-        # Initialize fireflies
-        fireflies = [np.random.random(self.n_dim) for _ in range(n_fireflies)]
+        # Initialize fireflies — list-of-vectors, NOT a 2-D array.
+        fireflies = [_A.random_uniform(self.n_dim) for _ in range(n_fireflies)]
         intensities = [self.evaluate(f) for f in fireflies]
 
         while self.evaluations < self.n_trials:
@@ -550,20 +563,18 @@ class FireflyAlgorithm(BaseOptimizer):
                         break
 
                     if intensities[j] < intensities[i]:  # j is brighter
-                        # Distance
-                        r = np.linalg.norm(fireflies[i] - fireflies[j])
+                        r = _A.norm(fireflies[i] - fireflies[j])
+                        beta = beta0 * _A.exp(-gamma * r * r)
 
-                        # Attractiveness
-                        beta = beta0 * np.exp(-gamma * r**2)
-
-                        # Move towards brighter firefly
-                        fireflies[i] = (
+                        # Move firefly i toward the brighter firefly j,
+                        # with a small random jitter.
+                        fireflies[i] = _A.clip(
                             fireflies[i]
                             + beta * (fireflies[j] - fireflies[i])
-                            + alpha * np.random.randn(self.n_dim)
+                            + alpha * _A.random_normal(self.n_dim),
+                            0,
+                            1,
                         )
-
-                        fireflies[i] = np.clip(fireflies[i], 0, 1)
 
                         if self.evaluations < self.n_trials:
                             intensities[i] = self.evaluate(fireflies[i])
@@ -698,43 +709,49 @@ class HillClimbing(BaseOptimizer):
 
 
 class HarmonySearch(BaseOptimizer):
-    """Harmony Search algorithm."""
+    """Harmony Search algorithm.
 
-    def optimize(self) -> Tuple[float, np.ndarray]:
+    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    """
+
+    def optimize(self):
         HMS = min(20, max(5, self.n_dim * 2))  # Harmony Memory Size
         HMCR = 0.9  # Harmony Memory Considering Rate
         PAR = 0.3  # Pitch Adjusting Rate
 
-        # Initialize harmony memory
+        # Initialize harmony memory.
         harmony_memory = []
         for _ in range(HMS):
             if self.evaluations >= self.n_trials:
                 break
-            harmony = np.random.random(self.n_dim)
+            harmony = _A.random_uniform(self.n_dim)
             fitness = self.evaluate(harmony)
             harmony_memory.append({"harmony": harmony, "fitness": fitness})
 
         while self.evaluations < self.n_trials:
-            new_harmony = np.zeros(self.n_dim)
+            new_harmony = _A.zeros(self.n_dim)
 
             for j in range(self.n_dim):
-                if np.random.random() < HMCR:
-                    # Pick from harmony memory
+                if _A.random_scalar() < HMCR:
+                    # Pick from harmony memory.
                     selected = random.choice(harmony_memory)
                     value = selected["harmony"][j]
 
-                    # Pitch adjustment
-                    if np.random.random() < PAR:
-                        value = np.clip(value + np.random.normal(0, 0.1), 0, 1)
+                    # Pitch adjustment.
+                    if _A.random_scalar() < PAR:
+                        # Add a single Gaussian-distributed nudge with sigma=0.1.
+                        # `random_normal(1)[0]` is one draw from the shim's RNG;
+                        # `0.1 *` scales it.
+                        value = max(0.0, min(1.0, value + 0.1 * _A.random_normal(1)[0]))
 
                     new_harmony[j] = value
                 else:
-                    # Random selection
-                    new_harmony[j] = np.random.random()
+                    # Random selection along this dimension.
+                    new_harmony[j] = _A.random_scalar()
 
             new_fitness = self.evaluate(new_harmony)
 
-            # Update harmony memory (replace worst if new harmony is better)
+            # Update harmony memory (replace worst if new harmony is better).
             harmony_memory.sort(key=lambda x: x["fitness"])
             if new_fitness < harmony_memory[-1]["fitness"]:
                 harmony_memory[-1] = {

--- a/humpday/optimizers/search_algorithms.py
+++ b/humpday/optimizers/search_algorithms.py
@@ -107,31 +107,36 @@ class CoordinateDescent(BaseOptimizer):
 
 
 class PatternSearch(BaseOptimizer):
-    """Pattern Search algorithm."""
+    """Pattern Search algorithm.
 
-    def optimize(self) -> Tuple[float, np.ndarray]:
-        x = np.random.random(self.n_dim)
+    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    Probes both signs of each coordinate axis at the current step size;
+    grows the step when it succeeds, halves it when no probe improves;
+    restarts when the step gets too small.
+    """
+
+    def optimize(self):
+        x = _A.random_uniform(self.n_dim)
         f = self.evaluate(x)
         step_size = 0.1
 
         while self.evaluations < self.n_trials:
             improved = False
 
-            # Pattern directions (coordinate directions + diagonals)
+            # Pattern directions: +/- each coordinate axis.
             directions = []
-            # Coordinate directions
             for i in range(self.n_dim):
-                direction = np.zeros(self.n_dim)
+                direction = _A.zeros(self.n_dim)
                 direction[i] = 1
                 directions.append(direction)
                 directions.append(-direction)
 
-            # Try each direction
+            # First-improvement: take the first direction that helps.
             for direction in directions:
                 if self.evaluations >= self.n_trials:
                     break
 
-                x_trial = np.clip(x + step_size * direction, 0, 1)
+                x_trial = _A.clip(x + step_size * direction, 0, 1)
                 f_trial = self.evaluate(x_trial)
 
                 if f_trial < f:
@@ -145,8 +150,8 @@ class PatternSearch(BaseOptimizer):
             else:
                 step_size *= 0.5
                 if step_size < 1e-6:
-                    # Random restart
-                    x = np.random.random(self.n_dim)
+                    # Random restart.
+                    x = _A.random_uniform(self.n_dim)
                     if self.evaluations < self.n_trials:
                         f = self.evaluate(x)
                     step_size = 0.1

--- a/tests/test_ported_algorithms.py
+++ b/tests/test_ported_algorithms.py
@@ -34,8 +34,13 @@ import pytest
 PORTED = [
     ("evolutionary_algorithms", "RandomSearch"),
     ("evolutionary_algorithms", "HillClimbing"),
+    ("evolutionary_algorithms", "SimulatedAnnealing"),
+    ("evolutionary_algorithms", "HarmonySearch"),
+    ("evolutionary_algorithms", "TabuSearch"),
+    ("evolutionary_algorithms", "FireflyAlgorithm"),
     ("search_algorithms", "AdaptiveRandomSearch"),
     ("search_algorithms", "CoordinateDescent"),
+    ("search_algorithms", "PatternSearch"),
 ]
 
 
@@ -77,17 +82,23 @@ def test_pure_backend_works_for_ported_algorithms(tmp_path):
         assert A.BACKEND == "pure", f"expected pure, got {A.BACKEND}"
 
         from humpday.optimizers.evolutionary_algorithms import (
-            RandomSearch, HillClimbing,
+            RandomSearch, HillClimbing, SimulatedAnnealing, HarmonySearch,
+            TabuSearch, FireflyAlgorithm,
         )
         from humpday.optimizers.search_algorithms import (
-            AdaptiveRandomSearch, CoordinateDescent,
+            AdaptiveRandomSearch, CoordinateDescent, PatternSearch,
         )
 
         def sphere(x):
             return float(sum((xi - 0.5) ** 2 for xi in x))
 
         results = {}
-        for cls in [RandomSearch, HillClimbing, AdaptiveRandomSearch, CoordinateDescent]:
+        ALGORITHMS = [
+            RandomSearch, HillClimbing, SimulatedAnnealing, HarmonySearch,
+            TabuSearch, FireflyAlgorithm,
+            AdaptiveRandomSearch, CoordinateDescent, PatternSearch,
+        ]
+        for cls in ALGORITHMS:
             opt = cls(sphere, n_trials=200, n_dim=5)
             best_value, best_x = opt.optimize()
             results[cls.__name__] = {
@@ -126,12 +137,10 @@ def test_pure_backend_works_for_ported_algorithms(tmp_path):
     import json
 
     results = json.loads(completed.stdout.strip().splitlines()[-1])
-    assert set(results) == {
-        "RandomSearch",
-        "HillClimbing",
-        "AdaptiveRandomSearch",
-        "CoordinateDescent",
-    }
+    expected = {name for _, name in PORTED}
+    assert set(results) == expected, (
+        f"missing or extra results: expected {expected}, got {set(results)}"
+    )
     for name, r in results.items():
         assert r["evaluations"] <= 200, f"{name}: {r['evaluations']} > 200"
         assert r["best_x_len"] == 5, f"{name}: best_x len {r['best_x_len']}"


### PR DESCRIPTION
Continues the numpy-removal effort started in #48 (shim) and #51 (first batch). This PR ports five more 1-D algorithms that do not need any new shim primitives:

  - SimulatedAnnealing  (humpday/optimizers/evolutionary_algorithms.py)
  - HarmonySearch       (humpday/optimizers/evolutionary_algorithms.py)
  - TabuSearch          (humpday/optimizers/evolutionary_algorithms.py)
  - FireflyAlgorithm    (humpday/optimizers/evolutionary_algorithms.py)
  - PatternSearch       (humpday/optimizers/search_algorithms.py)

After this PR, 9 of 22 algorithms are numpy-optional. Remaining 13:

  Population-based 2-D arrays (need a few new shim ops):
    ParticleSwarm, DifferentialEvolution, GeneticAlgorithm,
    EvolutionStrategy, AntColonyOpt                       (5)
  Classic numerical (need 2-D `np.eye`, `argsort`):
    NelderMead, Powell                                     (2)
  Linalg-using (need solve / eigh / cholesky):
    LBFGSB, CMA-ES, BayesianOpt,
    PRIMA_UOBYQA, PRIMA_NEWUOA, PRIMA_BOBYQA              (6)

## Why these 5 specifically

The "trivial" set in PR #51's roadmap was sized 12, but a closer survey showed 7 of those use 2-D arrays or `random.choice`/`random.randint` that the shim does not yet expose. They will land in the next batch alongside shim extensions.

The five in this PR all use the shim API as-is — vector arithmetic, elementwise math, the existing random primitives. No shim changes.

## Per-algorithm port notes

SimulatedAnnealing
  np.random.random(n) -> _A.random_uniform(n)
  np.clip            -> _A.clip
  np.random.random() -> _A.random_scalar()
  np.exp(scalar)     -> _A.exp(scalar)  (the shim's _elementwise passes
                                          scalars through math.exp)

HarmonySearch
  As above, plus np.zeros -> _A.zeros. `np.random.normal(0, 0.1)` becomes
  `0.1 * _A.random_normal(1)[0]` — slightly more verbose but no new API.

TabuSearch
  As above, plus np.linalg.norm -> _A.norm. The tabu distance check
  iterates over a list of vectors and computes pairwise L2.

FireflyAlgorithm
  Population stored as a Python list of 1-D vectors (numpy.ndarray under
  the numpy backend, _Vec under pure) — no 2-D array needed. Pairwise
  attraction uses _A.norm and _A.exp.

PatternSearch
  np.zeros(n) -> _A.zeros(n); unary negation `-direction` lands on
  _Vec.__neg__ which already returns a _Vec.

## Tests

`tests/test_ported_algorithms.py::PORTED` extended from 4 to 9 entries; the parametrised `test_numpy_backend` now covers all 9 algorithms, and `test_pure_backend_works_for_ported_algorithms` does the subprocess HUMPDAY_FORCE_PURE_ARRAY=1 dance for all 9.

10 tests pass (9 numpy + 1 pure-backend subprocess).

## Verification

  - Full suite: 271 passed, 21 skipped, 0 failures, 44s.
  - ruff check . / ruff format --check .: clean.
  - HUMPDAY_FORCE_PURE_ARRAY=1: all 9 algorithms complete with `best_x` of type `_Vec` and best_value < 1.0 on the 5-D sphere.