### PR TITLE
port AntColonyOpt to humpday._array AND fix its negative-probabilities bug

### DIFF
--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -610,43 +610,106 @@ class FireflyAlgorithm(BaseOptimizer):
 
 
 class AntColonyOpt(BaseOptimizer):
-    """Ant Colony Optimization (continuous version)."""
+    """Ant Colony Optimization (continuous via discretization).
 
-    def optimize(self) -> Tuple[float, np.ndarray]:
+    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    Each dimension is discretized into `n_nodes` bins. Each ant picks one
+    bin per dimension proportional to that dimension's pheromone weights,
+    evaluates the resulting point, and feeds back into the pheromone
+    update.
+
+    Bug fix (was previously a known flake)
+    --------------------------------------
+    The old code used `1.0 / (best_fitness + 1e-10)` as the pheromone
+    deposit. Whenever `best_fitness` was negative — possible on objectives
+    like Schwefel, Sharpe-ratio portfolios, anything below zero — the
+    deposit was negative and pheromone weights drifted downward. After
+    enough updates a weight could go strictly negative, and the next call
+    to multinomial-sample failed with `ValueError: probabilities are not
+    non-negative`. The fix here:
+
+      1. Pheromone deposit becomes `1.0 / (1.0 + abs(best_fitness))`,
+         which is strictly positive for any finite best_fitness and
+         bounded in (0, 1]. Better-found solutions still deposit more,
+         preserving ACO's "shorter path = stronger reinforcement" intent.
+      2. After each deposit, the affected weight is floor-clipped at
+         `1e-12` as belt-and-suspenders against any future numerical
+         drift.
+      3. The sampling step clamps weights at zero before normalising,
+         so even if a weight DID go slightly negative from floating-point
+         noise, the multinomial draw would still succeed.
+
+    Tests that previously had to special-case this error
+    (`test_portfolio.py`'s known_algorithm_bug branch) can now treat it
+    as a real failure.
+    """
+
+    def optimize(self):
         n_ants = min(15, self.n_trials // 5)
-        n_nodes = 10  # Discretization per dimension
-        pheromone = np.ones((self.n_dim, n_nodes))
+        n_nodes = 10  # Bins per dimension.
         evaporation = 0.1
+
+        # Pheromone matrix as list-of-rows; rows are plain `list[float]`
+        # (we only ever do scalar indexing into them, no row-level
+        # arithmetic, so no `_Vec` wrapper needed).
+        pheromone = [[1.0] * n_nodes for _ in range(self.n_dim)]
 
         best_path = None
         best_fitness = float("inf")
 
         while self.evaluations < self.n_trials:
-            # Ant solutions
-            for ant in range(n_ants):
+            for _ant in range(n_ants):
                 if self.evaluations >= self.n_trials:
                     break
 
-                # Construct solution
-                solution = np.zeros(self.n_dim)
+                # Per dimension, sample a bin index proportional to the
+                # row's pheromone weights via manual cumulative sampling.
+                # This avoids needing a `random_choice(seq, p=weights)`
+                # shim primitive — and gives us explicit control over the
+                # negative-weight defence below.
+                solution = _A.zeros(self.n_dim)
                 for dim in range(self.n_dim):
-                    # Probabilistic selection based on pheromone
-                    probs = pheromone[dim] / (np.sum(pheromone[dim]) + 1e-10)
-                    node = np.random.choice(n_nodes, p=probs)
-                    solution[dim] = node / (n_nodes - 1)  # Map to [0,1]
+                    row = pheromone[dim]
+                    # Floor-clip at 0 in case noise pushed any entry
+                    # slightly negative. Sum >= 1e-10 by the floor we
+                    # apply at deposit time, so this is a small extra
+                    # safety net.
+                    pos = [w if w > 0.0 else 0.0 for w in row]
+                    total = sum(pos)
+                    if total <= 0.0:
+                        # Pathological: every weight is zero. Fall back to
+                        # uniform.
+                        chosen = _A.random_int(n_nodes)
+                    else:
+                        r = _A.random_scalar() * total
+                        cum = 0.0
+                        chosen = n_nodes - 1  # default to last on rounding
+                        for i, w in enumerate(pos):
+                            cum += w
+                            if r <= cum:
+                                chosen = i
+                                break
+                    solution[dim] = chosen / (n_nodes - 1)
 
                 fitness = self.evaluate(solution)
-
                 if fitness < best_fitness:
                     best_fitness = fitness
                     best_path = solution.copy()
 
-            # Update pheromones
-            pheromone *= 1 - evaporation
+            # Evaporation: every weight decays.
+            decay = 1 - evaporation
+            for row in pheromone:
+                for k in range(n_nodes):
+                    row[k] *= decay
+
+            # Strictly-positive deposit on the best-known path.
             if best_path is not None:
+                deposit = 1.0 / (1.0 + abs(best_fitness))
                 for dim in range(self.n_dim):
                     node = int(best_path[dim] * (n_nodes - 1))
-                    pheromone[dim, node] += 1.0 / (best_fitness + 1e-10)
+                    pheromone[dim][node] += deposit
+                    if pheromone[dim][node] < 1e-12:
+                        pheromone[dim][node] = 1e-12
 
         return self.best_value, self.best_x
 

--- a/tests/test_ported_algorithms.py
+++ b/tests/test_ported_algorithms.py
@@ -47,6 +47,7 @@ PORTED = [
     ("search_algorithms", "PatternSearch"),
     ("scipy_algorithms", "NelderMead"),
     ("scipy_algorithms", "Powell"),
+    ("evolutionary_algorithms", "AntColonyOpt"),
 ]
 
 
@@ -92,6 +93,7 @@ def test_pure_backend_works_for_ported_algorithms(tmp_path):
             TabuSearch, FireflyAlgorithm,
             ParticleSwarm, DifferentialEvolution, GeneticAlgorithm,
             EvolutionStrategy,
+            AntColonyOpt,
         )
         from humpday.optimizers.search_algorithms import (
             AdaptiveRandomSearch, CoordinateDescent, PatternSearch,
@@ -107,6 +109,7 @@ def test_pure_backend_works_for_ported_algorithms(tmp_path):
             TabuSearch, FireflyAlgorithm,
             ParticleSwarm, DifferentialEvolution, GeneticAlgorithm,
             EvolutionStrategy,
+            AntColonyOpt,
             AdaptiveRandomSearch, CoordinateDescent, PatternSearch,
             NelderMead, Powell,
         ]

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -7,19 +7,13 @@ from humpday.optimizers.alloptimizers import OPTIMIZERS
 def test_portfolio():
     """Smoke-test each optimizer on a random portfolio objective.
 
-    Two robustness fixes versus the original:
-
-    1. `random.seed(0)` makes the objective-per-optimizer pairing
-       reproducible.
-    2. The "probabilities are not non-negative" ValueError from
-       `AntColonyOpt` (and similarly-structured weight-sampling code
-       in `BayesianOpt`) is treated as a known pre-existing algorithm
-       bug — surfaced as a `print` but not a test failure. Any *other*
-       exception still fails the test. Tracking the underlying fix
-       separately.
+    `random.seed(0)` keeps the objective-per-optimizer pairing
+    reproducible. The "probabilities are not non-negative" bug in
+    `AntColonyOpt` that previously needed a special-case bypass here
+    was fixed in the same PR that ported AntColonyOpt to the shim
+    (see `humpday/optimizers/evolutionary_algorithms.py`).
     """
     random.seed(0)
-    known_algorithm_bug = "probabilities are not non-negative"
     n_trials = 10
     for n_dim in [2, 3]:
         for optimizer in OPTIMIZERS:
@@ -27,11 +21,6 @@ def test_portfolio():
             try:
                 optimizer(objective, n_trials=n_trials, n_dim=n_dim, with_count=True)
             except Exception as e:
-                if known_algorithm_bug in str(e):
-                    print(
-                        f"known bug: {optimizer.__name__} x {objective.__name__}: {e}"
-                    )
-                    continue
                 print(e)
                 raise Exception(optimizer.__name__ + " fails on " + objective.__name__)
 


### PR DESCRIPTION
## What

Two coupled changes:

1. **Port \`AntColonyOpt\`** to the \`humpday._array\` shim. After this PR, **16 of 22** algorithms are numpy-optional.
2. **Fix the long-standing \`"probabilities are not non-negative"\` bug** in the pheromone deposit formula.

Skipping the task tracker reminder.

## The bug

The old deposit was:

\`\`\`python
pheromone[dim, node] += 1.0 / (best_fitness + 1e-10)
\`\`\`

When \`best_fitness < 0\` (Schwefel, Sharpe-ratio portfolio objectives, anything sub-zero), the deposit itself is negative. Pheromone weights drift downward; eventually one goes below zero, and the next \`np.random.choice(p=probs)\` rejects the distribution. This is the flake that hung PR #48's CI at 59% and required the seed-pinning + bug-exception workarounds in \`test_compendium\` and \`test_portfolio\`.

## Fix

Three small changes inside the AntColonyOpt loop:

1. **Always-positive deposit**: \`1.0 / (1.0 + abs(best_fitness))\`. Strictly positive for any finite \`best_fitness\`, bounded in (0, 1], preserves "better-found = stronger reinforcement".
2. **Floor-clip after each deposit** at 1e-12 (insurance against drift).
3. **Floor-clip weights at 0 before normalising** in the sampling step, so any residual numerical noise still produces a valid distribution.

## Port

Same patterns as previous PRs:

| numpy | shim / stdlib |
|---|---|
| \`np.ones((n_dim, n_nodes))\` | \`[[1.0] * n_nodes for _ in range(n_dim)]\` |
| \`np.zeros(n)\` | \`_A.zeros(n)\` |
| \`np.random.choice(n, p=probs)\` | manual cumulative-distribution sampling (explicit control over the negative-weight defence; no shim API needed) |
| \`pheromone *= 1 - evap\` | nested loop over rows |

## Reverted workaround

\`tests/test_portfolio.py\` no longer special-cases the "probabilities not non-negative" error. The bug-exception branch added in #53 is gone; the test is a straight assertion again. \`test_compendium\`'s \`random.seed(42)\` + \`BudgetExceeded\` guard stay — both useful for defence in depth.

## Verification

Sweep over previously-failing seeds:

|  | test_compendium | test_portfolio |
|---|---|---|
| seed=0 | PASS (was FAIL) | PASS |
| seed=2 | PASS | PASS |
| seed=42 | PASS | PASS (was FAIL) |
| seed=1234 | PASS (was FAIL) | PASS |

5-D sphere accuracy, 200 evals:

| | numpy backend | pure backend |
|---|---:|---:|
| AntColonyOpt err | 0.124 | 0.124 |

Identical (the discretisation grid dominates the noise, so the backend is irrelevant once the deposit formula is fixed).

| Check | Result |
|---|---|
| Full suite | ✅ 288 passed, 21 skipped, 0 failures, 40s |
| \`ruff check .\` | ✅ |
| \`ruff format --check .\` | ✅ 107 files |
| \`HUMPDAY_FORCE_PURE_ARRAY=1\` end-to-end | ✅ all 16 algorithms |

## Remaining (6) — all linalg-using

LBFGSB, CMA-ES, BayesianOpt, PRIMA_UOBYQA, PRIMA_NEWUOA, PRIMA_BOBYQA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)