### PR TITLE
add SVD, QR, pinv to the shim + GOALS.md (foundation for PRIMA-trio port)

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -1,0 +1,128 @@
+# HumpDay Goals & Status
+
+Single source of truth for what's done and what's left, across all 22 algorithms.
+**Supersedes** `RESUME.md` (stale, from a prior session) and `NUMPY_REMOVAL_RESUME.md` (focused on one work-stream; merge into this file when its goal column is fully ✅).
+
+Legend: ✅ done · 🟡 partial / in-progress · ❌ not done · ❓ unknown / unverified
+
+## Status matrix
+
+| Algorithm | 3rd party | JS | no-numpy | demo | contests | int links | ext links | logic | perf |
+|---|---|---|---|---|---|---|---|---|---|
+| PRIMA_UOBYQA | ✅ | ❓ | ❌ | 🟡 | ✅ | ❓ | ❓ | ✅ | ❓ |
+| PRIMA_NEWUOA | ✅ | ❓ | ❌ | 🟡 | ✅ | ❓ | ❓ | ✅ | ❓ |
+| PRIMA_BOBYQA | ✅ | ❓ | ❌ | 🟡 | ✅ | ❓ | ❓ | ✅ | ❓ |
+| NelderMead | ✅ | ❓ | ✅ | 🟡 | ✅ | ❓ | ❓ | ✅ | ❓ |
+| Powell | ✅ | ❓ | ✅ | 🟡 | ✅ | ❓ | ❓ | ✅ | ❓ |
+| LBFGSB | ✅ | ❓ | ✅ | 🟡 | ✅ | ❓ | ❓ | 🟡 | ❓ |
+| DifferentialEvolution | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| ParticleSwarm | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| SimulatedAnnealing | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| GeneticAlgorithm | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| RandomSearch | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| BayesianOpt | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | 🟡 | ❓ |
+| CMAEvolutionStrategy | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| TabuSearch | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| FireflyAlgorithm | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| AntColonyOpt | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| EvolutionStrategy | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| HillClimbing | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| HarmonySearch | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| AdaptiveRandomSearch | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| CoordinateDescent | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| PatternSearch | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
+
+## Column meanings
+
+| Column | What "✅" means | Where to look |
+|---|---|---|
+| **3rd party** | Algorithm has been validated against a reference implementation (SciPy / PRIMA / etc.). | `tests/test_implementation_validation.py`, `tests/test_complete_validation.py`, PR #43 fidelity-audit notes |
+| **JS** | Python output cross-validated against the JavaScript port at the same seed / inputs. | `tests/test_python_js_validation.py`, `docs/js/modules/*.js` |
+| **no-numpy** | Algorithm works under `HUMPDAY_FORCE_PURE_ARRAY=1` (the shim's pure-Python backend). | `tests/test_ported_algorithms.py::PORTED` |
+| **demo** | Algorithm appears correctly in `docs/algorithm-visualization-demo.html` and the visualizer's algorithm selector. The "demo" status reflects whether the algorithm is listed AND whether the docs/index.html table shows the proper Python source link (not the wrong "Not in Python core" label). | `docs/algorithm-visualization-demo.html`, `docs/js/algorithm-visualizer.js`, `docs/index.html` |
+| **contests** | Algorithm is registered in the contest framework and runnable from the live contest page. | `docs/contest.html`, `humpday/optimizers/adaptive_optimizer.py` |
+| **int links** | Every internal anchor / file link on the algorithm's docs page resolves. | `docs/algorithms/<algorithm>.html`, `docs/index.html` |
+| **ext links** | Every external paper / repo link still returns 200. | algorithm docs pages, `humpday/optimizers/*.py` docstrings |
+| **logic** | The algorithm's implementation has been read end-to-end and matches its reference; no known numerical bugs. | code review + `tests/test_optimizers.py::test_compendium` |
+| **perf** | Algorithm has a current Elo / relative-performance benchmark recorded. | `humpday/optimizers/adaptive_optimizer.py`, benchmark scripts |
+
+## Cell-status notes (where current marks deviate from a blanket ✅)
+
+- **PRIMA trio · no-numpy** — three algorithms remain numpy-dependent; need `svd` added to the shim first. See "PRIMA trio port" below.
+- **All algorithms · JS** — the JavaScript port exists at `docs/js/modules/*.js`, but I am unaware of an automated Python↔JS parity sweep that runs in CI. `tests/test_python_js_validation.py` exists; most of its cases are skipped (10 skips in the test inventory). Mark every cell as ❓ until that gap is verified.
+- **All algorithms · demo** — the matrix here reflects the actual state of two specific bugs:
+  - `docs/index.html` Algorithm Categories section was fixed in PR #49 to list all 22 algorithms; that's why the column isn't ❌ across the board.
+  - `docs/index.html` algorithm table at lines 285-359 still has 9 rows that say `<em>Not in Python core</em>` for algorithms that ARE in Python. Those nine are marked ❌ here. The affected nine are: BayesianOpt, CMAEvolutionStrategy, TabuSearch, FireflyAlgorithm, AntColonyOpt, EvolutionStrategy, AdaptiveRandomSearch, CoordinateDescent, PatternSearch. Fix details are in the "Documentation bugs" section below.
+- **LBFGSB · logic** — 🟡 because the class is named L-BFGS-B but is structurally finite-difference gradient + momentum (no actual L-BFGS quasi-Newton). Naming is misleading; behaviour is reasonable for a derivative-free baseline. Either rename the class or genuinely implement L-BFGS quasi-Newton updates.
+- **BayesianOpt · logic** — 🟡 because the GP kernel had broadcasting tricks (numpy path) and a separate pure-Python path with explicit loops, gated on `_A.BACKEND`. Both paths verified against the sphere, but no rigorous validation against `scikit-optimize` or `BoTorch`.
+- **All algorithms · int links / ext links / perf** — ❓ across the board pending a sweep.
+
+## Project-level work items (separate from per-algorithm goals)
+
+### PRIMA trio port
+
+Last three algorithms still on direct numpy. Plan:
+
+1. Add `svd` to the shim.
+   - Numpy backend: re-export `np.linalg.svd`.
+   - Pure backend: implement via Jacobi-style eigendecomposition of `AᵀA` (sketch in `NUMPY_REMOVAL_RESUME.md`).
+   - Parametrised tests under both backends.
+2. Port `PRIMA_UOBYQA`, `PRIMA_NEWUOA`, `PRIMA_BOBYQA`, using the `list[_Vec]` pattern for 2-D arrays (same as NelderMead in PR #54).
+3. Replace `np.linalg.pinv` fallbacks with `solve(A + ε I, I)`.
+4. Add the three to `tests/test_ported_algorithms.py::PORTED`.
+
+### Numpy-optional milestone wrap-up
+
+After all 22 algorithms are numpy-optional:
+
+1. **`pyproject.toml`** — move `numpy>=1.21.5` from `[project] dependencies` to `[project.optional-dependencies] fast = ["numpy>=1.21.5"]`.
+2. **`README.md`** — update the comparison table to reflect that the bare wheel (87 KB) is genuinely pure-Python; `[fast]` install pulls in ~33 MB of numpy.
+3. **Version bump** to `0.10.0` (or `1.0.0` to signal the milestone).
+
+### Documentation bugs
+
+1. **`docs/index.html` lines 285-359** — nine rows still claim `<em>Not in Python core</em>` for algorithms that have been in Python all along. Replace each with a proper `<a>` link to the Python source file. Algorithms affected: BayesianOpt, CMAEvolutionStrategy, TabuSearch, FireflyAlgorithm, AntColonyOpt, EvolutionStrategy, AdaptiveRandomSearch, CoordinateDescent, PatternSearch.
+2. **`docs/RESUME.md`** — older session notes; delete or move to a historical folder once this `GOALS.md` is established as the canonical doc.
+
+### Test-infrastructure debts
+
+1. **`test_compendium`** and **`test_portfolio`** rely on seeded `random.choice` to avoid pre-existing algorithm flakes. Keep the seeds + the `BudgetExceeded` guard in `test_compendium` — both protect against future regressions.
+2. **Pure-backend subprocess test** runs all 19 ported algorithms in one forked process with `HUMPDAY_FORCE_PURE_ARRAY=1`. Currently uses `n_trials=50` to fit a 180s timeout on CI hardware; numpy-backend tests still use 200.
+3. **Python↔JS parity** — `tests/test_python_js_validation.py` has 10 skipped cases. Either resurrect them or replace with a clean reference suite.
+
+### CI sanity
+
+1. The publish workflow (`.github/workflows/publish.yml`) uses OIDC trusted publishing. PyPI side must be configured with: owner `microprediction`, repo `humpday`, workflow filename `publish.yml`, environment `pypi`.
+2. After the recent suspension incident, avoid bursts of many PRs in a short window with AI-attributed commits — that pattern looks like spam to GitHub's automation.
+
+## How to update this file
+
+When you finish work that flips a cell:
+
+1. Change the cell glyph in the status matrix.
+2. If the change clears a row entirely, the algorithm is "done" for that goal; consider whether the goal-column itself can be marked complete project-wide.
+3. If the change adds a new project-level concern, append to the appropriate section.
+4. Don't grow this file with per-PR narratives. Those belong in commit messages and PR descriptions. This is a *status* doc, not a history.
+
+## Quick verification commands
+
+```bash
+# Numpy-optional progress: count of algorithms in PORTED
+grep -c '^    (' tests/test_ported_algorithms.py | head
+
+# Lint + format clean across the repo
+uvx ruff check .
+uvx ruff format --check .
+
+# Full test suite (with pure-backend subprocess)
+python -m pytest tests/ --ignore=tests/validation -q
+
+# Force-pure smoke test for any individual algorithm
+HUMPDAY_FORCE_PURE_ARRAY=1 python -c "
+from humpday.optimizers.evolutionary_algorithms import CMAEvolutionStrategy
+def f(x): return float(sum((xi - 0.5)**2 for xi in x))
+opt = CMAEvolutionStrategy(f, n_trials=100, n_dim=5)
+v, x = opt.optimize()
+print(v, list(x))
+"
+```

--- a/humpday/_array_numpy_linalg.py
+++ b/humpday/_array_numpy_linalg.py
@@ -61,6 +61,7 @@ def transpose(A):
 solve = _np.linalg.solve
 inv = _np.linalg.inv
 cholesky = _np.linalg.cholesky
+pinv = _np.linalg.pinv
 
 
 def eigh(A):
@@ -68,6 +69,20 @@ def eigh(A):
     where eigenvectors is a 2-D array whose columns are the unit eigenvectors,
     matching `numpy.linalg.eigh`."""
     return _np.linalg.eigh(A)
+
+
+def svd(A, full_matrices=False):
+    """Singular value decomposition. Returns (U, s, Vt) such that
+    `A ≈ U @ diag(s) @ Vt`. Matches `numpy.linalg.svd(A, full_matrices=False)`
+    by default — the thin / reduced form, which is what every humpday
+    caller wants."""
+    return _np.linalg.svd(A, full_matrices=full_matrices)
+
+
+def qr(A):
+    """QR factorisation. Returns (Q, R) such that `A = Q @ R`,
+    matching `numpy.linalg.qr(A, mode='reduced')`."""
+    return _np.linalg.qr(A)
 
 
 __all__ = [
@@ -81,6 +96,9 @@ __all__ = [
     "transpose",
     "solve",
     "inv",
+    "pinv",
     "cholesky",
     "eigh",
+    "svd",
+    "qr",
 ]

--- a/humpday/_array_pure_linalg.py
+++ b/humpday/_array_pure_linalg.py
@@ -325,6 +325,175 @@ def eigh(
     return sorted_vals, sorted_vecs
 
 
+# ---------------------------------------------------------------------------
+# QR decomposition (modified Gram-Schmidt)
+# ---------------------------------------------------------------------------
+
+
+def qr(A) -> Tuple[List[List[float]], List[List[float]]]:
+    """Reduced QR: returns (Q, R) where Q has orthonormal columns, R is
+    upper-triangular, and A = Q @ R. Uses modified Gram-Schmidt — numerically
+    decent for the small matrices PRIMA passes (n ≤ tens). For ill-conditioned
+    or very tall matrices, Householder would be preferable.
+    """
+    m = len(A)
+    n = len(A[0])
+    if m < n:
+        raise ValueError(f"qr requires m >= n, got {m}x{n}")
+
+    # Work columnwise. `cols` holds the (eventually-orthonormal) columns of Q.
+    # Build by copying A's columns and orthogonalising in-place.
+    cols = [[float(A[i][j]) for i in range(m)] for j in range(n)]
+    R = matrix_zeros(n, n)
+
+    for j in range(n):
+        # Subtract projections onto previous q_i.
+        for i in range(j):
+            qi = cols[i]
+            r_ij = sum(qi[k] * cols[j][k] for k in range(m))
+            R[i][j] = r_ij
+            for k in range(m):
+                cols[j][k] -= r_ij * qi[k]
+        # Normalise the residual to get q_j.
+        r_jj = math.sqrt(sum(v * v for v in cols[j]))
+        R[j][j] = r_jj
+        if r_jj < _PIVOT_TOL:
+            # Rank-deficient column: fill with an arbitrary unit vector
+            # orthogonal to what we have so far. For PRIMA's use, simplest
+            # safe choice is the j-th standard basis vector projected against
+            # current Q.
+            cand = [0.0] * m
+            cand[j if j < m else 0] = 1.0
+            for i in range(j):
+                qi = cols[i]
+                p = sum(qi[k] * cand[k] for k in range(m))
+                for k in range(m):
+                    cand[k] -= p * qi[k]
+            nrm = math.sqrt(sum(v * v for v in cand))
+            if nrm < _PIVOT_TOL:
+                cand = [0.0] * m
+                cand[(j + 1) % m] = 1.0
+            else:
+                cand = [v / nrm for v in cand]
+            cols[j] = cand
+        else:
+            cols[j] = [v / r_jj for v in cols[j]]
+
+    # Assemble Q as a 2-D list-of-rows from the column vectors.
+    Q = [[cols[j][i] for j in range(n)] for i in range(m)]
+    return Q, R
+
+
+# ---------------------------------------------------------------------------
+# Singular value decomposition (via eigh of A^T A)
+# ---------------------------------------------------------------------------
+
+
+def svd(
+    A, full_matrices: bool = False
+) -> Tuple[List[List[float]], _Vec, List[List[float]]]:
+    """Reduced SVD: returns (U, s, Vt) with A ≈ U @ diag(s) @ Vt.
+
+    Implementation: compute eigendecomposition of A^T A (n × n, symmetric
+    PSD). Eigenvalues give σ_i^2 (sorted descending after reordering); V
+    columns are the right singular vectors; U columns are computed as
+    A v_i / σ_i for nonzero σ_i, with rank-deficient columns filled from
+    the orthogonal complement.
+
+    Only `full_matrices=False` is supported (and is the numpy default for
+    SVD callers in humpday). The full form (square U / V) would require
+    extending U to an orthonormal basis when k < m; pull-request when
+    someone needs it.
+    """
+    if full_matrices:
+        raise NotImplementedError(
+            "svd(full_matrices=True) not supported in the pure backend yet"
+        )
+
+    m = len(A)
+    n = len(A[0])
+    k = min(m, n)
+
+    # B = A^T @ A, shape (n, n), symmetric PSD.
+    A_2d = [list(row) for row in A]
+    AT = transpose(A_2d)
+    B = matmul(AT, A_2d)
+
+    # eigh returns eigenvalues ascending. We want σ_i^2 descending, so
+    # reverse the order.
+    eigvals, V = eigh(B)
+    order = list(range(n))[::-1]
+    sigma_sq = [eigvals[i] for i in order]
+    V_sorted_cols = [[V[r][order[c]] for c in range(n)] for r in range(n)]
+
+    # σ_i = sqrt(max(λ_i, 0)) — eigenvalues should be ≥ 0 in exact
+    # arithmetic; clip to handle floating-point noise.
+    singular_values = [math.sqrt(max(s, 0.0)) for s in sigma_sq[:k]]
+
+    # Build U columns: u_i = A v_i / σ_i for σ_i > 0; otherwise fall back
+    # to an orthogonalised standard basis vector. Done columnwise then
+    # reassembled into a 2-D list-of-rows.
+    U_cols: List[List[float]] = []
+    for j in range(k):
+        sigma = singular_values[j]
+        if sigma > _PIVOT_TOL:
+            v_j = [V_sorted_cols[r][j] for r in range(n)]
+            A_v = matvec(A_2d, v_j)
+            U_cols.append([float(c) / sigma for c in A_v])
+        else:
+            # Rank-deficient: pick a standard basis vector and orthogonalise
+            # against the U columns already built.
+            cand = [0.0] * m
+            cand[j if j < m else 0] = 1.0
+            for prev in U_cols:
+                dot_p = sum(prev[i] * cand[i] for i in range(m))
+                for i in range(m):
+                    cand[i] -= dot_p * prev[i]
+            nrm = math.sqrt(sum(v * v for v in cand))
+            if nrm > _PIVOT_TOL:
+                cand = [v / nrm for v in cand]
+            U_cols.append(cand)
+
+    U = [[U_cols[j][i] for j in range(k)] for i in range(m)]
+    # Vt: rows are V's columns transposed (i.e. the right singular vectors
+    # written as rows).
+    Vt = [[V_sorted_cols[r][c] for r in range(n)] for c in range(k)]
+    return U, _Vec(singular_values), Vt
+
+
+# ---------------------------------------------------------------------------
+# Moore-Penrose pseudo-inverse (via SVD)
+# ---------------------------------------------------------------------------
+
+
+def pinv(A, rcond: float = 1e-15) -> List[List[float]]:
+    """Moore-Penrose pseudo-inverse: pinv(A) = V @ diag(1/s_truncated) @ U^T.
+    Singular values below `rcond * max(s)` are treated as zero (their
+    reciprocals are set to zero) — same convention as numpy.
+
+    `A` is m × n; `pinv(A)` is n × m.
+    """
+    U, s, Vt = svd(A, full_matrices=False)
+    if len(s) == 0:
+        m = len(A)
+        n = len(A[0])
+        return matrix_zeros(n, m)
+
+    s_max = max(s)
+    threshold = rcond * s_max if s_max > 0 else 0.0
+    s_inv = [(1.0 / si if si > threshold else 0.0) for si in s]
+
+    # pinv(A) = V @ diag(s_inv) @ U^T
+    # V is built from rows of Vt^T. Easier: V = transpose(Vt).
+    V = transpose(Vt)
+    UT = transpose(U)
+    # First M = diag(s_inv) @ UT — scales each row of UT by s_inv[i].
+    M = [
+        [s_inv[i] * UT[i][col] for col in range(len(UT[0]))] for i in range(len(s_inv))
+    ]
+    return matmul(V, M)
+
+
 __all__ = [
     "eye",
     "matrix_zeros",
@@ -336,6 +505,9 @@ __all__ = [
     "transpose",
     "solve",
     "inv",
+    "pinv",
     "cholesky",
     "eigh",
+    "svd",
+    "qr",
 ]

--- a/tests/test_array_shim_linalg.py
+++ b/tests/test_array_shim_linalg.py
@@ -258,6 +258,109 @@ def test_eigh_reconstruction(L):
         _close_vec(Av, lam_v, tol=1e-8)
 
 
+# ---------------------------------------------------------------------------
+# QR decomposition
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("L", BACKENDS)
+def test_qr_identity(L):
+    Q, R = L.qr(L.eye(3))
+    # Q should be the identity (up to sign of columns) and R upper-triangular.
+    # Check that Q @ R reconstructs the identity.
+    _close_matrix(L.matmul(Q, R), L.eye(3))
+
+
+@pytest.mark.parametrize("L", BACKENDS)
+def test_qr_reconstruction(L):
+    A = [[12.0, -51.0, 4.0], [6.0, 167.0, -68.0], [-4.0, 24.0, -41.0]]
+    Q, R = L.qr(A)
+    # Reconstruction: A = Q @ R
+    _close_matrix(L.matmul(Q, R), A, tol=1e-9)
+    # Q^T Q = I (orthonormal columns) — Q is 3x3 here, so Q^T Q is 3x3 identity.
+    QtQ = L.matmul(L.transpose(Q), Q)
+    _close_matrix(QtQ, L.eye(3), tol=1e-9)
+    # R is upper-triangular: every below-diagonal entry is zero.
+    for i in range(3):
+        for j in range(i):
+            assert abs(float(R[i][j])) < 1e-9, f"R[{i}][{j}] not zero: {R[i][j]}"
+
+
+@pytest.mark.parametrize("L", BACKENDS)
+def test_qr_tall_matrix(L):
+    # 4x2 — reduced QR returns 4x2 Q, 2x2 R.
+    A = [[1.0, 1.0], [1.0, -1.0], [1.0, 1.0], [1.0, -1.0]]
+    Q, R = L.qr(A)
+    _close_matrix(L.matmul(Q, R), A, tol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# SVD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("L", BACKENDS)
+def test_svd_diagonal(L):
+    # SVD of a diagonal matrix with distinct positive entries:
+    # singular values are the diagonal entries sorted descending.
+    A = [[3.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 2.0]]
+    U, s, Vt = L.svd(A, full_matrices=False)
+    _close_vec(list(s), [3.0, 2.0, 1.0], tol=1e-9)
+
+
+@pytest.mark.parametrize("L", BACKENDS)
+def test_svd_reconstruction(L):
+    A = [[1.0, 0.5, 0.3], [0.5, 2.0, 0.7], [0.3, 0.7, 1.5]]
+    U, s, Vt = L.svd(A, full_matrices=False)
+    # A ≈ U @ diag(s) @ Vt
+    n = len(s)
+    diag_s = L.diag(list(s))
+    reconstructed = L.matmul(L.matmul(U, diag_s), Vt)
+    _close_matrix(reconstructed, A, tol=1e-8)
+
+
+@pytest.mark.parametrize("L", BACKENDS)
+def test_svd_rectangular(L):
+    # 4x2 — reduced SVD returns U (4x2), s (length 2), Vt (2x2).
+    A = [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, -1.0]]
+    U, s, Vt = L.svd(A, full_matrices=False)
+    assert len(U) == 4
+    assert len(U[0]) == 2
+    assert len(s) == 2
+    assert len(Vt) == 2
+    assert len(Vt[0]) == 2
+    # Reconstruction
+    diag_s = L.diag(list(s))
+    reconstructed = L.matmul(L.matmul(U, diag_s), Vt)
+    _close_matrix(reconstructed, A, tol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Pseudo-inverse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("L", BACKENDS)
+def test_pinv_square_invertible(L):
+    # For invertible square A, pinv(A) == inv(A).
+    A = [[4.0, 7.0], [2.0, 6.0]]
+    Ap = L.pinv(A)
+    # A @ pinv(A) should be the 2x2 identity.
+    _close_matrix(L.matmul(A, Ap), [[1, 0], [0, 1]], tol=1e-8)
+
+
+@pytest.mark.parametrize("L", BACKENDS)
+def test_pinv_rank_deficient(L):
+    # Rank-1 matrix: only one nonzero singular value. pinv should still
+    # exist and yield a valid Moore-Penrose pseudo-inverse.
+    # A = u v^T with u = [1, 2], v = [1, 0, 1] -> rank 1.
+    A = [[1.0, 0.0, 1.0], [2.0, 0.0, 2.0]]
+    Ap = L.pinv(A)
+    # MP-1: A @ pinv(A) @ A == A
+    AAA = L.matmul(L.matmul(A, Ap), A)
+    _close_matrix(AAA, A, tol=1e-8)
+
+
 def test_pure_eigh_non_symmetric_raises():
     # The numpy backend silently symmetrises (it reads only the lower
     # triangle by default), so this guarantee is pure-only.


### PR DESCRIPTION
## What

Foundation for porting the PRIMA trio (UOBYQA, NEWUOA, BOBYQA) — the last three algorithms still on direct numpy. PRIMA uses \`np.linalg.svd\`, \`np.linalg.qr\`, and \`np.linalg.pinv\` heavily in its trust-region machinery; this PR adds the equivalent shim primitives so the actual port becomes a small follow-up.

Also adds **\`GOALS.md\`** as the canonical project status doc (rows = 22 algorithms, columns = 9 goals: 3rd-party validation, JS parity, no-numpy, demo page, contests, internal links, external links, logic review, perf benchmarks) and removes the earlier \`NUMPY_REMOVAL_RESUME.md\` since it's now superseded.

## Shim additions

### Numpy backend (\`humpday/_array_numpy_linalg.py\`)

Thin re-exports of \`np.linalg.{svd,qr,pinv}\`. No real code.

### Pure backend (\`humpday/_array_pure_linalg.py\`)

| Primitive | Approach |
|---|---|
| \`qr(A)\` | Modified Gram-Schmidt with rank-deficient-column fill. Numerically decent for the small matrices PRIMA passes (n ≤ tens). |
| \`svd(A, full_matrices=False)\` | Eigendecompose \`AᵀA\` to get σ² and V; build U as \`A v_i / σ_i\` with rank-deficient columns filled from the orthogonal complement. \`full_matrices=True\` is unimplemented — no caller in humpday needs it. |
| \`pinv(A, rcond=1e-15)\` | Moore-Penrose via SVD. Singular values below \`rcond * max(s)\` are treated as zero, matching numpy's convention. |

## Tests

\`tests/test_array_shim_linalg.py\` grows by **16 cases** (8 new asserts, each parametrised across both backends):

- QR: identity, reconstruction (A = Q @ R, Qᵀ Q = I, R upper-triangular), tall-matrix.
- SVD: diagonal-matrix singular values, reconstruction (A ≈ U @ diag(s) @ Vt), rectangular 4×2.
- pinv: square invertible (== inv), rank-deficient (MP-1: \`A @ pinv(A) @ A == A\`).

All 16 pass.

## Verification

| Check | Result |
|---|---|
| Full suite | ✅ 315 passed, 21 skipped, 0 failures, 55s |
| \`ruff check .\` | ✅ |
| \`ruff format --check .\` | ✅ 107 files |

## What this does NOT do

Purely additive — no optimizer code is changed. The PRIMA trio still uses direct numpy. Porting them to use these primitives lands in the follow-up PR.

Per-algorithm "no-numpy" column in GOALS.md is unchanged (19 / 22). The follow-up flips the remaining three.

## GOALS.md

New file at the repo root, intended as the single source of truth for project status going forward. Format described in the file's "How to update" section: rows = algorithms, columns = goals, cells = ✅ / 🟡 / ❌ / ❓. Project-level work items (PRIMA-trio plan, milestone wrap-up, documentation bugs, test debts) live in dedicated sections below the matrix.