### PR TITLE
docs(index): replace 9 wrong "Not in Python core" labels with Python source links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -282,7 +282,7 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                     <tr>
                         <td><code>BayesianOpt</code></td>
                         <td>Bayesian</td>
-                        <td><em>Not in Python core</em></td>
+                        <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L278" target="_blank">evolutionary_algorithms.py#L278</a></td>
                         <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L296" target="_blank">evolutionary-algorithms.js#L296</a></td>
                         <td><a href="https://arxiv.org/abs/1012.2599" target="_blank">Brochu et al. (2010)</a></td>
                         <td><a href="algorithms/bayesian-optimization.html">View →</a></td>
@@ -290,7 +290,7 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                     <tr>
                         <td><code>CMAEvolutionStrategy</code></td>
                         <td>Evolutionary</td>
-                        <td><em>Not in Python core</em></td>
+                        <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L479" target="_blank">evolutionary_algorithms.py#L479</a></td>
                         <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L408" target="_blank">evolutionary-algorithms.js#L408</a></td>
                         <td><a href="https://arxiv.org/abs/1604.00772" target="_blank">Hansen (2016)</a></td>
                         <td><a href="algorithms/cma-evolution-strategy.html">View →</a></td>
@@ -298,7 +298,7 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                     <tr>
                         <td><code>TabuSearch</code></td>
                         <td>Metaheuristic</td>
-                        <td><em>Not in Python core</em></td>
+                        <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L630" target="_blank">evolutionary_algorithms.py#L630</a></td>
                         <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L463" target="_blank">evolutionary-algorithms.js#L463</a></td>
                         <td><a href="https://doi.org/10.1287/ijoc.1.3.190" target="_blank">Glover (1989)</a></td>
                         <td><a href="algorithms/tabu-search.html">View →</a></td>
@@ -306,7 +306,7 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                     <tr>
                         <td><code>FireflyAlgorithm</code></td>
                         <td>Bio-inspired</td>
-                        <td><em>Not in Python core</em></td>
+                        <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L679" target="_blank">evolutionary_algorithms.py#L679</a></td>
                         <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L525" target="_blank">evolutionary-algorithms.js#L525</a></td>
                         <td><a href="https://doi.org/10.1007/978-3-642-04944-6_14" target="_blank">Yang (2008)</a></td>
                         <td><a href="algorithms/firefly-algorithm.html">View →</a></td>
@@ -314,7 +314,7 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                     <tr>
                         <td><code>AntColonyOpt</code></td>
                         <td>Swarm Intelligence</td>
-                        <td><em>Not in Python core</em></td>
+                        <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L724" target="_blank">evolutionary_algorithms.py#L724</a></td>
                         <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L582" target="_blank">evolutionary-algorithms.js#L582</a></td>
                         <td><a href="https://doi.org/10.1109/3477.484436" target="_blank">Dorigo et al. (1996)</a></td>
                         <td><a href="algorithms/ant-colony-optimization.html">View →</a></td>
@@ -330,7 +330,7 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                     <tr>
                         <td><code>EvolutionStrategy</code></td>
                         <td>Evolutionary</td>
-                        <td><em>Not in Python core</em></td>
+                        <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L829" target="_blank">evolutionary_algorithms.py#L829</a></td>
                         <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L719" target="_blank">evolutionary-algorithms.js#L719</a></td>
                         <td><a href="https://doi.org/10.1007/978-3-662-43505-2_44" target="_blank">Beyer & Schwefel (2002)</a></td>
                         <td><a href="algorithms/evolution-strategy.html">View →</a></td>
@@ -340,7 +340,7 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                     <tr>
                         <td><code>AdaptiveRandomSearch</code></td>
                         <td>Adaptive Search</td>
-                        <td><em>Not in Python core</em></td>
+                        <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L18" target="_blank">search_algorithms.py#L18</a></td>
                         <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L16" target="_blank">search-algorithms.js#L16</a></td>
                         <td><a href="https://doi.org/10.1007/BF01581033" target="_blank">Schumer & Steiglitz (1968)</a></td>
                         <td><a href="algorithms/adaptive-random-search.html">View →</a></td>
@@ -348,7 +348,7 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                     <tr>
                         <td><code>CoordinateDescent</code></td>
                         <td>Local Search</td>
-                        <td><em>Not in Python core</em></td>
+                        <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L57" target="_blank">search_algorithms.py#L57</a></td>
                         <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L69" target="_blank">search-algorithms.js#L69</a></td>
                         <td><a href="https://doi.org/10.1007/s10107-015-0892-3" target="_blank">Wright (2015)</a></td>
                         <td><a href="algorithms/coordinate-descent.html">View →</a></td>
@@ -356,7 +356,7 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                     <tr>
                         <td><code>PatternSearch</code></td>
                         <td>Direct Search</td>
-                        <td><em>Not in Python core</em></td>
+                        <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L109" target="_blank">search_algorithms.py#L109</a></td>
                         <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L129" target="_blank">search-algorithms.js#L129</a></td>
                         <td><a href="https://doi.org/10.1137/S1052623493250780" target="_blank">Torczon (1997)</a></td>
                         <td><a href="algorithms/pattern-search.html">View →</a></td>


### PR DESCRIPTION
## What

The algorithm-implementations table on the home page (\`docs/index.html\`) claimed nine algorithms were "Not in Python core" when in fact each had a real Python implementation in \`humpday.optimizers\`. Replace each \`<em>Not in Python core</em>\` cell with a github.com source link, matching the same href/text format used by every other row in the same table.

## Affected algorithms

| Algorithm | Source file |
|---|---|
| BayesianOpt | \`humpday/optimizers/evolutionary_algorithms.py#L278\` |
| CMAEvolutionStrategy | \`#L479\` |
| TabuSearch | \`#L630\` |
| FireflyAlgorithm | \`#L679\` |
| AntColonyOpt | \`#L724\` |
| EvolutionStrategy | \`#L829\` |
| AdaptiveRandomSearch | \`humpday/optimizers/search_algorithms.py#L18\` |
| CoordinateDescent | \`#L57\` |
| PatternSearch | \`#L109\` |

Line numbers sourced from a single \`grep -nE '^class'\` over the optimizer modules at HEAD, so they point at the current source.

## Verification

| Check | Result |
|---|---|
| \`grep -cF 'Not in Python core' docs/index.html\` | ✅ 0 (was 9) |
| HTML parses via \`html.parser\` | ✅ |
| \`ruff check .\` | ✅ All checks passed |
| \`ruff format --check .\` | ✅ 107 files already formatted |

## Why this is a small focused PR

Pulled out of the \`NUMPY_REMOVAL_RESUME.md\` doc-bug list (also captured in \`GOALS.md\`). It's a self-contained docs fix with no Python touched, so it's a good "post-suspension proof CI is healthy" warm-up before the larger PRIMA-trio numpy-removal PR.