### PR TITLE
port NelderMead + Powell to humpday._array (2-D, no linalg)

### DIFF
--- a/humpday/optimizers/scipy_algorithms.py
+++ b/humpday/optimizers/scipy_algorithms.py
@@ -8,93 +8,100 @@ for derivative-free and gradient-based optimization.
 Reference: https://docs.scipy.org/doc/scipy/reference/optimize.html
 """
 
+import math
 from typing import Tuple
 
 import numpy as np
+
+from humpday import _array as _A
 
 from .base import BaseOptimizer
 
 
 class NelderMead(BaseOptimizer):
-    """Nelder-Mead simplex algorithm (faithful to SciPy implementation)."""
+    """Nelder-Mead simplex algorithm (faithful to SciPy implementation).
 
-    def optimize(self) -> Tuple[float, np.ndarray]:
+    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    The simplex is stored as a Python list of n+1 vectors (each a `_Vec`
+    or numpy.ndarray, depending on backend) instead of as a 2-D array;
+    row operations become list comprehensions, fancy indexing becomes
+    explicit `[sim[i] for i in order]`, and `np.argsort` becomes
+    `sorted(range(...), key=fsim.__getitem__)`.
+    """
+
+    def optimize(self):
         n = self.n_dim
 
-        # SciPy parameter names and values (matches exactly)
-        rho = 1.0  # reflection coefficient (was alpha)
-        chi = 2.0  # expansion coefficient (was gamma)
-        psi = 0.5  # contraction coefficient (was beta)
-        sigma = 0.5  # shrinkage coefficient (same name)
+        # SciPy parameter values.
+        rho = 1.0  # reflection
+        chi = 2.0  # expansion
+        psi = 0.5  # contraction
+        sigma = 0.5  # shrinkage
 
-        # SciPy simplex initialization
+        # SciPy simplex-initialization constants.
         nonzdelt = 0.05
         zdelt = 0.00025
 
-        sim = np.empty((n + 1, n), dtype=float)
-
-        # Initial simplex construction (SciPy approach)
-        x0 = 0.3 + 0.4 * np.random.random(n)  # Interior starting point
-        sim[0] = x0
-
+        # Initial simplex: n+1 vertices. Vertex 0 is an interior random
+        # point; the rest perturb one coordinate at a time.
+        x0 = 0.3 + 0.4 * _A.random_uniform(n)
+        sim = [x0.copy()]
         for k in range(n):
             y = x0.copy()
             if y[k] != 0:
                 y[k] = (1 + nonzdelt) * y[k]
             else:
                 y[k] = zdelt
-            sim[k + 1] = y
+            sim.append(y)
 
-        # Ensure all points are within bounds
-        sim = np.clip(sim, 0, 1)
+        # Clip every vertex into the unit cube.
+        sim = [_A.clip(v, 0, 1) for v in sim]
 
-        # Evaluate initial simplex
-        fsim = np.zeros(n + 1)
+        # Evaluate initial simplex.
+        fsim = [0.0] * (n + 1)
         for k in range(n + 1):
             if self.evaluations >= self.n_trials:
                 break
             fsim[k] = self.evaluate(sim[k])
 
-        # Sort initial simplex
-        ind = np.argsort(fsim)
-        sim = sim[ind]
-        fsim = fsim[ind]
+        # Sort by fitness ascending (best first).
+        order = sorted(range(n + 1), key=fsim.__getitem__)
+        sim = [sim[i] for i in order]
+        fsim = [fsim[i] for i in order]
 
-        # SciPy tolerance parameters
-        xatol = 1e-4  # position tolerance
-        fatol = 1e-4  # function value tolerance
+        # SciPy tolerances.
+        xatol = 1e-4
+        fatol = 1e-4
 
-        # Main optimization loop (SciPy structure)
         while self.evaluations < self.n_trials:
-            # SciPy convergence check - EXACT match to SciPy implementation
-            if (
-                np.max(np.ravel(np.abs(sim[1:] - sim[0]))) <= xatol
-                and np.max(np.abs(fsim[0] - fsim[1:])) <= fatol
-            ):
+            # SciPy convergence check, restated without numpy broadcasting:
+            # max over all (i, k) of |sim[i][k] - sim[0][k]| <= xatol AND
+            # max over i of |fsim[0] - fsim[i]| <= fatol.
+            x_max = max(
+                abs(sim[i][k] - sim[0][k]) for i in range(1, n + 1) for k in range(n)
+            )
+            f_max = max(abs(fsim[0] - fsim[i]) for i in range(1, n + 1))
+            if x_max <= xatol and f_max <= fatol:
                 break
 
-            # Calculate centroid of best n points (SciPy approach)
-            xbar = np.add.reduce(sim[:-1], 0) / n
+            # Centroid of the best n vertices (sum-of-rows / n).
+            xbar = _A.zeros(n)
+            for v in sim[:-1]:
+                xbar = xbar + v
+            xbar = xbar / n
 
-            # Reflection step
-            xr = (1 + rho) * xbar - rho * sim[-1]
-            xr = np.clip(xr, 0, 1)
-
+            # Reflection.
+            xr = _A.clip((1 + rho) * xbar - rho * sim[-1], 0, 1)
             if self.evaluations >= self.n_trials:
                 break
-
             fxr = self.evaluate(xr)
 
             if fxr < fsim[0]:
-                # Expansion step
-                xe = (1 + rho * chi) * xbar - rho * chi * sim[-1]
-                xe = np.clip(xe, 0, 1)
-
+                # Expansion.
+                xe = _A.clip((1 + rho * chi) * xbar - rho * chi * sim[-1], 0, 1)
                 if self.evaluations >= self.n_trials:
                     break
-
                 fxe = self.evaluate(xe)
-
                 if fxe < fxr:
                     sim[-1] = xe
                     fsim[-1] = fxe
@@ -102,76 +109,73 @@ class NelderMead(BaseOptimizer):
                     sim[-1] = xr
                     fsim[-1] = fxr
             elif fxr < fsim[-2]:
-                # Accept reflection point
+                # Accept reflection.
                 sim[-1] = xr
                 fsim[-1] = fxr
             else:
-                # Contraction step
+                # Contraction (outside if fxr < fsim[-1], else inside).
                 if fxr < fsim[-1]:
-                    # Outside contraction
                     xc = (1 + psi * rho) * xbar - psi * rho * sim[-1]
                 else:
-                    # Inside contraction
                     xc = (1 - psi) * xbar + psi * sim[-1]
-
-                xc = np.clip(xc, 0, 1)
+                xc = _A.clip(xc, 0, 1)
 
                 if self.evaluations >= self.n_trials:
                     break
-
                 fxc = self.evaluate(xc)
 
                 if fxc < min(fxr, fsim[-1]):
                     sim[-1] = xc
                     fsim[-1] = fxc
                 else:
-                    # Shrink step (SciPy approach)
+                    # Shrink: every non-best vertex moves toward sim[0].
                     for j in range(1, n + 1):
-                        sim[j] = sim[0] + sigma * (sim[j] - sim[0])
-                        sim[j] = np.clip(sim[j], 0, 1)
+                        sim[j] = _A.clip(sim[0] + sigma * (sim[j] - sim[0]), 0, 1)
                         if self.evaluations < self.n_trials:
                             fsim[j] = self.evaluate(sim[j])
 
-            # Sort simplex (SciPy approach)
-            ind = np.argsort(fsim)
-            sim = sim[ind]
-            fsim = fsim[ind]
+            # Re-sort by fitness.
+            order = sorted(range(n + 1), key=fsim.__getitem__)
+            sim = [sim[i] for i in order]
+            fsim = [fsim[i] for i in order]
 
         return self.best_value, self.best_x
 
 
 class Powell(BaseOptimizer):
-    """Powell's method - direct adaptation from SciPy source code."""
+    """Powell's method - direct adaptation from SciPy source code.
 
-    def optimize(self) -> Tuple[float, np.ndarray]:
-        # Direct adaptation from SciPy's _minimize_powell
+    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    The direction set `direc` is stored as a list of rows; row accesses
+    are wrapped in `_A.asarray(...)` so they become `_Vec` (pure) or
+    ndarray (numpy) and support elementwise arithmetic on either path.
+    """
+
+    def optimize(self):
         n = self.n_dim
-        x = 0.3 + 0.4 * np.random.random(n)  # Start in interior
+        x = 0.3 + 0.4 * _A.random_uniform(n)  # Interior start
 
-        # Initial direction set (coordinate directions) - exactly like SciPy
-        direc = np.eye(n, dtype=float)
+        # Initial direction set: identity matrix (coordinate directions).
+        direc = _A.linalg.eye(n)
 
-        # SciPy default parameters
-        xtol = 1e-4
         ftol = 1e-4
-        maxiter = n * 20  # SciPy uses N*1000, but we have limited evaluations
+        maxiter = n * 20
 
         fval = self.evaluate(x)
         x1 = x.copy()
-        iter = 0
+        iteration = 0
 
-        # Main Powell loop - directly from SciPy
-        while iter < maxiter and self.evaluations < self.n_trials:
+        while iteration < maxiter and self.evaluations < self.n_trials:
             fx = fval
             bigind = 0
             delta = 0.0
 
-            # Line searches along each direction
+            # Line searches along each direction.
             for i in range(n):
                 if self.evaluations >= self.n_trials:
                     break
 
-                direc1 = direc[i]
+                direc1 = _A.asarray(direc[i])
                 fx2 = fval
                 fval, x, direc1 = self._linesearch_powell(x, direc1, fval)
 
@@ -179,20 +183,20 @@ class Powell(BaseOptimizer):
                     delta = fx2 - fval
                     bigind = i
 
-            iter += 1
+            iteration += 1
 
-            # SciPy convergence check
-            bnd = ftol * (np.abs(fx) + np.abs(fval)) + 1e-20
+            # SciPy convergence check.
+            bnd = ftol * (abs(fx) + abs(fval)) + 1e-20
             if 2.0 * (fx - fval) <= bnd:
                 break
 
             if self.evaluations >= self.n_trials:
                 break
 
-            # Construct the extrapolated point
+            # Construct the extrapolated point.
             direc1 = x - x1
             x1 = x.copy()
-            x2 = np.clip(x + direc1, 0, 1)  # Keep in bounds
+            x2 = _A.clip(x + direc1, 0, 1)
 
             if self.evaluations >= self.n_trials:
                 break
@@ -208,32 +212,34 @@ class Powell(BaseOptimizer):
 
                 if t < 0.0:
                     fval, x, direc1 = self._linesearch_powell(x, direc1, fval)
-                    if np.any(direc1):
-                        direc[bigind] = direc[-1].copy()
-                        direc[-1] = direc1
+                    # `np.any(arr)` for a float vector means "any non-zero entry".
+                    if any(v != 0 for v in direc1):
+                        direc[bigind] = list(direc[-1])
+                        direc[-1] = list(direc1)
 
         return self.best_value, self.best_x
 
     def _linesearch_powell(self, p, xi, fval):
-        """Improved line search for Powell method - SciPy inspired with golden section."""
+        """Bounded golden-section line search along direction `xi` from
+        point `p`. Returns `(best_f, best_x, scaled_direction)`."""
 
         def myfunc(alpha):
-            x_trial = np.clip(p + alpha * xi, 0, 1)
+            x_trial = _A.clip(p + alpha * xi, 0, 1)
             if self.evaluations >= self.n_trials:
                 return float("inf")
             return self.evaluate(x_trial)
 
-        # If direction is zero, don't optimize
-        if not np.any(xi):
+        # If direction is essentially zero, skip the search.
+        if not any(v != 0 for v in xi):
             return fval, p, xi
 
-        # Calculate safe alpha bounds to keep within [0,1] hypercube
+        # Clamp alpha so p + alpha * xi stays in [0, 1]^n.
         alpha_bounds = []
         for i in range(len(xi)):
-            if abs(xi[i]) > 1e-12:
-                # For constraint: 0 <= p[i] + alpha * xi[i] <= 1
-                bound1 = -p[i] / xi[i]
-                bound2 = (1.0 - p[i]) / xi[i]
+            xi_i = float(xi[i])
+            if abs(xi_i) > 1e-12:
+                bound1 = -float(p[i]) / xi_i
+                bound2 = (1.0 - float(p[i])) / xi_i
                 alpha_bounds.extend([bound1, bound2])
 
         if not alpha_bounds:
@@ -245,36 +251,30 @@ class Powell(BaseOptimizer):
         if alpha_max <= alpha_min:
             return fval, p, xi
 
-        # Golden section search
-        golden_ratio = (3.0 - np.sqrt(5.0)) / 2.0
+        # Golden-section search.
+        golden_ratio = (3.0 - math.sqrt(5.0)) / 2.0
         tol = 1e-6
         max_evals = min(10, self.n_trials - self.evaluations)
 
-        # Start with three points
         if abs(alpha_min) < abs(alpha_max):
             a, c = alpha_min, alpha_max
         else:
             a, c = alpha_max, alpha_min
 
-        # Golden section method
         b = a + golden_ratio * (c - a)
 
         if self.evaluations >= self.n_trials:
             return fval, p, xi
-
         fa = fval if abs(a) < 1e-10 else myfunc(a)
 
         if self.evaluations >= self.n_trials:
             return fval, p, xi
-
         fc = myfunc(c)
 
         if self.evaluations >= self.n_trials:
             return fval, p, xi
-
         fb = myfunc(b)
 
-        # Find minimum of the three
         best_alpha = a
         best_f = fa
         if fb < best_f:
@@ -284,7 +284,6 @@ class Powell(BaseOptimizer):
             best_alpha = c
             best_f = fc
 
-        # Refine with golden section if we have evaluations left
         evaluations_used = 3
         while (
             evaluations_used < max_evals
@@ -292,13 +291,11 @@ class Powell(BaseOptimizer):
             and self.evaluations < self.n_trials
         ):
             if c - b > b - a:
-                # Test point in larger interval
+                # Larger interval is on the right.
                 x = b + golden_ratio * (c - b)
                 fx = myfunc(x)
                 evaluations_used += 1
-
                 if fx < fb:
-                    # New minimum found
                     a, b = b, x
                     fa, fb = fb, fx
                     if fx < best_f:
@@ -308,13 +305,11 @@ class Powell(BaseOptimizer):
                     c = x
                     fc = fx
             else:
-                # Test point in smaller interval
+                # Larger interval is on the left.
                 x = b - golden_ratio * (b - a)
                 fx = myfunc(x)
                 evaluations_used += 1
-
                 if fx < fb:
-                    # New minimum found
                     c, b = b, x
                     fc, fb = fb, fx
                     if fx < best_f:
@@ -324,13 +319,12 @@ class Powell(BaseOptimizer):
                     a = x
                     fa = fx
 
-        # Return best result
         if best_f < fval:
-            x_new = np.clip(p + best_alpha * xi, 0, 1)
+            x_new = _A.clip(p + best_alpha * xi, 0, 1)
             xi_new = best_alpha * xi
             return best_f, x_new, xi_new
         else:
-            return fval, p, np.zeros_like(xi)
+            return fval, p, _A.zeros(len(xi))
 
 
 class LBFGSB(BaseOptimizer):

--- a/tests/test_ported_algorithms.py
+++ b/tests/test_ported_algorithms.py
@@ -45,6 +45,8 @@ PORTED = [
     ("search_algorithms", "AdaptiveRandomSearch"),
     ("search_algorithms", "CoordinateDescent"),
     ("search_algorithms", "PatternSearch"),
+    ("scipy_algorithms", "NelderMead"),
+    ("scipy_algorithms", "Powell"),
 ]
 
 
@@ -94,6 +96,7 @@ def test_pure_backend_works_for_ported_algorithms(tmp_path):
         from humpday.optimizers.search_algorithms import (
             AdaptiveRandomSearch, CoordinateDescent, PatternSearch,
         )
+        from humpday.optimizers.scipy_algorithms import NelderMead, Powell
 
         def sphere(x):
             return float(sum((xi - 0.5) ** 2 for xi in x))
@@ -105,6 +108,7 @@ def test_pure_backend_works_for_ported_algorithms(tmp_path):
             ParticleSwarm, DifferentialEvolution, GeneticAlgorithm,
             EvolutionStrategy,
             AdaptiveRandomSearch, CoordinateDescent, PatternSearch,
+            NelderMead, Powell,
         ]
         for cls in ALGORITHMS:
             opt = cls(sphere, n_trials=200, n_dim=5)


### PR DESCRIPTION
## What

Continues #48 / #51 / #52 / #53. Two more algorithms ported, both classic numerical with 2-D state but no heavy linalg.

- \`NelderMead\` — (n+1)-vertex simplex
- \`Powell\` — n×n direction set (identity-initialized)

**After this PR, 15 of 22 algorithms are numpy-optional.**

## Storage shape change

2-D arrays → Python lists of 1-D vectors. Same pattern as the population-based ports in #53, applied to algorithm-internal state:

| numpy | shim |
|---|---|
| \`np.empty((n+1, n))\` | \`[zeros(n) for _ in range(n+1)]\` |
| \`np.eye(n)\` | \`_A.linalg.eye(n)\` |
| \`sim[ind]\` (fancy indexing) | \`[sim[i] for i in ind]\` |
| \`sim[1:] - sim[0]\` | explicit loop |
| \`np.argsort(fsim)\` | \`sorted(range(len(fsim)), key=fsim.__getitem__)\` |
| \`np.add.reduce(rows, 0)\` | manual sum loop for centroid |

Pure-backend rows of \`linalg.eye\` come back as plain \`list[float]\`, so when Powell needs \`direc[i] * alpha\` elementwise, the row is wrapped: \`direc1 = _A.asarray(direc[i])\` makes it a \`_Vec\` (pure) or ndarray (numpy) and the arithmetic works on either path.

## Other substitutions

| numpy | shim / stdlib |
|---|---|
| \`np.random.random(n)\` | \`_A.random_uniform(n)\` |
| \`np.clip\` | \`_A.clip\` |
| \`np.sqrt(scalar)\` | \`math.sqrt\` |
| \`np.abs(scalar)\` | \`abs\` |
| \`np.any(vec)\` | \`any(v != 0 for v in vec)\` |
| \`np.zeros_like(xi)\` | \`_A.zeros(len(xi))\` |

**No new shim primitives required.**

## Empirical accuracy (5-D sphere, 200 evals)

| | numpy backend | pure backend |
|---|---:|---:|
| NelderMead err | 0.0001 | 0.0002 |
| Powell err | 0.12 | 0.08 |

Within an order of magnitude on both backends; both clearly working.

## Tests

\`tests/test_ported_algorithms.py::PORTED\` extended from 13 → 15. **16 tests pass** (15 numpy + 1 pure-backend subprocess).

## Verification

| Check | Result |
|---|---|
| Full suite | ✅ 287 passed, 21 skipped, 0 failures, 40s |
| \`ruff check .\` | ✅ |
| \`ruff format --check .\` | ✅ 107 files |
| \`HUMPDAY_FORCE_PURE_ARRAY=1\` end-to-end | ✅ all 15 algorithms |

## Remaining (7)

| Bucket | Count | Members |
|---|---:|---|
| Known bug | 1 | \`AntColonyOpt\` |
| Linalg | 6 | \`LBFGSB\`, \`CMA-ES\`, \`BayesianOpt\`, \`PRIMA_UOBYQA\`, \`PRIMA_NEWUOA\`, \`PRIMA_BOBYQA\` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)