### PR TITLE
numpy-optional milestone: move numpy to extras, bump 0.10.0 🎯

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -20,17 +20,17 @@ Legend: ✅ done · 🟡 partial / in-progress · ❌ not done · ❓ unknown / 
 | SimulatedAnnealing | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
 | GeneticAlgorithm | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
 | RandomSearch | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
-| BayesianOpt | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | 🟡 | ❓ |
-| CMAEvolutionStrategy | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
-| TabuSearch | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
-| FireflyAlgorithm | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
-| AntColonyOpt | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
-| EvolutionStrategy | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| BayesianOpt | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | 🟡 | ❓ |
+| CMAEvolutionStrategy | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| TabuSearch | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| FireflyAlgorithm | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| AntColonyOpt | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| EvolutionStrategy | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
 | HillClimbing | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
 | HarmonySearch | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
-| AdaptiveRandomSearch | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
-| CoordinateDescent | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
-| PatternSearch | ✅ | ❓ | ✅ | ❌ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| AdaptiveRandomSearch | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| CoordinateDescent | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
+| PatternSearch | ✅ | ❓ | ✅ | ✅ | ✅ | ❓ | ❓ | ✅ | ❓ |
 
 ## Column meanings
 
@@ -50,44 +50,21 @@ Legend: ✅ done · 🟡 partial / in-progress · ❌ not done · ❓ unknown / 
 
 - **PRIMA trio · no-numpy** — three algorithms remain numpy-dependent; need `svd` added to the shim first. See "PRIMA trio port" below.
 - **All algorithms · JS** — the JavaScript port exists at `docs/js/modules/*.js`, but I am unaware of an automated Python↔JS parity sweep that runs in CI. `tests/test_python_js_validation.py` exists; most of its cases are skipped (10 skips in the test inventory). Mark every cell as ❓ until that gap is verified.
-- **All algorithms · demo** — the matrix here reflects the actual state of two specific bugs:
-  - `docs/index.html` Algorithm Categories section was fixed in PR #49 to list all 22 algorithms; that's why the column isn't ❌ across the board.
-  - `docs/index.html` algorithm table at lines 285-359 still has 9 rows that say `<em>Not in Python core</em>` for algorithms that ARE in Python. Those nine are marked ❌ here. The affected nine are: BayesianOpt, CMAEvolutionStrategy, TabuSearch, FireflyAlgorithm, AntColonyOpt, EvolutionStrategy, AdaptiveRandomSearch, CoordinateDescent, PatternSearch. Fix details are in the "Documentation bugs" section below.
+- **All algorithms · demo** — `docs/index.html` Algorithm Categories section was fixed in PR #49 to list all 22 algorithms, and the 9 wrong `<em>Not in Python core</em>` rows were replaced with proper Python source links in PR #57. The 🟡 marks on the trust-region / classic-numerical rows reflect that the live visualizer demo at <https://humpday.microprediction.org/algorithm-visualization-demo.html> has not been individually verified against each algorithm; the docs index is good.
 - **LBFGSB · logic** — 🟡 because the class is named L-BFGS-B but is structurally finite-difference gradient + momentum (no actual L-BFGS quasi-Newton). Naming is misleading; behaviour is reasonable for a derivative-free baseline. Either rename the class or genuinely implement L-BFGS quasi-Newton updates.
 - **BayesianOpt · logic** — 🟡 because the GP kernel had broadcasting tricks (numpy path) and a separate pure-Python path with explicit loops, gated on `_A.BACKEND`. Both paths verified against the sphere, but no rigorous validation against `scikit-optimize` or `BoTorch`.
 - **All algorithms · int links / ext links / perf** — ❓ across the board pending a sweep.
 
 ## Project-level work items (separate from per-algorithm goals)
 
-### PRIMA trio port
-
-Last three algorithms still on direct numpy. Plan:
-
-1. Add `svd` to the shim.
-   - Numpy backend: re-export `np.linalg.svd`.
-   - Pure backend: implement via Jacobi-style eigendecomposition of `AᵀA` (sketch in `NUMPY_REMOVAL_RESUME.md`).
-   - Parametrised tests under both backends.
-2. Port `PRIMA_UOBYQA`, `PRIMA_NEWUOA`, `PRIMA_BOBYQA`, using the `list[_Vec]` pattern for 2-D arrays (same as NelderMead in PR #54).
-3. Replace `np.linalg.pinv` fallbacks with `solve(A + ε I, I)`.
-4. Add the three to `tests/test_ported_algorithms.py::PORTED`.
-
-### Numpy-optional milestone wrap-up
-
-After all 22 algorithms are numpy-optional:
-
-1. **`pyproject.toml`** — move `numpy>=1.21.5` from `[project] dependencies` to `[project.optional-dependencies] fast = ["numpy>=1.21.5"]`.
-2. **`README.md`** — update the comparison table to reflect that the bare wheel (87 KB) is genuinely pure-Python; `[fast]` install pulls in ~33 MB of numpy.
-3. **Version bump** to `0.10.0` (or `1.0.0` to signal the milestone).
-
 ### Documentation bugs
 
-1. **`docs/index.html` lines 285-359** — nine rows still claim `<em>Not in Python core</em>` for algorithms that have been in Python all along. Replace each with a proper `<a>` link to the Python source file. Algorithms affected: BayesianOpt, CMAEvolutionStrategy, TabuSearch, FireflyAlgorithm, AntColonyOpt, EvolutionStrategy, AdaptiveRandomSearch, CoordinateDescent, PatternSearch.
-2. **`docs/RESUME.md`** — older session notes; delete or move to a historical folder once this `GOALS.md` is established as the canonical doc.
+1. **`docs/RESUME.md`** — older session notes; delete or move to a historical folder once this `GOALS.md` is fully established as the canonical doc.
 
 ### Test-infrastructure debts
 
 1. **`test_compendium`** and **`test_portfolio`** rely on seeded `random.choice` to avoid pre-existing algorithm flakes. Keep the seeds + the `BudgetExceeded` guard in `test_compendium` — both protect against future regressions.
-2. **Pure-backend subprocess test** runs all 19 ported algorithms in one forked process with `HUMPDAY_FORCE_PURE_ARRAY=1`. Currently uses `n_trials=50` to fit a 180s timeout on CI hardware; numpy-backend tests still use 200.
+2. **Pure-backend subprocess test** runs all 22 ported algorithms in one forked process with `HUMPDAY_FORCE_PURE_ARRAY=1`. Currently uses `n_trials=50` to fit a 180s timeout on CI hardware; numpy-backend tests still use 200.
 3. **Python↔JS parity** — `tests/test_python_js_validation.py` has 10 skipped cases. Either resurrect them or replace with a clean reference suite.
 
 ### CI sanity

--- a/README.md
+++ b/README.md
@@ -6,13 +6,25 @@
 
 **[Documentation & Live Demos](https://humpday.microprediction.org)**
 
-22 derivative-free optimization algorithms in pure Python. No compilation, just numpy.
+22 derivative-free optimization algorithms in pure Python. No compilation, no required dependencies.
 
 ## Install & Use
 
 ```bash
 pip install humpday
 ```
+
+Zero runtime dependencies. Every algorithm has a pure-Python implementation
+that works wherever Python runs.
+
+If you want the numpy-accelerated backend for higher dimensions:
+
+```bash
+pip install humpday[fast]
+```
+
+The same algorithm code runs either way; humpday transparently uses numpy
+when it's available and falls back to pure Python when it isn't.
 
 ```python
 from humpday import minimize
@@ -26,20 +38,22 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]
 
 ## Algorithms
 
-22 validated optimizers: **[See them in action](https://humpday.microprediction.org)** | **[Source code](humpday/optimizers/optimizers.py)**
+22 validated optimizers: **[See them in action](https://humpday.microprediction.org)** | **[Source code](humpday/optimizers/alloptimizers.py)**
 
-Trust region methods, evolutionary algorithms, metaheuristics. 
+Trust region methods, evolutionary algorithms, metaheuristics.
 
 ## Comparison
 
-| Library | Dependencies | Install Size | Global Optimizers | Pure Python |
-|---------|--------------|--------------|-------------------|-------------|
-| **Humpday** | numpy only | ~1MB | 22 validated | ✅ |
-| SciPy | C/Fortran libs | ~50MB | 3 | ❌ |
-| Optuna | Many | ~100MB | 100+ | ❌ |
-| Nevergrad | Many | ~200MB | 200+ | ❌ |
+Marginal install footprint on top of a Python environment that already has numpy:
 
-**Humpday's niche**: When you need optimization that works anywhere Python runs, without dependencies or compilation.
+| Library | Adds on top of numpy | Global optimizers |
+|---------|---------------------:|------------------:|
+| **Humpday** | **~1 MB** (or zero without `[fast]`) | **22** |
+| SciPy       | ~100 MB | 6 documented |
+| Optuna      | ~30 MB  | 11 samplers |
+| Nevergrad   | ~230 MB | 540+ registered (tuned variants of ~30 base methods) |
+
+**Humpday's niche**: when you need optimization that works anywhere Python runs, without dependencies or compilation.
 
 ## License
 

--- a/humpday/_array_numpy.py
+++ b/humpday/_array_numpy.py
@@ -30,10 +30,13 @@ arange = _np.arange
 
 cos = _np.cos
 sin = _np.sin
+tan = _np.tan
+atan = _np.arctan  # arctan in numpy; shim uses the math-module name.
 exp = _np.exp
 log = _np.log
 sqrt = _np.sqrt
 abs = _np.abs  # noqa: A001 — intentional shadowing to match numpy's API
+pi = _np.pi
 
 # ---------------------------------------------------------------------------
 # Reductions
@@ -108,10 +111,13 @@ __all__ = [
     # Elementwise math
     "cos",
     "sin",
+    "tan",
+    "atan",
     "exp",
     "log",
     "sqrt",
     "abs",
+    "pi",
     # Reductions
     "sum",
     "mean",

--- a/humpday/_array_pure.py
+++ b/humpday/_array_pure.py
@@ -173,6 +173,14 @@ def sin(x):
     return _elementwise(math.sin, x)
 
 
+def tan(x):
+    return _elementwise(math.tan, x)
+
+
+def atan(x):
+    return _elementwise(math.atan, x)
+
+
 def exp(x):
     return _elementwise(math.exp, x)
 
@@ -187,6 +195,9 @@ def sqrt(x):
 
 def abs(x):  # noqa: A001 — match numpy API
     return _elementwise(_builtins.abs, x)
+
+
+pi = math.pi
 
 
 # ---------------------------------------------------------------------------
@@ -325,10 +336,13 @@ __all__ = [
     # Elementwise math
     "cos",
     "sin",
+    "tan",
+    "atan",
     "exp",
     "log",
     "sqrt",
     "abs",
+    "pi",
     # Reductions
     "sum",
     "mean",

--- a/humpday/optimizers/adaptive_optimizer.py
+++ b/humpday/optimizers/adaptive_optimizer.py
@@ -11,7 +11,7 @@ import os
 from collections.abc import Generator
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-import numpy as np
+from humpday import _array as _A
 
 from .alloptimizers import PURE_OPTIMIZERS, pure_optimize
 
@@ -127,7 +127,7 @@ def normalize_performance(values: List[float]) -> List[float]:
 
 
 def run_algorithm_tournament(
-    objective_generator: Generator[Callable[[np.ndarray], float], None, None],
+    objective_generator: Generator[Callable[[Any], float], None, None],
     trials_per_problem: int,
     n_problems: int,
     n_dim: int,
@@ -207,7 +207,7 @@ def run_algorithm_tournament(
 
 
 def adaptive_optimize(
-    objective_generator: Generator[Callable[[np.ndarray], float], None, None],
+    objective_generator: Generator[Callable[[Any], float], None, None],
     trials_budget: int,
     n_dim: int,
     n_warmup_problems: int = 5,
@@ -385,64 +385,71 @@ def suggest_algorithm_from_elo(
 # These are tested against reference implementations to ensure correctness
 
 
-# Pure lightweight implementations
+# Pure-Python objective-function generators for the Elo tournament. These
+# used to depend on numpy; rewritten via the shim so the whole adaptive
+# optimization path stays loadable without numpy.
+
+
+def _uniform_in(low: float, high: float, n: int):
+    """Length-n list of independent uniform [low, high) samples — what
+    `np.random.uniform(low, high, n)` returns. Uses the shim RNG so a
+    single `_A.seed(...)` call seeds every random source the package uses."""
+    span = high - low
+    return [low + span * _A.random_scalar() for _ in range(n)]
+
+
 def sphere_variants_generator(
     n_dim: int = 2,
-) -> Generator[Callable[[np.ndarray], float], None, None]:
-    """Generator yielding variants of the sphere function - pure lightweight implementation."""
+) -> Generator[Callable[[Any], float], None, None]:
+    """Generator yielding variants of the sphere function."""
 
     def sphere_pure(x):
-        """Pure sphere function: sum(x^2)"""
-        x = np.asarray(x)
-        return np.sum(x * x)
+        """sum(x_i ^ 2)"""
+        return sum(float(xi) * float(xi) for xi in x)
 
     def shifted_sphere(x):
-        """Sphere with random shift"""
-        x = np.asarray(x)
-        shift = np.random.uniform(-0.3, 0.3, len(x))
-        x_shifted = x + shift
-        return np.sum(x_shifted * x_shifted)
+        """Sphere with a random per-dimension shift in [-0.3, 0.3]."""
+        shift = _uniform_in(-0.3, 0.3, len(x))
+        return sum((float(xi) + s) * (float(xi) + s) for xi, s in zip(x, shift))
 
     def scaled_sphere(x):
-        """Sphere with different scales per dimension"""
-        x = np.asarray(x)
-        scales = np.random.uniform(0.5, 2.0, len(x))
-        x_scaled = scales * x
-        return np.sum(x_scaled * x_scaled)
+        """Sphere with random per-dimension scaling in [0.5, 2.0]."""
+        scales = _uniform_in(0.5, 2.0, len(x))
+        return sum((s * float(xi)) * (s * float(xi)) for xi, s in zip(x, scales))
 
     variants = [sphere_pure, shifted_sphere, scaled_sphere]
-
     while True:
-        yield np.random.choice(variants)
+        yield _A.random_choice(variants)
 
 
 def rosenbrock_variants_generator(
     n_dim: int = 2,
-) -> Generator[Callable[[np.ndarray], float], None, None]:
-    """Generator yielding variants of the Rosenbrock function - pure lightweight implementation."""
+) -> Generator[Callable[[Any], float], None, None]:
+    """Generator yielding variants of the Rosenbrock function."""
+
+    def _rosenbrock(values):
+        """Standard Rosenbrock applied to a flat sequence of floats."""
+        total = 0.0
+        for i in range(len(values) - 1):
+            a = float(values[i])
+            b = float(values[i + 1])
+            total += 100.0 * (b - a * a) ** 2 + (1.0 - a) ** 2
+        return total
 
     def rosenbrock_pure(x):
-        """Pure Rosenbrock function: sum(100*(x[i+1] - x[i]^2)^2 + (1 - x[i])^2)"""
-        x = np.asarray(x)
-        return np.sum(100.0 * (x[1:] - x[:-1] ** 2) ** 2 + (1 - x[:-1]) ** 2)
+        return _rosenbrock(list(x))
 
     def scaled_rosenbrock(x):
-        """Rosenbrock with random scaling"""
-        x = np.asarray(x)
-        scale = np.random.uniform(0.1, 5.0)
-        return scale * np.sum(100.0 * (x[1:] - x[:-1] ** 2) ** 2 + (1 - x[:-1]) ** 2)
+        """Rosenbrock × random scale in [0.1, 5.0]."""
+        scale = _uniform_in(0.1, 5.0, 1)[0]
+        return scale * _rosenbrock(list(x))
 
     def shifted_rosenbrock(x):
-        """Rosenbrock with random shift"""
-        x = np.asarray(x)
-        shift = np.random.uniform(-0.2, 0.2, len(x))
-        x_shifted = x + shift
-        return np.sum(
-            100.0 * (x_shifted[1:] - x_shifted[:-1] ** 2) ** 2
-            + (1 - x_shifted[:-1]) ** 2
-        )
+        """Rosenbrock with a random per-dimension shift in [-0.2, 0.2]."""
+        shift = _uniform_in(-0.2, 0.2, len(x))
+        shifted = [float(xi) + s for xi, s in zip(x, shift)]
+        return _rosenbrock(shifted)
 
     variants = [rosenbrock_pure, scaled_rosenbrock, shifted_rosenbrock]
-
     while True:
-        yield np.random.choice(variants)
+        yield _A.random_choice(variants)

--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -8,9 +8,6 @@ They excel at global optimization and handling multimodal landscapes.
 
 import math
 import random
-from typing import Tuple
-
-import numpy as np
 
 from humpday import _array as _A
 

--- a/humpday/optimizers/scipy_algorithms.py
+++ b/humpday/optimizers/scipy_algorithms.py
@@ -9,9 +9,6 @@ Reference: https://docs.scipy.org/doc/scipy/reference/optimize.html
 """
 
 import math
-from typing import Tuple
-
-import numpy as np
 
 from humpday import _array as _A
 
@@ -395,58 +392,3 @@ class LBFGSB(BaseOptimizer):
                 break
 
         return self.best_value, self.best_x
-
-    def _finite_difference_gradient(self, x, f, eps):
-        """Compute gradient using finite differences."""
-        grad = np.zeros(self.n_dim)
-
-        for i in range(self.n_dim):
-            if self.evaluations >= self.n_trials:
-                break
-
-            # Forward difference with bound checking
-            x_plus = x.copy()
-            if x[i] + eps <= 1.0:
-                x_plus[i] = x[i] + eps
-                f_plus = self.evaluate(x_plus)
-                grad[i] = (f_plus - f) / eps
-            else:
-                # Backward difference near upper bound
-                x_minus = x.copy()
-                x_minus[i] = max(0.0, x[i] - eps)
-                f_minus = self.evaluate(x_minus)
-                grad[i] = (f - f_minus) / eps
-
-        return grad
-
-    def _backtracking_line_search(self, x, f, grad, direction, c1=1e-4, alpha_max=1.0):
-        """Backtracking line search with Armijo condition."""
-        alpha = min(alpha_max, 1.0)
-        rho = 0.8  # Backtracking factor
-
-        # Ensure we don't violate bounds
-        for i in range(self.n_dim):
-            if direction[i] > 0:
-                alpha = min(alpha, (1.0 - x[i]) / (direction[i] + 1e-10))
-            elif direction[i] < 0:
-                alpha = min(alpha, x[i] / (-direction[i] + 1e-10))
-
-        armijo_condition = c1 * np.dot(grad, direction)
-
-        for _ in range(10):  # Max backtracking steps
-            if self.evaluations >= self.n_trials:
-                return None
-
-            x_new = np.clip(x + alpha * direction, 0, 1)
-            f_new = self.evaluate(x_new)
-
-            # Armijo condition
-            if f_new <= f + alpha * armijo_condition:
-                return alpha
-
-            alpha *= rho
-
-            if alpha < 1e-10:
-                break
-
-        return alpha if alpha >= 1e-10 else None

--- a/humpday/optimizers/scipy_interface.py
+++ b/humpday/optimizers/scipy_interface.py
@@ -5,134 +5,93 @@ This module provides thin wrappers that allow our unit hypercube [0,1]^n optimiz
 to work with arbitrary rectangular bounds, following SciPy conventions.
 """
 
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
-import numpy as np
+from humpday import _array as _A
 
 from .alloptimizers import PURE_OPTIMIZERS, pure_optimize, suggest_pure
 
 
-def unbounded_to_unit_cube(
-    x_real: np.ndarray, scale: Union[float, np.ndarray] = 1.0
-) -> np.ndarray:
-    """
-    Map from unbounded real space R^n to unit hypercube [0,1]^n.
-
-    Uses inverse tangent transformation: x_unit = (atan(x_real/scale)/π) + 0.5
-    This maps (-∞, +∞) to (0, 1) symmetrically around 0.5.
-
-    Parameters:
-    -----------
-    x_real : array_like
-        Point in unbounded space
-    scale : float or array_like, optional
-        Scaling factor for the transformation. Higher scale concentrates
-        more of the unit cube around larger values. Default is 1.0.
-    """
-    return (np.arctan(x_real / scale) / np.pi) + 0.5
+def unbounded_to_unit_cube(x_real, scale: Union[float, Any] = 1.0):
+    """Map ℝⁿ → (0, 1)ⁿ via `x_unit = atan(x_real / scale) / π + 0.5`.
+    Symmetric around 0.5; `scale` controls how much of the cube is
+    spent on which range of values."""
+    # Elementwise division when x_real is a vector and scale is a scalar
+    # works on both _Vec (via __truediv__) and numpy ndarray.
+    return (_A.atan(x_real / scale) / _A.pi) + 0.5
 
 
-def unit_cube_to_unbounded(
-    x_unit: np.ndarray, scale: Union[float, np.ndarray] = 1.0
-) -> np.ndarray:
-    """
-    Map from unit hypercube [0,1]^n to unbounded real space R^n.
-
-    Uses tangent transformation: x_real = scale * tan(π(x_unit - 0.5))
-    This maps (0, 1) to (-∞, +∞) symmetrically.
-
-    Parameters:
-    -----------
-    x_unit : array_like
-        Point in unit hypercube
-    scale : float or array_like, optional
-        Scaling factor for the transformation. Higher scale expands the
-        effective search range. Default is 1.0.
-    """
-    # Avoid singularities at 0 and 1
-    x_safe = np.clip(x_unit, 1e-15, 1 - 1e-15)
-    return scale * np.tan(np.pi * (x_safe - 0.5))
+def unit_cube_to_unbounded(x_unit, scale: Union[float, Any] = 1.0):
+    """Map (0, 1)ⁿ → ℝⁿ via `x_real = scale * tan(π (x_unit - 0.5))`.
+    Inverse of `unbounded_to_unit_cube`."""
+    x_safe = _A.clip(x_unit, 1e-15, 1 - 1e-15)
+    return scale * _A.tan(_A.pi * (x_safe - 0.5))
 
 
 def create_unbounded_objective(
-    objective: Callable, scale: Union[float, np.ndarray] = 1.0
+    objective: Callable, scale: Union[float, Any] = 1.0
 ) -> Callable:
-    """
-    Create objective function that maps from [0,1]^n to unbounded domain R^n.
-
-    Parameters:
-    -----------
-    objective : callable
-        Original objective function on unbounded domain
-    scale : float or array_like, optional
-        Scaling factor for the transformation. Should match the expected
-        scale of the problem. Default is 1.0.
-    """
+    """Wrap an objective defined on ℝⁿ so it can be called on a unit-cube
+    point — the wrapper applies `unit_cube_to_unbounded` internally."""
 
     def unbounded_objective(x_unit):
-        # Transform from unit cube to unbounded space
-        x_unit = np.asarray(x_unit)
+        x_unit = _A.asarray(x_unit)
         x_real = unit_cube_to_unbounded(x_unit, scale)
         return objective(x_real)
 
     return unbounded_objective
 
 
-def parse_bounds(bounds, n_dim: int) -> Tuple[np.ndarray, np.ndarray]:
-    """Parse bounds specification into lower and upper arrays."""
+def parse_bounds(bounds, n_dim: int):
+    """Parse a `bounds` specification into (lower, upper) vectors. Returns
+    either `_Vec` or numpy.ndarray pair depending on the active backend."""
     if bounds is None:
-        # Default to unit hypercube
-        return np.zeros(n_dim), np.ones(n_dim)
+        return _A.zeros(n_dim), _A.ones(n_dim)
 
     if isinstance(bounds, (list, tuple)) and len(bounds) == 2:
-        # Check if it's a single bound pair applied to all dimensions
+        # Single (lo, hi) pair, applied to every dimension.
         if isinstance(bounds[0], (int, float)) and isinstance(bounds[1], (int, float)):
-            lower = np.full(n_dim, bounds[0])
-            upper = np.full(n_dim, bounds[1])
+            lower = _A.full(n_dim, bounds[0])
+            upper = _A.full(n_dim, bounds[1])
             return lower, upper
 
-    # Otherwise expect list of (lower, upper) pairs
+    # Otherwise expect a sequence of (lower, upper) per-dimension pairs.
     if len(bounds) != n_dim:
         raise ValueError(f"Expected {n_dim} bound pairs, got {len(bounds)}")
 
-    lower = np.array([b[0] for b in bounds])
-    upper = np.array([b[1] for b in bounds])
+    lower = _A.asarray([b[0] for b in bounds])
+    upper = _A.asarray([b[1] for b in bounds])
 
-    # Validate bounds
-    if np.any(lower >= upper):
+    if any(float(lower[i]) >= float(upper[i]) for i in range(n_dim)):
         raise ValueError("Lower bounds must be less than upper bounds")
 
     return lower, upper
 
 
-def create_bounded_objective(
-    objective: Callable, lower: np.ndarray, upper: np.ndarray
-) -> Callable:
-    """Create objective function that maps from [0,1]^n to rectangular domain."""
+def create_bounded_objective(objective: Callable, lower, upper) -> Callable:
+    """Wrap an objective defined on [lower, upper] so it can be called on
+    a unit-cube point — the wrapper applies the affine map internally."""
 
     def bounded_objective(x_unit):
-        # Transform from unit hypercube to rectangular domain
-        x_unit = np.asarray(x_unit)
+        x_unit = _A.asarray(x_unit)
         x_real = lower + x_unit * (upper - lower)
         return objective(x_real)
 
     return bounded_objective
 
 
-def transform_solution(
-    x_unit: np.ndarray, lower: np.ndarray, upper: np.ndarray
-) -> np.ndarray:
-    """Transform solution from unit hypercube back to rectangular domain."""
+def transform_solution(x_unit, lower, upper):
+    """Map a unit-cube point back to the [lower, upper] box."""
     return lower + x_unit * (upper - lower)
 
 
 def cube_minimize(
     fun: Callable,
-    x0: Optional[np.ndarray] = None,
+    x0: Optional[Any] = None,
     args: Tuple = (),
     method: Optional[str] = None,
     bounds: Optional[Union[List[Tuple[float, float]], Tuple[float, float]]] = None,
-    scale: Optional[Union[float, np.ndarray]] = None,
+    scale: Optional[Union[float, Any]] = None,
     options: Optional[dict] = None,
 ) -> object:
     """
@@ -239,7 +198,7 @@ def cube_minimize(
         best_value, best_x_unit = pure_optimize(unbounded_obj, method, maxiter, n_dim)
 
         # Transform solution back to unbounded space
-        best_x = unit_cube_to_unbounded(np.array(best_x_unit), scale)
+        best_x = unit_cube_to_unbounded(_A.asarray(best_x_unit), scale)
     else:
         # Bounded optimization: map rectangular bounds to [0,1]^n
         lower, upper = parse_bounds(bounds, n_dim)
@@ -247,7 +206,7 @@ def cube_minimize(
         best_value, best_x_unit = pure_optimize(bounded_obj, method, maxiter, n_dim)
 
         # Transform solution back to original domain
-        best_x = transform_solution(np.array(best_x_unit), lower, upper)
+        best_x = transform_solution(_A.asarray(best_x_unit), lower, upper)
 
     # Create result object
     result = OptimizeResult(
@@ -328,10 +287,10 @@ def cube_minimize_scalar(
 
 def minimize(
     fun: Callable,
-    x0: Optional[np.ndarray] = None,
+    x0: Optional[Any] = None,
     method: Optional[str] = None,
     bounds: Optional[Union[List[Tuple[float, float]], Tuple[float, float]]] = None,
-    scale: Optional[Union[float, np.ndarray]] = None,
+    scale: Optional[Union[float, Any]] = None,
     options: Optional[dict] = None,
 ) -> object:
     """
@@ -440,49 +399,17 @@ def cube_prima_uobyqa(fun: Callable, bounds=None, options=None) -> object:
     return cube_minimize(fun, method="PRIMA_UOBYQA", bounds=bounds, options=options)
 
 
-# Domain transformation utilities for advanced users
-def transform_to_unit_cube(
-    x: np.ndarray, bounds: List[Tuple[float, float]]
-) -> np.ndarray:
-    """
-    Transform point from rectangular domain to unit hypercube.
-
-    Parameters:
-    -----------
-    x : array_like
-        Point in rectangular domain
-    bounds : list of tuples
-        Bounds specification [(x1_min, x1_max), ...]
-
-    Returns:
-    --------
-    x_unit : ndarray
-        Point in unit hypercube [0,1]^n
-    """
-    x = np.asarray(x)
+# Domain transformation utilities for advanced users.
+def transform_to_unit_cube(x, bounds: List[Tuple[float, float]]):
+    """Affine map from a rectangular box to the unit cube."""
+    x = _A.asarray(x)
     lower, upper = parse_bounds(bounds, len(x))
     return (x - lower) / (upper - lower)
 
 
-def transform_from_unit_cube(
-    x_unit: np.ndarray, bounds: List[Tuple[float, float]]
-) -> np.ndarray:
-    """
-    Transform point from unit hypercube to rectangular domain.
-
-    Parameters:
-    -----------
-    x_unit : array_like
-        Point in unit hypercube [0,1]^n
-    bounds : list of tuples
-        Bounds specification [(x1_min, x1_max), ...]
-
-    Returns:
-    --------
-    x : ndarray
-        Point in rectangular domain
-    """
-    x_unit = np.asarray(x_unit)
+def transform_from_unit_cube(x_unit, bounds: List[Tuple[float, float]]):
+    """Inverse of `transform_to_unit_cube`."""
+    x_unit = _A.asarray(x_unit)
     lower, upper = parse_bounds(bounds, len(x_unit))
     return lower + x_unit * (upper - lower)
 

--- a/humpday/optimizers/search_algorithms.py
+++ b/humpday/optimizers/search_algorithms.py
@@ -6,10 +6,6 @@ including methods like coordinate descent, pattern search, and adaptive random s
 They are particularly effective for local optimization and structured exploration.
 """
 
-from typing import Tuple
-
-import numpy as np
-
 from humpday import _array as _A
 
 from .base import BaseOptimizer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "humpday"
-version = "0.9.0"
+version = "0.10.0"
 description = "Taking the pain out of choosing a Python global optimizer"
 readme = "README.md"
 license = "MIT"
@@ -22,14 +22,19 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 
-# Core dependencies - Pyodide compatible
-dependencies = [
-    "numpy>=1.21.5",
-    # Pure Python optimization algorithms - no external optimizer packages needed
-    # Lightweight implementation with 22+ validated algorithms
-]
+# Core dependencies — none. Every algorithm has a pure-Python path via
+# `humpday._array`, so `pip install humpday` ships a true zero-dependency
+# wheel. For speed on dimensions where it matters, opt into the numpy
+# backend with `pip install humpday[fast]` below.
+dependencies = []
 
 [project.optional-dependencies]
+# Speed: numpy backend for the shim. Algorithm code calls the same shim
+# functions either way; numpy is transparently used when available.
+fast = [
+    "numpy>=1.21.5",
+]
+
 # Only include working optimizers that don't cause compatibility issues
 extra = [
     "optuna>=3.0.0",  # Known to work with Python 3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,12 @@ experimental = [
     # Note: ax-platform, nlopt, dlib, hyperopt have compatibility issues
 ]
 
-# Development dependencies
+# Development dependencies. Includes numpy because much of the test
+# suite imports numpy directly (parity tests, reference checks, etc.)
+# — `[fast]` is the *runtime* numpy opt-in for end-users; `[dev]` is
+# the superset needed to develop and run the full test suite.
 dev = [
+    "numpy>=1.21.5",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "black>=23.0.0",


### PR DESCRIPTION
## What

The capstone of the 11-PR numpy-removal effort (#48 → #59). With every algorithm now operating through the \`humpday._array\` shim, numpy can leave the required-dependencies list.

| | Before | After |
|---|---|---|
| \`pip install humpday\` | pulls in numpy (~33 MB) | **zero runtime dependencies** |
| \`pip install humpday[fast]\` | n/a | pulls in numpy, transparently used by the shim |
| Wheel size | ~87 KB (unchanged) | ~87 KB |
| Version | 0.9.0 | **0.10.0** |

## End-to-end verification (the demo)

\`\`\`
$ python -m venv /tmp/no-numpy --clear
$ /tmp/no-numpy/bin/pip install --no-cache-dir dist/humpday-0.10.0-py3-none-any.whl
$ /tmp/no-numpy/bin/pip list
Package Version
------- -------
humpday 0.10.0
pip     24.3.1

$ /tmp/no-numpy/bin/python -c "
    from humpday import _array as A, minimize, ALGORITHM_NAMES, __version__
    print(A.BACKEND, __version__, len(ALGORITHM_NAMES))
    # -> pure 0.10.0 22

    def f(x): return (x[0]-2)**2 + (x[1]-3)**2
    for m in ['DifferentialEvolution', 'NelderMead', 'PRIMA_BOBYQA', 'CMAEvolutionStrategy']:
        r = minimize(f, bounds=[(-5,5),(-5,5)], method=m, options={'maxiter': 200})
        print(m, list(r.x), r.fun)
"
\`\`\`

All 22 algorithms load. Four sampled algorithms converge on a 2-D paraboloid with the pure backend.

## Changes

### \`pyproject.toml\`

- \`version = "0.10.0"\` (was 0.9.0).
- \`dependencies = []\` (was \`["numpy>=1.21.5"]\`).
- New \`[project.optional-dependencies] fast = ["numpy>=1.21.5"]\` group.

### \`README.md\`

- Tagline: *"No compilation, just numpy."* → *"No compilation, no required dependencies."*
- Install section: documents both \`pip install humpday\` (zero deps) and \`pip install humpday[fast]\` (numpy backend).
- Comparison table: replaced "Install Size" with **"Adds on top of numpy"**, using the measured values from this session.
- Broken \`optimizers.py\` source-code link repointed to \`alloptimizers.py\` (the old monolith was deleted in #50).

### Cleanups that this PR also catches

Several optimizer modules still had a top-level \`import numpy as np\` that was either entirely unused after the per-algorithm ports or only referenced from dead helper methods:

| File | Cleanup |
|---|---|
| \`scipy_algorithms.py\` | Dropped dead LBFGSB helpers (\`_finite_difference_gradient\`, \`_backtracking_line_search\`) and the now-unused import. |
| \`search_algorithms.py\` | Dropped the unused import. |
| \`evolutionary_algorithms.py\` | Dropped the unused top-level import. BayesianOpt's numpy-backend kernel path still imports numpy locally inside its backend gate. |

### Modules that needed real porting

| File | Notes |
|---|---|
| \`scipy_interface.py\` | Unit-cube transforms (\`atan\` / \`tan\` / \`clip\` / \`asarray\` / \`zeros\` / \`ones\` / \`full\`) and bound parsing now use the shim. |
| \`adaptive_optimizer.py\` | The Elo system was already pure-Python; the \`sphere_variants_generator\` / \`rosenbrock_variants_generator\` test fixtures had \`np.random.uniform\`, \`np.random.choice\`, \`np.asarray\`, \`np.sum(x*x)\` calls — replaced. |

### Shim additions

\`_A.tan\`, \`_A.atan\`, \`_A.pi\` added to both backends (needed by the cube transforms). Tests exercise them in \`tests/test_array_shim.py\`.

### \`GOALS.md\`

- PRIMA-trio rows flip to ✅ on no-numpy column.
- The nine demo-column ❌s (resolved by #57) flip to ✅.
- The "Numpy-optional milestone wrap-up" section is gone — this *is* the wrap-up.
- The "Not in Python core" docs-bug item is removed (resolved by #57).

## What's not in this PR

Auxiliary modules (\`humpday/objectives/*\`, \`humpday/transforms/*\`, \`humpday/visualization/*\`) still import numpy. They are NOT loaded by \`from humpday import minimize\`, so they don't block the zero-dependency install. Porting them is out of scope; track in GOALS.md if you want to chase those next.

## Verification

| Check | Result |
|---|---|
| Bare \`pip install humpday\` works without numpy | ✅ (demo above) |
| Full test suite (dev env with numpy) | ✅ 318 passed, 21 skipped, 0 failures, 55s |
| \`ruff check .\` | ✅ |
| \`ruff format --check .\` | ✅ 107 files |