### PR TITLE
Restore documentation pages and clean up broken links

### DIFF
--- a/docs/algorithms/adaptive-random-search.html
+++ b/docs/algorithms/adaptive-random-search.html
@@ -333,7 +333,6 @@
                         <li><a href="https://link.springer.com/article/10.1023/A:1008358414138" target="_blank">Adaptive Random Search Methods (Spall)</a></li>
                         <li><a href="https://en.wikipedia.org/wiki/Random_search" target="_blank">Random Search Wikipedia</a></li>
                         <li><a href="https://www.jmlr.org/papers/volume13/bergstra12a/bergstra12a.pdf" target="_blank">Random Search for Hyper-Parameter Optimization</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Random_search" target="_blank">Random Search Tutorial</a></li>
                         <li><a href="https://arxiv.org/abs/1803.07055" target="_blank">Simple random search provides competitive approach</a></li>
                     </ul>
 

--- a/docs/algorithms/adaptive-random-search.html
+++ b/docs/algorithms/adaptive-random-search.html
@@ -1,164 +1,197 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Adaptive Random Search - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: linear-gradient(35deg, #27ae %, #2ecc7 %);
+        .header {
+            background: linear-gradient(135deg, #27ae60 0%, #2ecc71 100%);
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
-            background: linear-gradient(35deg, #e8f5e8 %, #dedda %);
-            border-left: p solid #27ae;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: linear-gradient(135deg, #e8f5e8 0%, #d4edda 100%);
+            border-left: 4px solid #27ae60;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+
+        .adaptive-note {
+            background: #e7f3ff;
+            border: 1px solid #b3d9ff;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .adaptive-note h3 {
+            margin-top: 0;
+            color: #0066cc;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Adaptive Random Search (Custom)</h1>
+            <p>Intelligent Random Search with Learning</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,33 +199,33 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Adaptive Random Search (ARS)</strong> etends basic random search with intelligent adaptation mechanisms that learn from the optimization history. Unlike pure random search, ARS adjusts its sampling strategy, step sizes, or search regions based on success patterns, making it more efficient while maintaining the simplicity and robustness of random search methods.
+                <strong>Adaptive Random Search (ARS)</strong> extends basic random search with intelligent adaptation mechanisms that learn from the optimization history. Unlike pure random search, ARS adjusts its sampling strategy, step sizes, or search regions based on success patterns, making it more efficient while maintaining the simplicity and robustness of random search methods.
             </div>
 
             <div class="adaptive-note">
                 <h3>🧠 Adaptive Intelligence</h3>
                 <p><strong>Adaptive Random Search learns and adapts during optimization:</strong></p>
                 <ul>
-                    <li> <strong>Success-Based Learning:</strong> Adjust strategy based on improvement patterns</li>
-                    <li> <strong>Dynamic Step Size:</strong> Increase/decrease search radius based on success rate</li>
-                    <li>🗺️ <strong>Region ocusing:</strong> Concentrate search in promising areas</li>
-                    <li>⚖️ <strong>Eploration Balance:</strong> Maintain global search capability while eploiting good regions</li>
+                    <li>📈 <strong>Success-Based Learning:</strong> Adjust strategy based on improvement patterns</li>
+                    <li>🎯 <strong>Dynamic Step Size:</strong> Increase/decrease search radius based on success rate</li>
+                    <li>🗺️ <strong>Region Focusing:</strong> Concentrate search in promising areas</li>
+                    <li>⚖️ <strong>Exploration Balance:</strong> Maintain global search capability while exploiting good regions</li>
                 </ul>
             </div>
 
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Adaptive Random Search in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -213,10 +246,10 @@
                             <strong>Enhanced Random Search</strong><br>
                             Random sampling with adaptive parameter adjustment<br>
                             Learning from optimization history<br>
-                            <em>Developed: Various researchers, 97s-8s</em>
+                            <em>Developed: Various researchers, 1970s-80s</em>
                         </td>
                         <td>
-                            <a href="https://link.springer.com/article/.23/A:835838" target="_blank" class="link-button paper">📄 ARS Survey</a>
+                            <a href="https://link.springer.com/article/10.1023/A:1008358414138" target="_blank" class="link-button paper">📄 ARS Survey</a>
                         </td>
                     </tr>
                     <tr>
@@ -228,7 +261,7 @@
                             <em>Reference: Optimization literature and custom implementations</em>
                         </td>
                         <td>
-                            <a href="https://github.com/topics/adaptive-search" target="_blank" class="link-button python"> GitHub Eamples</a>
+                            <a href="https://github.com/topics/adaptive-search" target="_blank" class="link-button python">🔍 GitHub Examples</a>
                         </td>
                     </tr>
                     <tr>
@@ -237,10 +270,10 @@
                             <strong>Humpday Adaptive Random Search</strong><br>
                             Custom implementation with success-rate adaptation<br>
                             Dynamic step size and region focusing<br>
-                            <em>ile: humpday/optimizers/adaptiverandom.py</em>
+                            <em>File: humpday/optimizers/adaptiverandom.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -252,7 +285,7 @@
                             <em>Class: AdaptiveRandomSearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
                         </td>
                     </tr>
                     <tr>
@@ -263,7 +296,7 @@
                             <strong>Humpday JS:</strong> None (pure JavaScript)
                         </td>
                         <td>
-                            <span style="color: #95a5a;">✨ No eternal dependencies</span>
+                            <span style="color: #95a5a6;">✨ No external dependencies</span>
                         </td>
                     </tr>
                 </tbody>
@@ -274,127 +307,138 @@
                 <ul>
                     <li><strong>Best for:</strong> Problems where pure random search works but can be improved</li>
                     <li><strong>Dimensions:</strong> Scalable to high dimensions like random search</li>
-                    <li><strong>unction evaluations:</strong> More efficient than pure random search</li>
-                    <li><strong>Convergence:</strong> Better than O(/√n) through adaptive learning</li>
+                    <li><strong>Function evaluations:</strong> More efficient than pure random search</li>
+                    <li><strong>Convergence:</strong> Better than O(1/√n) through adaptive learning</li>
                     <li><strong>Robustness:</strong> Maintains random search robustness with added intelligence</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation of adaptive random search implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing against pure random search baseline</li>
+                    <li>🎯 Target: Demonstrate improved efficiency over basic random search</li>
+                    <li>📊 Metrics: Convergence speed, adaptation effectiveness, final solution quality</li>
+                    <li>🔧 Reference: Performance improvement over RandomSearch implementation</li>
+                </ul>
+                <p><em>Success measured by improvement over pure random search baseline.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
                 <div id="moreContent" class="more-content">
                     <h3>📚 Educational Resources</h3>
                     <ul>
-                        <li><a href="https://link.springer.com/article/.23/A:835838" target="_blank">Adaptive Random Search Methods (Spall)</a></li>
+                        <li><a href="https://link.springer.com/article/10.1023/A:1008358414138" target="_blank">Adaptive Random Search Methods (Spall)</a></li>
                         <li><a href="https://en.wikipedia.org/wiki/Random_search" target="_blank">Random Search Wikipedia</a></li>
-                        <li><a href="https://www.jmlr.org/papers/volume3/bergstra2a/bergstra2a.pdf" target="_blank">Random Search for Hyper-Parameter Optimization</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Random_search" target="_blank">Random Search Tutorial</a></li>
-                        <li><a href="https://ariv.org/abs/83.755" target="_blank">Simple random search provides competitive approach</a></li>
+                        <li><a href="https://www.jmlr.org/papers/volume13/bergstra12a/bergstra12a.pdf" target="_blank">Random Search for Hyper-Parameter Optimization</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Random_search" target="_blank">Random Search Tutorial</a></li>
+                        <li><a href="https://arxiv.org/abs/1803.07055" target="_blank">Simple random search provides competitive approach</a></li>
                     </ul>
 
-                    <h3> Adaptation Mechanisms</h3>
+                    <h3>🔬 Adaptation Mechanisms</h3>
                     <ul>
-                        <li><strong>Step Size Adaptation:</strong> σ(t+) = σ(t) × factor based on success rate</li>
+                        <li><strong>Step Size Adaptation:</strong> σ(t+1) = σ(t) × factor based on success rate</li>
                         <li><strong>Success Rate Tracking:</strong> Monitor fraction of improvements over recent history</li>
-                        <li><strong>Region ocusing:</strong> Bias sampling toward successful regions</li>
+                        <li><strong>Region Focusing:</strong> Bias sampling toward successful regions</li>
                         <li><strong>Direction Learning:</strong> Learn promising search directions</li>
                         <li><strong>Population Size:</strong> Adapt number of samples per iteration</li>
                         <li><strong>Distribution Shape:</strong> Modify sampling distribution parameters</li>
                     </ul>
 
-                    <h3>📐 Mathematical oundation</h3>
+                    <h3>📐 Mathematical Foundation</h3>
                     <ul>
                         <li><strong>Success Rate:</strong> p_s(t) = (# improvements) / (# recent samples)</li>
-                        <li><strong>Step Size Update:</strong> σ(t+) = σ(t) × ep(α × (p_s(t) - p_target))</li>
-                        <li><strong>Sampling:</strong> (t+) ~ N(_best, σ(t)²I) or other adaptive distributions</li>
-                        <li><strong>Region Weight:</strong> w_i ∝ ep(β × improvement_i) for region focusing</li>
+                        <li><strong>Step Size Update:</strong> σ(t+1) = σ(t) × exp(α × (p_s(t) - p_target))</li>
+                        <li><strong>Sampling:</strong> x(t+1) ~ N(x_best, σ(t)²I) or other adaptive distributions</li>
+                        <li><strong>Region Weight:</strong> w_i ∝ exp(β × improvement_i) for region focusing</li>
                     </ul>
 
                     <h3>⚙️ Key Parameters</h3>
                     <ul>
-                        <li><strong>Initial Step Size:</strong> σ₀ typically .-.5 of search range</li>
-                        <li><strong>Target Success Rate:</strong> p_target usually .-.3</li>
+                        <li><strong>Initial Step Size:</strong> σ₀ typically 0.1-0.5 of search range</li>
+                        <li><strong>Target Success Rate:</strong> p_target usually 0.1-0.3</li>
                         <li><strong>Adaptation Rate:</strong> α controls speed of step size changes</li>
                         <li><strong>Memory Window:</strong> How many recent samples to consider</li>
-                        <li><strong>Min/Ma Step Size:</strong> Bounds to prevent degenerate behavior</li>
+                        <li><strong>Min/Max Step Size:</strong> Bounds to prevent degenerate behavior</li>
                     </ul>
 
-                    <h3> ARS Algorithm Pseudocode</h3>
-                    <pre style="background: #f8f9fa; padding: 5p; border-radius: 8p; font-family: monospace;">
-function adaptiveRandomSearch(f, , maEvals, targetSuccessRate):
-    _best = 
-    f_best = f()
-    stepSize = .3  // Initial step size
-    successCount = 
-    windowSize = 5
+                    <h3>🎯 ARS Algorithm Pseudocode</h3>
+                    <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
+function adaptiveRandomSearch(f, x0, maxEvals, targetSuccessRate):
+    x_best = x0
+    f_best = f(x0)
+    stepSize = 0.3  // Initial step size
+    successCount = 0
+    windowSize = 50
     evaluations = []
 
-    for eval in  to maEvals:
+    for eval in 1 to maxEvals:
         // Generate candidate with current step size
-        _candidate = _best + stepSize * randomGaussian(n)
-        _candidate = clip(_candidate, [,])  // Bounds
-        f_candidate = f(_candidate)
+        x_candidate = x_best + stepSize * randomGaussian(n)
+        x_candidate = clip(x_candidate, [0,1])  // Bounds
+        f_candidate = f(x_candidate)
 
         // Track success/failure
         improved = (f_candidate < f_best)
         evaluations.append(improved)
 
         if improved:
-            _best = _candidate
+            x_best = x_candidate
             f_best = f_candidate
-            successCount += 
+            successCount += 1
 
         // Adapt step size every windowSize evaluations
-        if eval % windowSize == :
+        if eval % windowSize == 0:
             successRate = successCount / windowSize
 
             if successRate > targetSuccessRate:
-                stepSize *= .2  // Increase eploration
+                stepSize *= 1.2  // Increase exploration
             else:
-                stepSize *= .8  // ocus search
+                stepSize *= 0.8  // Focus search
 
-            stepSize = clip(stepSize, [., .])
-            successCount = 
+            stepSize = clip(stepSize, [0.01, 1.0])
+            successCount = 0
 
-    return _best, f_best
+    return x_best, f_best
                     </pre>
 
-                    <h3> ARS Variants</h3>
+                    <h3>🔧 ARS Variants</h3>
                     <ul>
-                        <li><strong>/5-th Rule ARS:</strong> Adapt step size based on success rate ≈ /5</li>
+                        <li><strong>1/5-th Rule ARS:</strong> Adapt step size based on success rate ≈ 1/5</li>
                         <li><strong>Multi-Point ARS:</strong> Generate multiple candidates per iteration</li>
-                        <li><strong>Directional ARS:</strong> Learn and eploit successful search directions</li>
+                        <li><strong>Directional ARS:</strong> Learn and exploit successful search directions</li>
                         <li><strong>Region-Based ARS:</strong> Partition search space and adapt per region</li>
-                        <li><strong>Covariance ARS:</strong> Adapt full covariance matri like CMA-ES</li>
+                        <li><strong>Covariance ARS:</strong> Adapt full covariance matrix like CMA-ES</li>
                         <li><strong>Hybrid ARS:</strong> Combine with local search or other methods</li>
                     </ul>
 
-                    <h3> Adaptation Strategies</h3>
+                    <h3>📊 Adaptation Strategies</h3>
                     <ul>
                         <li><strong>Success-Based:</strong> Adapt based on improvement frequency</li>
                         <li><strong>Progress-Based:</strong> Adapt based on magnitude of improvements</li>
                         <li><strong>Diversity-Based:</strong> Maintain population diversity</li>
                         <li><strong>Distance-Based:</strong> Adapt based on distance between improvements</li>
-                        <li><strong>Gradient-ree:</strong> Estimate search direction without gradients</li>
+                        <li><strong>Gradient-Free:</strong> Estimate search direction without gradients</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🚀 Applications</h3>
                     <ul>
                         <li><strong>Hyperparameter Optimization:</strong> Machine learning model tuning</li>
-                        <li><strong>Black-Bo Optimization:</strong> When gradient information unavailable</li>
-                        <li><strong>Noisy unctions:</strong> Robust to evaluation noise</li>
-                        <li><strong>Epensive unctions:</strong> Efficient use of limited evaluations</li>
-                        <li><strong>Multi-Modal unctions:</strong> Balance eploration and eploitation</li>
+                        <li><strong>Black-Box Optimization:</strong> When gradient information unavailable</li>
+                        <li><strong>Noisy Functions:</strong> Robust to evaluation noise</li>
+                        <li><strong>Expensive Functions:</strong> Efficient use of limited evaluations</li>
+                        <li><strong>Multi-Modal Functions:</strong> Balance exploration and exploitation</li>
                         <li><strong>Simulation Optimization:</strong> Parameter tuning for simulations</li>
                     </ul>
 
-                    <h3> Advantages of ARS</h3>
+                    <h3>💡 Advantages of ARS</h3>
                     <ul>
                         <li><strong>Simplicity:</strong> Easy to implement and understand</li>
                         <li><strong>Robustness:</strong> Inherits random search reliability</li>
                         <li><strong>Efficiency:</strong> Better than pure random search</li>
-                        <li><strong>Parameter-Light:</strong> ew hyperparameters to tune</li>
+                        <li><strong>Parameter-Light:</strong> Few hyperparameters to tune</li>
                         <li><strong>Parallelizable:</strong> Easy to distribute evaluations</li>
                         <li><strong>No Assumptions:</strong> Works on any objective function</li>
                     </ul>
@@ -404,7 +448,7 @@ function adaptiveRandomSearch(f, , maEvals, targetSuccessRate):
                         <li><strong>Slower than Specialized Methods:</strong> Less efficient than problem-specific algorithms</li>
                         <li><strong>Parameter Sensitivity:</strong> Performance depends on adaptation parameters</li>
                         <li><strong>High Dimensions:</strong> Still suffers from curse of dimensionality</li>
-                        <li><strong>Local Structure:</strong> Doesn't eploit smooth function structure</li>
+                        <li><strong>Local Structure:</strong> Doesn't exploit smooth function structure</li>
                         <li><strong>Memory Requirements:</strong> Needs to track success history</li>
                     </ul>
 
@@ -422,67 +466,67 @@ function adaptiveRandomSearch(f, , maEvals, targetSuccessRate):
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
-        
+                button.textContent = '📚 More Resources';
+            }
+        }
 
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/ant-colony-optimization.html
+++ b/docs/algorithms/ant-colony-optimization.html
@@ -1,151 +1,182 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Ant Colony Optimization (acopy) - Implementation Details</title>
     <style>
-        body 
-            font-family: -apple-system, BlinkMacSystemont, "Segoe UI", Roboto, sans-serif;
-            line-height: .;
-            margin: ;
-            padding: 2p;
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 20px;
             background: #ffffff;
             color: #333;
-        
+        }
 
-        .container 
-            ma-width: 9p;
-            margin:  auto;
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
             background: white;
-            border: p solid #ddd;
-            bo-shadow:  2p p rgba(,,,.5);
-        
+            border: 1px solid #ddd;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+        }
 
-        .header 
+        .header {
             background: #f8f9fa;
-            padding: 2p;
-            border-bottom: p solid #ddd;
-        
+            padding: 20px;
+            border-bottom: 1px solid #ddd;
+        }
 
-        .header h 
-            margin:   5p ;
-            font-size: .8em;
-            font-weight: ;
+        .header h1 {
+            margin: 0 0 5px 0;
+            font-size: 1.8em;
+            font-weight: 600;
             color: #333;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: em;
-            color: #;
-        
+        .header p {
+            margin: 0;
+            font-size: 1em;
+            color: #666;
+        }
 
-        .content 
-            padding: 2p;
-        
+        .content {
+            padding: 20px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 2p ;
-            border: p solid #ddd;
-        
+            margin: 20px 0;
+            border: 1px solid #ddd;
+        }
 
-        .implementation-table th 
+        .implementation-table th {
             background: #f8f9fa;
-            padding: 2p;
-            tet-align: left;
-            font-weight: ;
+            padding: 12px;
+            text-align: left;
+            font-weight: 600;
             color: #333;
-            border-bottom: p solid #ddd;
-        
+            border-bottom: 1px solid #ddd;
+        }
 
-        .implementation-table td 
-            padding: 2p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 12px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
+        .implementation-table .category {
+            font-weight: 600;
             color: #333;
             background: #f8f9fa;
-        
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: p 2p;
-            background: #7bff;
+            padding: 6px 12px;
+            background: #007bff;
             color: white;
-            tet-decoration: none;
-            border-radius: 3p;
-            font-size: .9em;
-            margin: 2p;
-        
+            text-decoration: none;
+            border-radius: 3px;
+            font-size: 0.9em;
+            margin: 2px;
+        }
 
-        .link-button:hover 
-            background: #5b3;
-        
+        .link-button:hover {
+            background: #0056b3;
+        }
 
-        .algorithm-description 
+        .algorithm-description {
             background: #f8f9fa;
-            border: p solid #ddd;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #7bff;
-            tet-decoration: none;
-        
+        .back-nav a {
+            color: #007bff;
+            text-decoration: none;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #f8f9fa;
-            border: p solid #ddd;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
+        .performance-notes h3 {
+            margin-top: 0;
             color: #333;
-        
+        }
 
-        .more-section 
-            margin-top: 2p;
-            border-top: p solid #ddd;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 20px;
+            border-top: 1px solid #ddd;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #7bff;
+        .more-toggle {
+            background: #007bff;
             color: white;
             border: none;
-            padding: 8p p;
-            border-radius: 3p;
+            padding: 8px 16px;
+            border-radius: 3px;
             cursor: pointer;
-            font-size: .9em;
-        
+            font-size: 0.9em;
+        }
 
-        .more-toggle:hover 
-            background: #5b3;
-        
+        .more-toggle:hover {
+            background: #0056b3;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 5p;
-        
+            margin-top: 15px;
+        }
 
+        .validation-pending {
+            background: #f8f9fa;
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #333;
+        }
+
+        .harmony-note {
+            background: #f8f9fa;
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .harmony-note h3 {
+            margin-top: 0;
+            color: #333;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Ant Colony Optimization (acopy)</h1>
+            <p>Swarm Intelligence Algorithm</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -153,16 +184,16 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Ant Colony Optimization (ACO)</strong> is a nature-inspired metaheuristic algorithm based on the foraging behavior of ants. Developed by Marco Dorigo in the 99s, it mimics how ants find optimal paths from their nest to food sources by depositing and following pheromone trails. The algorithm uses a population of artificial ants that build solutions incrementally, guided by pheromone information and heuristic values.
+                <strong>Ant Colony Optimization (ACO)</strong> is a nature-inspired metaheuristic algorithm based on the foraging behavior of ants. Developed by Marco Dorigo in the 1990s, it mimics how ants find optimal paths from their nest to food sources by depositing and following pheromone trails. The algorithm uses a population of artificial ants that build solutions incrementally, guided by pheromone information and heuristic values.
             </div>
 
             <div class="harmony-note">
-                <h3>Ant oraging Metaphor</h3>
+                <h3>Ant Foraging Metaphor</h3>
                 <p><strong>Ant Colony Optimization mimics ant foraging behavior:</strong></p>
                 <ul>
                     <li><strong>Pheromone Trails:</strong> Chemical markers indicating solution quality</li>
                     <li><strong>Ant Agents:</strong> Artificial ants building solutions step by step</li>
-                    <li><strong>Probabilistic Construction:</strong> Choose net move based on pheromone and heuristic info</li>
+                    <li><strong>Probabilistic Construction:</strong> Choose next move based on pheromone and heuristic info</li>
                     <li><strong>Collective Intelligence:</strong> Global optimization through local interactions</li>
                 </ul>
             </div>
@@ -170,16 +201,16 @@
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Ant Colony Optimization in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -200,10 +231,10 @@
                             <strong>Zong Woo Geem</strong><br>
                             Music-inspired optimization metaheuristic<br>
                             Based on musical improvisation and harmony composition<br>
-                            <em>Published: 2</em>
+                            <em>Published: 2001</em>
                         </td>
                         <td>
-                            <a href="https://link.springer.com/article/.23/A:9283" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://link.springer.com/article/10.1023/A:1010928611306" target="_blank" class="link-button paper">📄 Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -211,7 +242,7 @@
                         <td>
                             <strong>pyHarmonySearch</strong><br>
                             Tested against pyHarmonySearch package<br>
-                            Optional eternal dependency for validation<br>
+                            Optional external dependency for validation<br>
                             <em>Reference: PyPI harmony search implementation</em>
                         </td>
                         <td>
@@ -224,10 +255,10 @@
                             <strong>Humpday Harmony Search</strong><br>
                             Custom implementation with classical HS operators<br>
                             Harmony memory, pitch adjustment, and randomization<br>
-                            <em>ile: humpday/optimizers/harmonysearch.py</em>
+                            <em>File: humpday/optimizers/harmonysearch.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -239,7 +270,7 @@
                             <em>Class: HarmonySearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
                         </td>
                     </tr>
                     <tr>
@@ -250,7 +281,7 @@
                             <strong>Humpday JS:</strong> None (pure JavaScript)
                         </td>
                         <td>
-                            <span style="color: #95a5a;">✨ No eternal dependencies</span>
+                            <span style="color: #95a5a6;">✨ No external dependencies</span>
                         </td>
                     </tr>
                 </tbody>
@@ -261,12 +292,23 @@
                 <ul>
                     <li><strong>Best for:</strong> Continuous optimization, parameter tuning, engineering design</li>
                     <li><strong>Dimensions:</strong> Handles moderate to high dimensions well</li>
-                    <li><strong>unction evaluations:</strong> Memory-based, HMS × generations</li>
-                    <li><strong>Convergence:</strong> Steady improvement through memory eploitation</li>
-                    <li><strong>Robustness:</strong> Balance between eploitation and eploration through HS operators</li>
+                    <li><strong>Function evaluations:</strong> Memory-based, HMS × generations</li>
+                    <li><strong>Convergence:</strong> Steady improvement through memory exploitation</li>
+                    <li><strong>Robustness:</strong> Balance between exploitation and exploration through HS operators</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>Validation Status: PASSED</h3>
+                <p><strong>Harmony search implementation validated against SciPy reference.</strong></p>
+                <ul>
+                    <li>Test framework: 20 runs across 4 benchmark functions</li>
+                    <li>Target: Statistical performance comparison vs SciPy</li>
+                    <li>Metrics: Win rate, solution quality, convergence consistency</li>
+                    <li>Reference: SciPy differential_evolution implementation</li>
+                </ul>
+                <p><em>Validation rate: 95.5% overall (21/22 algorithms passed)</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">More Resources</button>
@@ -274,13 +316,13 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Harmony_search" target="_blank">Harmony Search Wikipedia</a></li>
-                        <li><a href="https://link.springer.com/article/.23/A:9283" target="_blank">Original HS Paper (Geem et al., 2)</a></li>
-                        <li><a href="https://www.springer.com/gp/book/978327378" target="_blank">Music-Inspired Harmony Search Algorithm</a></li>
-                        <li><a href="https://ieeeplore.ieee.org/document/53873" target="_blank">Improved Harmony Search Algorithm</a></li>
-                        <li><a href="https://link.springer.com/journal/287" target="_blank">International Journal of Optimization</a></li>
+                        <li><a href="https://link.springer.com/article/10.1023/A:1010928611306" target="_blank">Original HS Paper (Geem et al., 2001)</a></li>
+                        <li><a href="https://www.springer.com/gp/book/9783642007378" target="_blank">Music-Inspired Harmony Search Algorithm</a></li>
+                        <li><a href="https://ieeexplore.ieee.org/document/4531873" target="_blank">Improved Harmony Search Algorithm</a></li>
+                        <li><a href="https://link.springer.com/journal/10287" target="_blank">International Journal of Optimization</a></li>
                     </ul>
 
-                    <h3> Core Algorithm Components</h3>
+                    <h3>🔬 Core Algorithm Components</h3>
                     <ul>
                         <li><strong>Harmony Memory (HM):</strong> Population of HMS best solutions found</li>
                         <li><strong>Harmony Memory Size (HMS):</strong> Number of solutions stored</li>
@@ -290,46 +332,46 @@
                         <li><strong>Random Selection:</strong> Generate completely new value</li>
                     </ul>
 
-                    <h3>📐 Mathematical ormulation</h3>
+                    <h3>📐 Mathematical Formulation</h3>
                     <ul>
-                        <li><strong>Memory Selection:</strong> 'ᵢ = HMⱼ(i) with probability HMCR</li>
-                        <li><strong>Pitch Adjustment:</strong> 'ᵢ = 'ᵢ ± rand() × bw with probability PAR</li>
-                        <li><strong>Random Selection:</strong> 'ᵢ ~ Uniform(LBᵢ, UBᵢ) with probability (-HMCR)</li>
+                        <li><strong>Memory Selection:</strong> x'ᵢ = HMⱼ(i) with probability HMCR</li>
+                        <li><strong>Pitch Adjustment:</strong> x'ᵢ = x'ᵢ ± rand() × bw with probability PAR</li>
+                        <li><strong>Random Selection:</strong> x'ᵢ ~ Uniform(LBᵢ, UBᵢ) with probability (1-HMCR)</li>
                         <li><strong>Memory Update:</strong> Replace worst harmony if new harmony is better</li>
                     </ul>
 
                     <h3>⚙️ Key Parameters</h3>
                     <ul>
-                        <li><strong>HMS:</strong> Harmony Memory Size, typically -5</li>
-                        <li><strong>HMCR:</strong> Memory Consideration Rate, usually .7-.95</li>
-                        <li><strong>PAR:</strong> Pitch Adjusting Rate, usually .-.5</li>
+                        <li><strong>HMS:</strong> Harmony Memory Size, typically 10-50</li>
+                        <li><strong>HMCR:</strong> Memory Consideration Rate, usually 0.7-0.95</li>
+                        <li><strong>PAR:</strong> Pitch Adjusting Rate, usually 0.1-0.5</li>
                         <li><strong>bw:</strong> Bandwidth for pitch adjustment</li>
-                        <li><strong>Termination:</strong> Maimum iterations or convergence criteria</li>
+                        <li><strong>Termination:</strong> Maximum iterations or convergence criteria</li>
                     </ul>
 
-                    <h3> Harmony Search Algorithm Pseudocode</h3>
-                    <pre style="background: #f8f9fa; padding: 5p; border-radius: 8p; font-family: monospace;">
-function harmonySearch(objectiveunction, HMS, HMCR, PAR, maIter):
-    // Step : Initialize Harmony Memory
+                    <h3>🎯 Harmony Search Algorithm Pseudocode</h3>
+                    <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
+function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
+    // Step 1: Initialize Harmony Memory
     HM = []
-    for i in  to HMS:
+    for i in 1 to HMS:
         harmony = generateRandomSolution()
-        HM.add(harmony, objectiveunction(harmony))
+        HM.add(harmony, objectiveFunction(harmony))
 
-    sortByitness(HM)
+    sortByFitness(HM)
 
     // Step 2: Improvise New Harmony
-    for iteration in  to maIter:
+    for iteration in 1 to maxIter:
         newHarmony = []
 
-        for j in  to problemDimension:
+        for j in 1 to problemDimension:
             if random() < HMCR:  // Memory consideration
                 // Choose value from memory
-                randomHarmonyInde = randomInt(, HMS-)
-                newValue = HM[randomHarmonyInde][j]
+                randomHarmonyIndex = randomInt(0, HMS-1)
+                newValue = HM[randomHarmonyIndex][j]
 
                 if random() < PAR:  // Pitch adjustment
-                    newValue += (random() - .5) * 2 * bandwidth
+                    newValue += (random() - 0.5) * 2 * bandwidth
                     newValue = clip(newValue, lowerBound, upperBound)
 
             else:  // Random selection
@@ -338,18 +380,18 @@ function harmonySearch(objectiveunction, HMS, HMCR, PAR, maIter):
             newHarmony[j] = newValue
 
         // Step 3: Update Harmony Memory
-        newitness = objectiveunction(newHarmony)
+        newFitness = objectiveFunction(newHarmony)
 
-        if newitness < HM[HMS-].fitness:  // Better than worst
-            HM[HMS-] = (newHarmony, newitness)
-            sortByitness(HM)
+        if newFitness < HM[HMS-1].fitness:  // Better than worst
+            HM[HMS-1] = (newHarmony, newFitness)
+            sortByFitness(HM)
 
-    return HM[]  // Best harmony
+    return HM[0]  // Best harmony
                     </pre>
 
-                    <h3> Harmony Search Variants</h3>
+                    <h3>🔧 Harmony Search Variants</h3>
                     <ul>
-                        <li><strong>Classical HS:</strong> Original algorithm with fied parameters</li>
+                        <li><strong>Classical HS:</strong> Original algorithm with fixed parameters</li>
                         <li><strong>Improved HS (IHS):</strong> Dynamic PAR and bandwidth adjustment</li>
                         <li><strong>Self-Adaptive HS:</strong> Automatic parameter tuning</li>
                         <li><strong>Global-Best HS:</strong> Use best harmony for pitch adjustment</li>
@@ -367,24 +409,24 @@ function harmonySearch(objectiveunction, HMS, HMCR, PAR, maIter):
                         <li><strong>Aesthetic Quality:</strong> Objective function value</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🚀 Applications</h3>
                     <ul>
                         <li><strong>Engineering Design:</strong> Structural optimization, water distribution</li>
                         <li><strong>Energy Systems:</strong> Power system optimization, renewable energy</li>
                         <li><strong>Manufacturing:</strong> Production scheduling, resource allocation</li>
                         <li><strong>Transportation:</strong> Vehicle routing, traffic optimization</li>
-                        <li><strong>Machine Learning:</strong> eature selection, neural network training</li>
+                        <li><strong>Machine Learning:</strong> Feature selection, neural network training</li>
                         <li><strong>Economics:</strong> Portfolio optimization, supply chain management</li>
                     </ul>
 
-                    <h3> Advantages of Harmony Search</h3>
+                    <h3>💡 Advantages of Harmony Search</h3>
                     <ul>
                         <li><strong>Simplicity:</strong> Easy to understand and implement</li>
-                        <li><strong>ew Parameters:</strong> Only HMS, HMCR, PAR to tune</li>
+                        <li><strong>Few Parameters:</strong> Only HMS, HMCR, PAR to tune</li>
                         <li><strong>Memory-Based:</strong> Maintains population of good solutions</li>
-                        <li><strong>leibility:</strong> Adapts to continuous and discrete problems</li>
-                        <li><strong>Balance:</strong> Good trade-off between eploration and eploitation</li>
-                        <li><strong>No Gradient Needed:</strong> Works with black-bo functions</li>
+                        <li><strong>Flexibility:</strong> Adapts to continuous and discrete problems</li>
+                        <li><strong>Balance:</strong> Good trade-off between exploration and exploitation</li>
+                        <li><strong>No Gradient Needed:</strong> Works with black-box functions</li>
                     </ul>
 
                     <h3>⚠️ Limitations</h3>
@@ -393,29 +435,29 @@ function harmonySearch(objectiveunction, HMS, HMCR, PAR, maIter):
                         <li><strong>Premature Convergence:</strong> May converge too quickly with wrong parameters</li>
                         <li><strong>Slow Convergence:</strong> Can be slow on some problem types</li>
                         <li><strong>Local Search Ability:</strong> Limited fine-tuning capability</li>
-                        <li><strong>Memory Management:</strong> ied memory size may be suboptimal</li>
+                        <li><strong>Memory Management:</strong> Fixed memory size may be suboptimal</li>
                     </ul>
 
                     <h3>🔄 Parameter Guidelines</h3>
                     <ul>
-                        <li><strong>HMCR = .9:</strong> High memory consideration for eploitation</li>
-                        <li><strong>HMCR = .:</strong> Low memory consideration for eploration</li>
-                        <li><strong>PAR = .3:</strong> Moderate pitch adjustment</li>
-                        <li><strong>HMS = -3:</strong> Small memory for fast convergence</li>
-                        <li><strong>HMS = 5-:</strong> Large memory for diverse population</li>
+                        <li><strong>HMCR = 0.9:</strong> High memory consideration for exploitation</li>
+                        <li><strong>HMCR = 0.1:</strong> Low memory consideration for exploration</li>
+                        <li><strong>PAR = 0.3:</strong> Moderate pitch adjustment</li>
+                        <li><strong>HMS = 10-30:</strong> Small memory for fast convergence</li>
+                        <li><strong>HMS = 50-100:</strong> Large memory for diverse population</li>
                         <li><strong>Dynamic Parameters:</strong> Adapt HMCR, PAR during search</li>
                     </ul>
 
-                    <h3> Creative Aspects</h3>
+                    <h3>🎨 Creative Aspects</h3>
                     <ul>
                         <li><strong>Artistic Inspiration:</strong> Based on human creativity and musical composition</li>
                         <li><strong>Improvisation Process:</strong> Mimics how musicians create new melodies</li>
                         <li><strong>Harmony Aesthetics:</strong> Better solutions are like more beautiful music</li>
                         <li><strong>Cultural Bridge:</strong> Connects optimization with arts and music</li>
-                        <li><strong>Intuitive Understanding:</strong> Easy to eplain through musical metaphor</li>
+                        <li><strong>Intuitive Understanding:</strong> Easy to explain through musical metaphor</li>
                     </ul>
 
-                    <h3> Comparison with Other Metaheuristics</h3>
+                    <h3>📊 Comparison with Other Metaheuristics</h3>
                     <ul>
                         <li><strong>vs GA:</strong> Memory-based vs generation-based evolution</li>
                         <li><strong>vs PSO:</strong> Discrete memory vs continuous population movement</li>
@@ -429,67 +471,67 @@ function harmonySearch(objectiveunction, HMS, HMCR, PAR, maIter):
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = 'Less Resources';
-             else 
+                button.textContent = 'Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = 'More Resources';
-            
-        
+                button.textContent = 'More Resources';
+            }
+        }
 
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/bayesian-optimization.html
+++ b/docs/algorithms/bayesian-optimization.html
@@ -1,164 +1,184 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Bayesian Optimization - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #398db;
+        .header {
+            background: #3498db;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
-            background: #deaf8;
-            border-left: p solid #398db;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #d6eaf8;
+            border-left: 4px solid #3498db;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Bayesian Optimization (scikit-optimize)</h1>
+            <p>Sequential Model-Based Optimization</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,22 +186,22 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Bayesian Optimization</strong> is a sequential design strategy for global optimization of epensive-to-evaluate functions. It uses a probabilistic surrogate model (typically Gaussian Process) to model the objective function and an acquisition function to guide the search toward promising regions. It's particularly effective when function evaluations are costly.
+                <strong>Bayesian Optimization</strong> is a sequential design strategy for global optimization of expensive-to-evaluate functions. It uses a probabilistic surrogate model (typically Gaussian Process) to model the objective function and an acquisition function to guide the search toward promising regions. It's particularly effective when function evaluations are costly.
             </div>
 
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Bayesian Optimization in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -197,15 +217,15 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td class="category">Algorithmic oundation</td>
+                        <td class="category">Algorithmic Foundation</td>
                         <td>
                             <strong>Sequential Model-Based Optimization</strong><br>
                             Gaussian Process regression + acquisition functions<br>
-                            Epected Improvement, Upper Confidence Bound<br>
-                            <em>Developed: 9s-7s (Kushner, Močkus)</em>
+                            Expected Improvement, Upper Confidence Bound<br>
+                            <em>Developed: 1960s-70s (Kushner, Močkus)</em>
                         </td>
                         <td>
-                            <a href="https://ariv.org/abs/87.28" target="_blank" class="link-button paper">📄 Tutorial Paper</a>
+                            <a href="https://arxiv.org/abs/1807.02811" target="_blank" class="link-button paper">📄 Tutorial Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -218,31 +238,31 @@
                         </td>
                         <td>
                             <a href="https://scikit-optimize.github.io/stable/" target="_blank" class="link-button python">📦 Skopt Docs</a>
-                            <a href="https://github.com/scikit-optimize/scikit-optimize" target="_blank" class="link-button python"> GitHub</a>
+                            <a href="https://github.com/scikit-optimize/scikit-optimize" target="_blank" class="link-button python">🔍 GitHub</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">HumpDay Python Implementation</td>
+                        <td class="category">Humpday Python Wrapper</td>
                         <td>
                             <strong>Humpday Integration</strong><br>
-                            Uses skopt.gp_minimize() with Epected Improvement<br>
+                            Uses skopt.gp_minimize() with Expected Improvement<br>
                             Automatic hyperparameter optimization for GP<br>
-                            <em>ile: humpday/optimizers/bayesianopt.py</em>
+                            <em>File: humpday/optimizers/bayesianopt.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Implementation</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Humpday JavaScript Port</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
-                            Simplified Bayesian optimization with GP approimation<br>
-                            Epected Improvement acquisition function<br>
+                            Simplified Bayesian optimization with GP approximation<br>
+                            Expected Improvement acquisition function<br>
                             <em>Class: BayesianOpt</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
                         </td>
                     </tr>
                     <tr>
@@ -250,7 +270,7 @@
                         <td>
                             <strong>Reference:</strong> scikit-optimize, scikit-learn<br>
                             <strong>Humpday Python:</strong> scikit-optimize, numpy<br>
-                            <strong>Humpday JS:</strong> None (simplified GP approimation)
+                            <strong>Humpday JS:</strong> None (simplified GP approximation)
                         </td>
                         <td>
                             <a href="https://pypi.org/project/scikit-optimize/" target="_blank" class="link-button python">📦 PyPI</a>
@@ -262,14 +282,25 @@
             <div class="performance-notes">
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Epensive function evaluations, black-bo optimization</li>
-                    <li><strong>Dimensions:</strong> Typically -2 dimensions (GP scaling limitations)</li>
-                    <li><strong>unction evaluations:</strong> Very sample efficient, - evaluations</li>
-                    <li><strong>Convergence:</strong> Ecellent with limited budget, global optimization</li>
+                    <li><strong>Best for:</strong> Expensive function evaluations, black-box optimization</li>
+                    <li><strong>Dimensions:</strong> Typically 1-20 dimensions (GP scaling limitations)</li>
+                    <li><strong>Function evaluations:</strong> Very sample efficient, 10-100 evaluations</li>
+                    <li><strong>Convergence:</strong> Excellent with limited budget, global optimization</li>
                     <li><strong>Robustness:</strong> Handles noise well, uncertainty quantification</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation against scikit-optimize reference implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing JavaScript vs skopt.gp_minimize()</li>
+                    <li>🎯 Target: Similar optimization performance with limited budgets</li>
+                    <li>📊 Metrics: Sample efficiency, convergence quality, acquisition behavior</li>
+                    <li>🔧 Challenge: Approximating full GP functionality in JavaScript</li>
+                </ul>
+                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
@@ -277,41 +308,41 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://scikit-optimize.github.io/stable/" target="_blank">scikit-optimize Documentation</a></li>
-                        <li><a href="https://ariv.org/abs/87.28" target="_blank">Bayesian Optimization Tutorial (razier)</a></li>
-                        <li><a href="https://distill.pub/22/bayesian-optimization/" target="_blank">Visual Introduction to Bayesian Optimization</a></li>
-                        <li><a href="http://krasserm.github.io/28/3/2/bayesian-optimization/" target="_blank">Bayesian Optimization from Scratch</a></li>
-                        <li><a href="https://www.cs.o.ac.uk/people/nando.defreitas/publications/BayesOptLoop.pdf" target="_blank">Practical Bayesian Optimization (Snoek et al.)</a></li>
+                        <li><a href="https://arxiv.org/abs/1807.02811" target="_blank">Bayesian Optimization Tutorial (Frazier)</a></li>
+                        <li><a href="https://distill.pub/2020/bayesian-optimization/" target="_blank">Visual Introduction to Bayesian Optimization</a></li>
+                        <li><a href="http://krasserm.github.io/2018/03/21/bayesian-optimization/" target="_blank">Bayesian Optimization from Scratch</a></li>
+                        <li><a href="https://www.cs.ox.ac.uk/people/nando.defreitas/publications/BayesOptLoop.pdf" target="_blank">Practical Bayesian Optimization (Snoek et al.)</a></li>
                     </ul>
 
-                    <h3> Core Components</h3>
+                    <h3>🔬 Core Components</h3>
                     <ul>
                         <li><strong>Surrogate Model:</strong> Gaussian Process regression with uncertainty</li>
-                        <li><strong>Acquisition unction:</strong> Epected Improvement, Upper Confidence Bound, Entropy Search</li>
-                        <li><strong>Kernel unctions:</strong> RB, Matérn, polynomial kernels</li>
-                        <li><strong>Hyperparameter Learning:</strong> Maimum likelihood estimation</li>
+                        <li><strong>Acquisition Function:</strong> Expected Improvement, Upper Confidence Bound, Entropy Search</li>
+                        <li><strong>Kernel Functions:</strong> RBF, Matérn, polynomial kernels</li>
+                        <li><strong>Hyperparameter Learning:</strong> Maximum likelihood estimation</li>
                         <li><strong>Multi-Point Selection:</strong> Batch acquisition for parallel evaluation</li>
                     </ul>
 
-                    <h3> Acquisition unctions</h3>
+                    <h3>🎯 Acquisition Functions</h3>
                     <ul>
-                        <li><strong>Epected Improvement (EI):</strong> E[ma(f() - f_best, )]</li>
-                        <li><strong>Upper Confidence Bound (UCB):</strong> μ() + β*σ()</li>
-                        <li><strong>Probability of Improvement (PI):</strong> P[f() > f_best + ξ]</li>
+                        <li><strong>Expected Improvement (EI):</strong> E[max(f(x) - f_best, 0)]</li>
+                        <li><strong>Upper Confidence Bound (UCB):</strong> μ(x) + β*σ(x)</li>
+                        <li><strong>Probability of Improvement (PI):</strong> P[f(x) > f_best + ξ]</li>
                         <li><strong>Entropy Search:</strong> Information gain about global optimum</li>
-                        <li><strong>Knowledge Gradient:</strong> Epected value of perfect information</li>
+                        <li><strong>Knowledge Gradient:</strong> Expected value of perfect information</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🚀 Applications</h3>
                     <ul>
                         <li><strong>Hyperparameter Optimization:</strong> Machine learning model tuning</li>
-                        <li><strong>Eperimental Design:</strong> Scientific eperiments and A/B testing</li>
+                        <li><strong>Experimental Design:</strong> Scientific experiments and A/B testing</li>
                         <li><strong>Engineering Optimization:</strong> CAD parameter tuning</li>
                         <li><strong>Drug Discovery:</strong> Molecular property optimization</li>
                         <li><strong>Robotics:</strong> Control parameter learning</li>
                         <li><strong>AutoML:</strong> Architecture search and pipeline optimization</li>
                     </ul>
 
-                    <h3> Advanced Techniques</h3>
+                    <h3>🔧 Advanced Techniques</h3>
                     <ul>
                         <li><strong>Multi-Task GP:</strong> Transfer learning between related problems</li>
                         <li><strong>Multi-Objective BO:</strong> Pareto optimization with GP models</li>
@@ -320,7 +351,7 @@
                         <li><strong>Distributed BO:</strong> Asynchronous parallel optimization</li>
                     </ul>
 
-                    <h3>📐 Mathematical oundation</h3>
+                    <h3>📐 Mathematical Foundation</h3>
                     <ul>
                         <li><strong>Gaussian Processes:</strong> Non-parametric Bayesian regression</li>
                         <li><strong>Regret Bounds:</strong> Theoretical convergence guarantees</li>
@@ -333,67 +364,67 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
-        
+                button.textContent = '📚 More Resources';
+            }
+        }
 
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/bobyqa.html
+++ b/docs/algorithms/bobyqa.html
@@ -271,10 +271,8 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/BOBYQA" target="_blank">BOBYQA Wikipedia</a></li>
-                        <li><a href="https://www.pdfo.net/docs/" target="_blank">PDFO Documentation</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Trust_region_methods" target="_blank">Trust Region Methods</a></li>
-                        <li><a href="https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=a08b2a15b27d8a5b27d4b3b6d3e4f5e6d7f8e9f0" target="_blank">Bound Constrained Optimization Overview</a></li>
-                    </ul>
+                        <li><a href="https://www.pdfo.net/" target="_blank">PDFO Documentation</a></li>
+                        </ul>
                 </div>
             </div>
         </div>

--- a/docs/algorithms/bobyqa.html
+++ b/docs/algorithms/bobyqa.html
@@ -1,169 +1,169 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>BOBYQA (Prima) - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #2c3e5;
+        .header {
+            background: #2c3e50;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
 
-        .algorithm-description 
-            background: #e8ff3;
-            border-left: p solid #27ae;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #e8f6f3;
+            border-left: 4px solid #27ae60;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
     </style>
 </head>
 <body>
     <div class="container">
         <div class="header">
-            <h>BOBYQA (PDO)</h>
-            <p>Bound constrained Optimization BY Quadratic Approimation</p>
+            <h1>BOBYQA (PDFO)</h1>
+            <p>Bound constrained Optimization BY Quadratic Approximation</p>
         </div>
 
         <div class="content">
@@ -172,22 +172,22 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>BOBYQA</strong> is Powell's trust-region method specifically designed for bound-constrained optimization. It builds quadratic models while respecting variable bounds, making it ideal for optimization problems with simple constraints like the unit hypercube [,]ⁿ used in our competition.
+                <strong>BOBYQA</strong> is Powell's trust-region method specifically designed for bound-constrained optimization. It builds quadratic models while respecting variable bounds, making it ideal for optimization problems with simple constraints like the unit hypercube [0,1]ⁿ used in our competition.
             </div>
 
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See BOBYQA in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -207,36 +207,36 @@
                         <td>
                             <strong>M.J.D. Powell</strong><br>
                             Trust-region method for bound-constrained problems<br>
-                            Etends NEWUOA with eplicit bound handling<br>
-                            <em>Published: 29</em>
+                            Extends NEWUOA with explicit bound handling<br>
+                            <em>Published: 2009</em>
                         </td>
                         <td>
-                            <a href="https://doi.org/.5/32973.32979" target="_blank" class="link-button paper">📄 Paper</a>
+                            <a href="https://doi.org/10.1145/1132973.1132979" target="_blank" class="link-button paper">📄 Paper</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Reference Package</td>
                         <td>
-                            <strong>PDO (Python Derivative-ree Optimization)</strong><br>
-                            Wraps Powell's original ortran BOBYQA implementation<br>
+                            <strong>PDFO (Python Derivative-Free Optimization)</strong><br>
+                            Wraps Powell's original Fortran BOBYQA implementation<br>
                             Handles bound constraints with numerical precision<br>
                             <em>Package: pdfo</em>
                         </td>
                         <td>
-                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">📦 PDO</a>
-                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">📦 PDFO</a>
+                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python">🐍 Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">HumpDay Python Implementation</td>
+                        <td class="category">Humpday Python Wrapper</td>
                         <td>
                             <strong>Humpday Integration</strong><br>
-                            Calls PDO's BOBYQA implementation<br>
+                            Calls PDFO's BOBYQA implementation<br>
                             Standardized interface for optimization contests<br>
-                            <em>ile: humpday/optimizers/prima_algorithms.py</em>
+                            <em>File: humpday/optimizers/prima_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python"> Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -248,7 +248,7 @@
                             <em>Class: PRIMA_BOBYQA</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript"> JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
                         </td>
                     </tr>
                 </tbody>
@@ -257,9 +257,9 @@
             <div class="performance-notes">
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Bound-constrained optimization problems, especially [,]ⁿ</li>
-                    <li><strong>Dimensions:</strong> Ecellent performance up to + dimensions</li>
-                    <li><strong>unction evaluations:</strong> Very efficient with bounds guidance</li>
+                    <li><strong>Best for:</strong> Bound-constrained optimization problems, especially [0,1]ⁿ</li>
+                    <li><strong>Dimensions:</strong> Excellent performance up to 100+ dimensions</li>
+                    <li><strong>Function evaluations:</strong> Very efficient with bounds guidance</li>
                     <li><strong>Convergence:</strong> Superior to UOBYQA/NEWUOA on bounded problems</li>
                     <li><strong>Robustness:</strong> Handles boundary conditions elegantly</li>
                 </ul>
@@ -271,9 +271,9 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/BOBYQA" target="_blank">BOBYQA Wikipedia</a></li>
-                        <li><a href="https://www.pdfo.net/docs/" target="_blank">PDO Documentation</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Trust_region_methods" target="_blank">Trust Region Methods</a></li>
-                        <li><a href="https://citeseer.ist.psu.edu/document?repid=rep&type=pdf&doi=a8b2a5b27d8a5b27db3bd3ef5ed7f8e9f" target="_blank">Bound Constrained Optimization Overview</a></li>
+                        <li><a href="https://www.pdfo.net/docs/" target="_blank">PDFO Documentation</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Trust_region_methods" target="_blank">Trust Region Methods</a></li>
+                        <li><a href="https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=a08b2a15b27d8a5b27d4b3b6d3e4f5e6d7f8e9f0" target="_blank">Bound Constrained Optimization Overview</a></li>
                     </ul>
                 </div>
             </div>
@@ -281,67 +281,67 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
-        
+                button.textContent = '📚 More Resources';
+            }
+        }
 
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/cma-evolution-strategy.html
+++ b/docs/algorithms/cma-evolution-strategy.html
@@ -1,164 +1,184 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>CMA-ES - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #a85;
+        .header {
+            background: #16a085;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
+        .algorithm-description {
             background: #e8f8f5;
-            border-left: p solid #a85;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+            border-left: 4px solid #16a085;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>CMA-ES (DEAP/cmaes)</h1>
+            <p>Covariance Matrix Adaptation Evolution Strategy</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,22 +186,22 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>CMA-ES (Covariance Matri Adaptation Evolution Strategy)</strong> is a state-of-the-art evolutionary algorithm for continuous optimization. Developed by Nikolaus Hansen and Andreas Ostermeier, CMA-ES adapts its search distribution by learning from the covariance structure of successful mutations. It's considered one of the most effective black-bo optimizers for continuous problems.
+                <strong>CMA-ES (Covariance Matrix Adaptation Evolution Strategy)</strong> is a state-of-the-art evolutionary algorithm for continuous optimization. Developed by Nikolaus Hansen and Andreas Ostermeier, CMA-ES adapts its search distribution by learning from the covariance structure of successful mutations. It's considered one of the most effective black-box optimizers for continuous problems.
             </div>
 
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See CMA-ES in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -200,12 +220,12 @@
                         <td class="category">Original Algorithm</td>
                         <td>
                             <strong>Hansen & Ostermeier</strong><br>
-                            Self-adaptive evolution strategy with covariance matri learning<br>
+                            Self-adaptive evolution strategy with covariance matrix learning<br>
                             Invariant to affine transformations of the search space<br>
-                            <em>Published: 99-2</em>
+                            <em>Published: 1996-2001</em>
                         </td>
                         <td>
-                            <a href="https://ariv.org/abs/.772" target="_blank" class="link-button paper">📄 Tutorial</a>
+                            <a href="https://arxiv.org/abs/1604.00772" target="_blank" class="link-button paper">📄 Tutorial</a>
                         </td>
                     </tr>
                     <tr>
@@ -217,20 +237,20 @@
                             <em>Package: cmaes</em>
                         </td>
                         <td>
-                            <a href="https://github.com/CMA-ES/pycma" target="_blank" class="link-button python"> pycma</a>
+                            <a href="https://github.com/CMA-ES/pycma" target="_blank" class="link-button python">🐍 pycma</a>
                             <a href="https://pypi.org/project/cmaes/" target="_blank" class="link-button python">📦 cmaes</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">HumpDay Python Implementation</td>
+                        <td class="category">Humpday Python Wrapper</td>
                         <td>
                             <strong>Humpday Integration</strong><br>
                             Uses cmaes or DEAP implementation<br>
                             Configured for optimization contests<br>
-                            <em>ile: humpday/optimizers/cmaopt.py</em>
+                            <em>File: humpday/optimizers/cmaopt.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Implementation</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -238,11 +258,11 @@
                         <td>
                             <strong>Browser Implementation</strong><br>
                             JavaScript port of core CMA-ES algorithm<br>
-                            Covariance matri adaptation and evolution paths<br>
+                            Covariance matrix adaptation and evolution paths<br>
                             <em>Class: CMAEvolutionStrategy</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
                         </td>
                     </tr>
                     <tr>
@@ -263,72 +283,83 @@
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Continuous optimization, ill-conditioned problems, noisy functions</li>
-                    <li><strong>Dimensions:</strong> Ecellent from 2D up to hundreds of dimensions</li>
-                    <li><strong>unction evaluations:</strong> Population-based, typically λ ≈ +⌊3log(n)⌋</li>
+                    <li><strong>Dimensions:</strong> Excellent from 2D up to hundreds of dimensions</li>
+                    <li><strong>Function evaluations:</strong> Population-based, typically λ ≈ 4+⌊3log(n)⌋</li>
                     <li><strong>Convergence:</strong> Outstanding convergence on smooth and rugged landscapes</li>
                     <li><strong>Robustness:</strong> Scale-invariant, rotation-invariant, noise-tolerant</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation against cmaes reference implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing JavaScript vs cmaes.CMA() or pycma</li>
+                    <li>🎯 Target: Statistical equivalence with proper covariance adaptation</li>
+                    <li>📊 Metrics: Convergence rate, final objective values, covariance evolution</li>
+                    <li>🔧 Challenge: Complex matrix operations and parameter updates in JavaScript</li>
+                </ul>
+                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
                 <div id="moreContent" class="more-content">
                     <h3>📚 Educational Resources</h3>
                     <ul>
-                        <li><a href="https://ariv.org/abs/.772" target="_blank">CMA-ES Tutorial (Hansen, 2)</a></li>
+                        <li><a href="https://arxiv.org/abs/1604.00772" target="_blank">CMA-ES Tutorial (Hansen, 2016)</a></li>
                         <li><a href="https://github.com/CMA-ES/pycma" target="_blank">pycma - Official Python Implementation</a></li>
                         <li><a href="https://cma-es.github.io/" target="_blank">CMA-ES Home Page</a></li>
                         <li><a href="https://en.wikipedia.org/wiki/CMA-ES" target="_blank">CMA-ES Wikipedia</a></li>
-                        <li><a href="https://link.springer.com/article/.7/s527" target="_blank">Original CMA-ES Paper (2)</a></li>
+                        <li><a href="https://link.springer.com/article/10.1007/s001000050217" target="_blank">Original CMA-ES Paper (2001)</a></li>
                     </ul>
 
-                    <h3> Core Algorithm Components</h3>
+                    <h3>🔬 Core Algorithm Components</h3>
                     <ul>
                         <li><strong>Population:</strong> λ offspring generated from multivariate normal distribution</li>
-                        <li><strong>Selection:</strong> μ best individuals become parents for net generation</li>
+                        <li><strong>Selection:</strong> μ best individuals become parents for next generation</li>
                         <li><strong>Recombination:</strong> Weighted average of selected individuals</li>
-                        <li><strong>Covariance Update:</strong> C(g+) = (-c_cov)C(g) + c_cov * update</li>
+                        <li><strong>Covariance Update:</strong> C(g+1) = (1-c_cov)C(g) + c_cov * update</li>
                         <li><strong>Step Size:</strong> σ adapted based on evolution path length</li>
                         <li><strong>Evolution Paths:</strong> Track search direction over generations</li>
                     </ul>
 
-                    <h3>📐 Mathematical oundation</h3>
+                    <h3>📐 Mathematical Foundation</h3>
                     <ul>
-                        <li><strong>Multivariate Normal:</strong>  ~ N(m, σ²C) sampling distribution</li>
+                        <li><strong>Multivariate Normal:</strong> x ~ N(m, σ²C) sampling distribution</li>
                         <li><strong>Rank-μ Update:</strong> C_μ = Σᵢ wᵢ yᵢyᵢᵀ (rank-μ covariance update)</li>
-                        <li><strong>Rank- Update:</strong> C₁ = p_c p_cᵀ (evolution path outer product)</li>
+                        <li><strong>Rank-1 Update:</strong> C₁ = p_c p_cᵀ (evolution path outer product)</li>
                         <li><strong>CSA:</strong> Cumulative Step-size Adaptation using conjugate evolution path</li>
                         <li><strong>Invariance:</strong> Transformation-invariant under affine coordinate changes</li>
                     </ul>
 
                     <h3>⚙️ Key Parameters</h3>
                     <ul>
-                        <li><strong>Population Size:</strong> λ =  + ⌊3ln(n)⌋</li>
+                        <li><strong>Population Size:</strong> λ = 4 + ⌊3ln(n)⌋</li>
                         <li><strong>Parents:</strong> μ = ⌊λ/2⌋</li>
-                        <li><strong>Weights:</strong> wᵢ = ln(μ+.5) - ln(i) for i=..μ</li>
-                        <li><strong>Learning Rates:</strong> c_cov ≈ 2/(n²+), c_c ≈ /(n+)</li>
-                        <li><strong>Damping:</strong> d_σ ≈  + 2ma(, √((μ_eff-)/(n+)) - )</li>
+                        <li><strong>Weights:</strong> wᵢ = ln(μ+0.5) - ln(i) for i=1..μ</li>
+                        <li><strong>Learning Rates:</strong> c_cov ≈ 2/(n²+6), c_c ≈ 4/(n+4)</li>
+                        <li><strong>Damping:</strong> d_σ ≈ 1 + 2max(0, √((μ_eff-1)/(n+1)) - 1)</li>
                     </ul>
 
-                    <h3> CMA-ES Variants</h3>
+                    <h3>🎯 CMA-ES Variants</h3>
                     <ul>
                         <li><strong>CMA-ES:</strong> Standard algorithm with full covariance adaptation</li>
                         <li><strong>BIPOP-CMA-ES:</strong> Bi-population restart strategy</li>
                         <li><strong>IPOP-CMA-ES:</strong> Increasing population restart strategy</li>
                         <li><strong>sep-CMA-ES:</strong> Separable CMA-ES for high dimensions</li>
                         <li><strong>VD-CMA:</strong> VkD-CMA for very high dimensions</li>
-                        <li><strong>NES:</strong> Natural Evolution Strategy variant</li>
+                        <li><strong>xNES:</strong> Natural Evolution Strategy variant</li>
                     </ul>
 
-                    <h3> Applications & Success Stories</h3>
+                    <h3>🚀 Applications & Success Stories</h3>
                     <ul>
                         <li><strong>Engineering Design:</strong> Antenna design, aerodynamics optimization</li>
                         <li><strong>Machine Learning:</strong> Neural network hyperparameter optimization</li>
                         <li><strong>Control Systems:</strong> Controller parameter tuning</li>
                         <li><strong>Game AI:</strong> Strategy parameter evolution</li>
-                        <li><strong>Scientific Computing:</strong> Parameter estimation in comple models</li>
-                        <li><strong>Black-Bo Challenges:</strong> Consistent top performer in BBOB competitions</li>
+                        <li><strong>Scientific Computing:</strong> Parameter estimation in complex models</li>
+                        <li><strong>Black-Box Challenges:</strong> Consistent top performer in BBOB competitions</li>
                     </ul>
 
                     <h3>🏆 Why CMA-ES is Special</h3>
@@ -338,7 +369,7 @@
                         <li><strong>Principled Design:</strong> Theoretically motivated updates</li>
                         <li><strong>Empirical Success:</strong> Top performer on many benchmark suites</li>
                         <li><strong>Noise Handling:</strong> Built-in mechanisms for noisy optimization</li>
-                        <li><strong>Constraint Handling:</strong> Etensions for constrained problems</li>
+                        <li><strong>Constraint Handling:</strong> Extensions for constrained problems</li>
                     </ul>
                 </div>
             </div>
@@ -346,67 +377,67 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
-        
+                button.textContent = '📚 More Resources';
+            }
+        }
 
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -1,164 +1,197 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Coordinate Descent - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #395e;
+        .header {
+            background: #34495e;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
+        .algorithm-description {
             background: #f7f9fc;
-            border-left: p solid #395e;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+            border-left: 4px solid #34495e;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+
+        .coordinate-note {
+            background: #e8f4fd;
+            border: 1px solid #bee5eb;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .coordinate-note h3 {
+            margin-top: 0;
+            color: #0c5460;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Coordinate Descent (Custom)</h1>
+            <p>Alternating Single-Variable Optimization</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,32 +199,32 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Coordinate Descent</strong> is a fundamental optimization algorithm that cyclically optimizes along individual coordinate directions. At each iteration, it minimizes the objective function with respect to one coordinate while keeping all others fied. This simple approach is surprisingly effective for many problems and forms the basis for more sophisticated optimization methods.
+                <strong>Coordinate Descent</strong> is a fundamental optimization algorithm that cyclically optimizes along individual coordinate directions. At each iteration, it minimizes the objective function with respect to one coordinate while keeping all others fixed. This simple approach is surprisingly effective for many problems and forms the basis for more sophisticated optimization methods.
             </div>
 
             <div class="coordinate-note">
                 <h3>📐 Coordinate-Wise Optimization</h3>
                 <p><strong>Coordinate descent alternates between variables systematically:</strong></p>
                 <ul>
-                    <li> <strong>One Variable at a Time:</strong> Optimize ₁, then ₂, then ₃, etc.</li>
-                    <li>🔄 <strong>Cyclical Updates:</strong> Return to ₁ after reaching ₙ</li>
-                    <li>📏 <strong>Line Search:</strong> Eact or approimate minimization along each ais</li>
-                    <li> <strong>Simplicity:</strong> Reduces n-dimensional to many -dimensional problems</li>
+                    <li>🎯 <strong>One Variable at a Time:</strong> Optimize x₁, then x₂, then x₃, etc.</li>
+                    <li>🔄 <strong>Cyclical Updates:</strong> Return to x₁ after reaching xₙ</li>
+                    <li>📏 <strong>Line Search:</strong> Exact or approximate minimization along each axis</li>
+                    <li>⚡ <strong>Simplicity:</strong> Reduces n-dimensional to many 1-dimensional problems</li>
                 </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Coordinate Descent in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -208,12 +241,12 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td class="category">Algorithm oundation</td>
+                        <td class="category">Algorithm Foundation</td>
                         <td>
                             <strong>Classic Optimization Method</strong><br>
-                            Alternating minimization along coordinate aes<br>
+                            Alternating minimization along coordinate axes<br>
                             Gauss-Seidel style iterative updates<br>
-                            <em>Historical: Early numerical optimization (95s+)</em>
+                            <em>Historical: Early numerical optimization (1950s+)</em>
                         </td>
                         <td>
                             <a href="https://en.wikipedia.org/wiki/Coordinate_descent" target="_blank" class="link-button info">📖 Wikipedia</a>
@@ -228,7 +261,7 @@
                             <em>Self-reference: Algorithm-specific variants</em>
                         </td>
                         <td>
-                            <a href="https://web.stanford.edu/~boyd/papers/pro_algs.html" target="_blank" class="link-button info">📚 Boyd et al.</a>
+                            <a href="https://web.stanford.edu/~boyd/papers/prox_algs.html" target="_blank" class="link-button info">📚 Boyd et al.</a>
                         </td>
                     </tr>
                     <tr>
@@ -237,10 +270,10 @@
                             <strong>Humpday Coordinate Descent</strong><br>
                             Custom implementation with line search<br>
                             Cyclical coordinate selection<br>
-                            <em>ile: humpday/optimizers/coordinatedescent.py</em>
+                            <em>File: humpday/optimizers/coordinatedescent.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -252,7 +285,7 @@
                             <em>Class: CoordinateDescent</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
                         </td>
                     </tr>
                     <tr>
@@ -263,7 +296,7 @@
                             <strong>Humpday JS:</strong> None (pure JavaScript)
                         </td>
                         <td>
-                            <span style="color: #95a5a;">✨ No eternal dependencies</span>
+                            <span style="color: #95a5a6;">✨ No external dependencies</span>
                         </td>
                     </tr>
                 </tbody>
@@ -273,13 +306,24 @@
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Separable problems, sparse optimization, large-scale problems</li>
-                    <li><strong>Dimensions:</strong> Ecellent scalability to high dimensions</li>
-                    <li><strong>unction evaluations:</strong> Efficient, especially with eact line search</li>
-                    <li><strong>Convergence:</strong> Linear convergence on smooth, strongly conve problems</li>
+                    <li><strong>Dimensions:</strong> Excellent scalability to high dimensions</li>
+                    <li><strong>Function evaluations:</strong> Efficient, especially with exact line search</li>
+                    <li><strong>Convergence:</strong> Linear convergence on smooth, strongly convex problems</li>
                     <li><strong>Robustness:</strong> Simple, stable, handles non-smooth functions reasonably</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation of coordinate descent implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing against theoretical convergence behavior</li>
+                    <li>🎯 Target: Proper cyclical coordinate optimization and convergence</li>
+                    <li>📊 Metrics: Coordinate-wise improvements, convergence rate</li>
+                    <li>🔧 Reference: Self-validation against algorithmic specification</li>
+                </ul>
+                <p><em>Coordinate descent behavior is well-defined - implementation correctness is key validation.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
@@ -287,88 +331,88 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Coordinate_descent" target="_blank">Coordinate Descent Wikipedia</a></li>
-                        <li><a href="https://web.stanford.edu/~boyd/papers/pro_algs.html" target="_blank">Proimal Algorithms (Boyd et al.)</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Coordinate_descent" target="_blank">Coordinate Descent Tutorial</a></li>
-                        <li><a href="https://ariv.org/abs/52.759" target="_blank">Coordinate Descent Converges aster with Gauss-Southwell Rule</a></li>
-                        <li><a href="https://www.stat.cmu.edu/~ryantibs/conveopt/" target="_blank">CMU Conve Optimization Notes</a></li>
+                        <li><a href="https://web.stanford.edu/~boyd/papers/prox_algs.html" target="_blank">Proximal Algorithms (Boyd et al.)</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Coordinate_descent" target="_blank">Coordinate Descent Tutorial</a></li>
+                        <li><a href="https://arxiv.org/abs/1502.04759" target="_blank">Coordinate Descent Converges Faster with Gauss-Southwell Rule</a></li>
+                        <li><a href="https://www.stat.cmu.edu/~ryantibs/convexopt/" target="_blank">CMU Convex Optimization Notes</a></li>
                     </ul>
 
-                    <h3> Algorithm Variants</h3>
+                    <h3>🔬 Algorithm Variants</h3>
                     <ul>
-                        <li><strong>Cyclic Coordinate Descent:</strong> ied order through coordinates</li>
+                        <li><strong>Cyclic Coordinate Descent:</strong> Fixed order through coordinates</li>
                         <li><strong>Random Coordinate Descent:</strong> Random coordinate selection</li>
                         <li><strong>Gauss-Southwell:</strong> Choose coordinate with largest gradient component</li>
                         <li><strong>Block Coordinate Descent:</strong> Update blocks of coordinates simultaneously</li>
                         <li><strong>Accelerated Coordinate Descent:</strong> Momentum-based improvements</li>
                     </ul>
 
-                    <h3>📐 Mathematical oundation</h3>
+                    <h3>📐 Mathematical Foundation</h3>
                     <ul>
-                        <li><strong>Update Rule:</strong> _i^(k+) = arg min_z f(_^(k+), ..., _i-^(k+), z, _i+^k, ..., _n^k)</li>
-                        <li><strong>Separability:</strong> f() = Σᵢ fᵢ(ᵢ) + interaction terms</li>
-                        <li><strong>Convergence Rate:</strong> O(/k) for conve, linear for strongly conve</li>
-                        <li><strong>Line Search:</strong> Eact or Armijo backtracking along coordinate</li>
+                        <li><strong>Update Rule:</strong> x_i^(k+1) = arg min_z f(x_1^(k+1), ..., x_{i-1}^(k+1), z, x_{i+1}^k, ..., x_n^k)</li>
+                        <li><strong>Separability:</strong> f(x) = Σᵢ fᵢ(xᵢ) + interaction terms</li>
+                        <li><strong>Convergence Rate:</strong> O(1/k) for convex, linear for strongly convex</li>
+                        <li><strong>Line Search:</strong> Exact or Armijo backtracking along coordinate</li>
                     </ul>
 
                     <h3>⚙️ Coordinate Selection Strategies</h3>
                     <ul>
-                        <li><strong>Cyclic (Round-Robin):</strong> i = (k mod n) + </li>
-                        <li><strong>Random:</strong> i ~ Uniform, 2, ..., n</li>
-                        <li><strong>Gauss-Southwell:</strong> i = arg ma_j |∂f/∂_j|</li>
+                        <li><strong>Cyclic (Round-Robin):</strong> i = (k mod n) + 1</li>
+                        <li><strong>Random:</strong> i ~ Uniform{1, 2, ..., n}</li>
+                        <li><strong>Gauss-Southwell:</strong> i = arg max_j |∂f/∂x_j|</li>
                         <li><strong>Lipschitz-Based:</strong> Probability ∝ Lipschitz constants</li>
-                        <li><strong>Greedy:</strong> Choose coordinate with maimum epected decrease</li>
+                        <li><strong>Greedy:</strong> Choose coordinate with maximum expected decrease</li>
                     </ul>
 
-                    <h3> Algorithm Pseudocode</h3>
-                    <pre style="background: #f8f9fa; padding: 5p; border-radius: 8p; font-family: monospace;">
-function coordinateDescent(f, , maIter, tolerance):
-     = .copy()
-    n = length()
+                    <h3>🎯 Algorithm Pseudocode</h3>
+                    <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
+function coordinateDescent(f, x0, maxIter, tolerance):
+    x = x0.copy()
+    n = length(x)
 
-    for k in  to maIter:
-        _old = .copy()
+    for k in 1 to maxIter:
+        x_old = x.copy()
 
-        for i in  to n:  // Cyclic coordinate selection
+        for i in 1 to n:  // Cyclic coordinate selection
             // Optimize f along coordinate i
-            [i] = lineSearch(lambda t: f(..., [i-], t, [i+], ...))
+            x[i] = lineSearch(lambda t: f(..., x[i-1], t, x[i+1], ...))
 
-        if || - _old|| < tolerance:
+        if ||x - x_old|| < tolerance:
             break
 
-    return 
+    return x
                     </pre>
 
-                    <h3> When Coordinate Descent Ecels</h3>
+                    <h3>💡 When Coordinate Descent Excels</h3>
                     <ul>
-                        <li><strong>Separable unctions:</strong> f() = Σᵢ fᵢ(ᵢ) with minimal coupling</li>
+                        <li><strong>Separable Functions:</strong> f(x) = Σᵢ fᵢ(xᵢ) with minimal coupling</li>
                         <li><strong>Sparse Problems:</strong> Most coordinates have little impact</li>
                         <li><strong>Large Scale:</strong> Memory efficient, good for high dimensions</li>
-                        <li><strong>Non-smooth unctions:</strong> Handles piecewise linear objectives</li>
-                        <li><strong>Constrained Problems:</strong> Easy to handle bo constraints</li>
+                        <li><strong>Non-smooth Functions:</strong> Handles piecewise linear objectives</li>
+                        <li><strong>Constrained Problems:</strong> Easy to handle box constraints</li>
                     </ul>
 
                     <h3>⚠️ Limitations</h3>
                     <ul>
                         <li><strong>Coupling:</strong> Slow on strongly coupled variables</li>
                         <li><strong>Conditioning:</strong> Poor performance on ill-conditioned problems</li>
-                        <li><strong>Non-Conve:</strong> Can get trapped in local minima</li>
+                        <li><strong>Non-Convex:</strong> Can get trapped in local minima</li>
                         <li><strong>Step Size:</strong> May require careful line search tuning</li>
                         <li><strong>Coordinate System:</strong> Performance depends on variable scaling</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🚀 Applications</h3>
                     <ul>
-                        <li><strong>Lasso Regression:</strong> L-regularized least squares</li>
+                        <li><strong>Lasso Regression:</strong> L1-regularized least squares</li>
                         <li><strong>SVM Training:</strong> Sequential minimal optimization (SMO)</li>
-                        <li><strong>Matri actorization:</strong> Alternating least squares</li>
+                        <li><strong>Matrix Factorization:</strong> Alternating least squares</li>
                         <li><strong>Deep Learning:</strong> Per-layer parameter updates</li>
                         <li><strong>Game Theory:</strong> Best response dynamics</li>
                         <li><strong>Signal Processing:</strong> Sparse coding and denoising</li>
                     </ul>
 
-                    <h3> Modern Etensions</h3>
+                    <h3>🔧 Modern Extensions</h3>
                     <ul>
-                        <li><strong>Proimal Coordinate Descent:</strong> Handle non-smooth regularizers</li>
+                        <li><strong>Proximal Coordinate Descent:</strong> Handle non-smooth regularizers</li>
                         <li><strong>Stochastic Coordinate Descent:</strong> Random sampling with convergence guarantees</li>
                         <li><strong>Parallel Coordinate Descent:</strong> Update multiple coordinates simultaneously</li>
                         <li><strong>Adaptive Methods:</strong> Automatically adjust step sizes</li>
@@ -380,65 +424,65 @@ function coordinateDescent(f, , maIter, tolerance):
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -332,7 +332,6 @@
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Coordinate_descent" target="_blank">Coordinate Descent Wikipedia</a></li>
                         <li><a href="https://web.stanford.edu/~boyd/papers/prox_algs.html" target="_blank">Proximal Algorithms (Boyd et al.)</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Coordinate_descent" target="_blank">Coordinate Descent Tutorial</a></li>
                         <li><a href="https://arxiv.org/abs/1502.04759" target="_blank">Coordinate Descent Converges Faster with Gauss-Southwell Rule</a></li>
                         <li><a href="https://www.stat.cmu.edu/~ryantibs/convexopt/" target="_blank">CMU Convex Optimization Notes</a></li>
                     </ul>

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -1,168 +1,168 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Differential Evolution (SciPy) - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #2c3e5;
+        .header {
+            background: #2c3e50;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
 
-        .algorithm-description 
-            background: #e8ff3;
-            border-left: p solid #27ae;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #e8f6f3;
+            border-left: 4px solid #27ae60;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
     </style>
 </head>
 <body>
     <div class="container">
         <div class="header">
-            <h>Differential Evolution (SciPy)</h>
+            <h1>Differential Evolution (SciPy)</h1>
             <p>Population-based Global Optimization</p>
         </div>
 
@@ -172,21 +172,21 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Differential Evolution</strong> is a population-based evolutionary algorithm that uses vector differences to eplore the search space. It's particularly effective on multimodal and noisy functions, making it one of the most reliable global optimization methods available.
+                <strong>Differential Evolution</strong> is a population-based evolutionary algorithm that uses vector differences to explore the search space. It's particularly effective on multimodal and noisy functions, making it one of the most reliable global optimization methods available.
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Differential Evolution in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -208,10 +208,10 @@
                             <strong>Rainer Storn & Kenneth Price</strong><br>
                             Evolutionary algorithm using vector differences<br>
                             Population-based with mutation, crossover, and selection<br>
-                            <em>Published: 997</em>
+                            <em>Published: 1997</em>
                         </td>
                         <td>
-                            <a href="https://doi.org/.23/A:82282328" target="_blank" class="link-button paper">📄 Paper</a>
+                            <a href="https://doi.org/10.1023/A:1008202821328" target="_blank" class="link-button paper">📄 Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -220,22 +220,22 @@
                             <strong>Python Implementation</strong><br>
                             Uses SciPy's optimize.differential_evolution<br>
                             Highly optimized with multiple DE variants<br>
-                            <em>ile: humpday/optimizers/scipy_algorithms.py</em>
+                            <em>File: humpday/optimizers/scipy_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python"> Python Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">🐍 Python Code</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
-                            Pure JavaScript DE with classic DE/rand//bin strategy<br>
+                            Pure JavaScript DE with classic DE/rand/1/bin strategy<br>
                             Population management and vector operations<br>
                             <em>Class: DifferentialEvolution</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript"> JavaScript Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">🌐 JavaScript Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -255,10 +255,10 @@
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Global optimization, multimodal and noisy functions</li>
-                    <li><strong>Dimensions:</strong> Scales well from 2D to + dimensions</li>
-                    <li><strong>unction evaluations:</strong> Population-based, typically + evaluations</li>
+                    <li><strong>Dimensions:</strong> Scales well from 2D to 100+ dimensions</li>
+                    <li><strong>Function evaluations:</strong> Population-based, typically 1000+ evaluations</li>
                     <li><strong>Convergence:</strong> Reliable global convergence but can be slow</li>
-                    <li><strong>Robustness:</strong> Ecellent on discontinuous and highly multimodal landscapes</li>
+                    <li><strong>Robustness:</strong> Excellent on discontinuous and highly multimodal landscapes</li>
                 </ul>
             </div>
 
@@ -268,12 +268,12 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Differential_evolution" target="_blank">Differential Evolution Wikipedia</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Differential_evolution" target="_blank">Northwestern Optimization Course</a></li>
-                        <li><a href="https://pablormier.github.io/27/9/5/a-tutorial-on-differential-evolution-with-python/" target="_blank">Python Tutorial</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Differential_evolution" target="_blank">Northwestern Optimization Course</a></li>
+                        <li><a href="https://pablormier.github.io/2017/09/05/a-tutorial-on-differential-evolution-with-python/" target="_blank">Python Tutorial</a></li>
                         <li><a href="http://www.icsi.berkeley.edu/~storn/code.html" target="_blank">Original Author's Code</a></li>
                     </ul>
 
-                    <h> Algorithm Overview</h>
+                    <h4>🧬 Algorithm Overview</h4>
                     <p>Differential Evolution uses a simple yet powerful strategy:</p>
                     <ul>
                         <li><strong>Population:</strong> Maintains multiple candidate solutions</li>
@@ -282,74 +282,74 @@
                         <li><strong>Selection:</strong> Keeps the better of target vs. trial</li>
                     </ul>
 
-                    <p><strong>Classic DE/rand//bin strategy:</strong></p>
-                    <p>Trial = X_a +  × (X_b - X_c)</p>
-                    <p>Where X_a, X_b, X_c are random population members and  is the scaling factor.</p>
+                    <p><strong>Classic DE/rand/1/bin strategy:</strong></p>
+                    <p>Trial = X_a + F × (X_b - X_c)</p>
+                    <p>Where X_a, X_b, X_c are random population members and F is the scaling factor.</p>
                 </div>
             </div>
         </div>
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -268,7 +268,6 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Differential_evolution" target="_blank">Differential Evolution Wikipedia</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Differential_evolution" target="_blank">Northwestern Optimization Course</a></li>
                         <li><a href="https://pablormier.github.io/2017/09/05/a-tutorial-on-differential-evolution-with-python/" target="_blank">Python Tutorial</a></li>
                         <li><a href="http://www.icsi.berkeley.edu/~storn/code.html" target="_blank">Original Author's Code</a></li>
                     </ul>

--- a/docs/algorithms/evolution-strategy.html
+++ b/docs/algorithms/evolution-strategy.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
+    <title>Evolution Strategy (μ+λ) - Implementation Details</title>
+    <style>
+        body {
+            font-family: 'Georgia', 'Times New Roman', serif;
+            margin: 0;
+            padding: 20px;
+            background: #f8f9fa;
+            color: #2c3e50;
+        }
+
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+
+        .header {
+            background: #2c3e50;
+            color: white;
+            padding: 30px;
+            text-align: center;
+        }
+
+        .header h1 {
+            margin: 0 0 10px 0;
+            font-size: 2.2em;
+        }
+
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
+
+        .content {
+            padding: 40px;
+        }
+
+        .implementation-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 30px 0;
+            border-radius: 10px;
+            overflow: hidden;
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
+
+        .implementation-table th {
+            background: #34495e;
+            color: white;
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
+
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
+            vertical-align: top;
+        }
+
+        .implementation-table tr:hover {
+            background: #f8f9fa;
+        }
+
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
+
+        .link-button {
+            display: inline-block;
+            padding: 8px 16px;
+            background: #3498db;
+            color: white;
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
+
+        .link-button:hover {
+            background: #2980b9;
+        }
+
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+
+        .algorithm-description {
+            background: #e8f6f3;
+            border-left: 4px solid #27ae60;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
+
+        .back-nav {
+            margin-bottom: 20px;
+        }
+
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
+
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
+
+        .performance-notes {
+            background: #fff3cd;
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
+
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
+
+        .more-toggle {
+            background: #3498db;
+            color: white;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 1em;
+        }
+
+        .more-toggle:hover {
+            background: #2980b9;
+        }
+
+        .more-content {
+            display: none;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Evolution Strategy (μ+λ)</h1>
+            <p>Classical Evolutionary Optimization</p>
+        </div>
+
+        <div class="content">
+            <div class="back-nav">
+                <a href="../contest.html">← Back to Optimizer Competition</a>
+            </div>
+
+            <div class="algorithm-description">
+                <strong>Evolution Strategy</strong> is one of the oldest evolutionary algorithms, dating to Rechenberg and Schwefel's work in 1960s Berlin. The (μ+λ) variant maintains μ parents, generates λ mutated offspring each generation, and selects the best μ individuals from the combined parent+offspring pool to form the next generation. It is the conceptual ancestor of CMA-ES.
+            </div>
+
+            <h2>Implementation Details</h2>
+            <table class="implementation-table">
+                <thead>
+                    <tr>
+                        <th>Component</th>
+                        <th>Details</th>
+                        <th>Links</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="category">Original Algorithm</td>
+                        <td>
+                            <strong>Ingo Rechenberg &amp; Hans-Paul Schwefel</strong><br>
+                            Mutation-driven evolutionary search<br>
+                            (μ+λ) selection over combined parent+offspring pool<br>
+                            <em>Published: 1965 (Rechenberg), 1975 (Schwefel)</em>
+                        </td>
+                        <td>
+                            <a href="https://en.wikipedia.org/wiki/Evolution_strategy" target="_blank" class="link-button paper">📖 Wikipedia</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="category">Humpday Python</td>
+                        <td>
+                            <strong>Pure-Python Implementation</strong><br>
+                            μ=10 parents, λ=min(30, n_trials/3) offspring<br>
+                            Gaussian mutation with fixed step size σ=0.2, clipped to the unit cube<br>
+                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
+                        </td>
+                        <td>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">🐍 Python Code</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="category">Library Dependencies</td>
+                        <td>
+                            <strong>Python:</strong> none required; numpy used transparently via <code>humpday._array</code> when installed via <code>pip install humpday[fast]</code>
+                        </td>
+                        <td>
+                            <a href="https://github.com/microprediction/humpday#optional-numpy-acceleration" target="_blank" class="link-button python">📖 Backends</a>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <div class="performance-notes">
+                <h3>🏁 Performance Characteristics</h3>
+                <ul>
+                    <li><strong>Best for:</strong> Continuous unconstrained optimization on moderate-dimensional problems</li>
+                    <li><strong>Dimensions:</strong> Works well from 2 up to a few dozen; favoured for "high-dimensional complex" routing in HumpDay's adaptive optimizer</li>
+                    <li><strong>Function evaluations:</strong> Each generation costs up to λ evaluations; total budget is set by <code>n_trials</code></li>
+                    <li><strong>Convergence:</strong> Reliable progress on smooth landscapes; can stall on highly multimodal surfaces without self-adaptation</li>
+                    <li><strong>Robustness:</strong> Tolerates noise via its population-and-selection structure; less robust than CMA-ES because step size σ is fixed</li>
+                </ul>
+            </div>
+
+            <div class="more-section">
+                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <div id="moreContent" class="more-content">
+                    <h3>📚 Educational Resources</h3>
+                    <ul>
+                        <li><a href="https://en.wikipedia.org/wiki/Evolution_strategy" target="_blank">Evolution Strategy Wikipedia</a></li>
+                        <li><a href="https://en.wikipedia.org/wiki/CMA-ES" target="_blank">CMA-ES (a self-adaptive descendant)</a></li>
+                    </ul>
+
+                    <h4>🧬 Algorithm Overview</h4>
+                    <ol>
+                        <li><strong>Initialize</strong> μ parents uniformly at random in the unit cube.</li>
+                        <li><strong>Mutate:</strong> pick a parent at random, perturb by σ·𝒩(0,I), clip to the unit cube. Repeat λ times.</li>
+                        <li><strong>Select:</strong> sort the combined (parent + offspring) pool by fitness and keep the best μ.</li>
+                        <li><strong>Repeat</strong> until the evaluation budget is exhausted.</li>
+                    </ol>
+
+                    <p><strong>Notation:</strong> the "+" in (μ+λ) indicates elitism — parents compete against their own offspring. The alternative (μ,λ) variant discards parents each generation; HumpDay implements the elitist (μ+λ) form.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        function toggleMore() {
+            const content = document.getElementById('moreContent');
+            const button = document.querySelector('.more-toggle');
+
+            if (content.style.display === 'none' || content.style.display === '') {
+                content.style.display = 'block';
+                button.textContent = '📚 Less Resources';
+            } else {
+                content.style.display = 'none';
+                button.textContent = '📚 More Resources';
+            }
+        }
+    </script>
+</body>
+</html>

--- a/docs/algorithms/firefly-algorithm.html
+++ b/docs/algorithms/firefly-algorithm.html
@@ -1,164 +1,197 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
-    <title>irefly Algorithm - Implementation Details</title>
+    <title>Firefly Algorithm - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: linear-gradient(35deg, #f39c2 %, #e7e22 %);
+        .header {
+            background: linear-gradient(135deg, #f39c12 0%, #e67e22 100%);
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
-            background: linear-gradient(35deg, #fef5e7 %, #fdebd %);
-            border-left: p solid #f39c2;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: linear-gradient(135deg, #fef5e7 0%, #fdebd0 100%);
+            border-left: 4px solid #f39c12;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+
+        .nature-inspired {
+            background: #e8f5e8;
+            border: 1px solid #c3e6c3;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .nature-inspired h3 {
+            margin-top: 0;
+            color: #2d5a2d;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Firefly Algorithm (Custom)</h1>
+            <p>Nature-Inspired Swarm Intelligence Optimizer</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,32 +199,32 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>irefly Algorithm (A)</strong> is a nature-inspired metaheuristic optimization algorithm developed by Xin-She Yang in 28. It mimics the flashing behavior and social interactions of fireflies, where the attractiveness and brightness of fireflies determine their movement patterns. The algorithm combines elements of swarm intelligence with local search capabilities.
+                <strong>Firefly Algorithm (FA)</strong> is a nature-inspired metaheuristic optimization algorithm developed by Xin-She Yang in 2008. It mimics the flashing behavior and social interactions of fireflies, where the attractiveness and brightness of fireflies determine their movement patterns. The algorithm combines elements of swarm intelligence with local search capabilities.
             </div>
 
             <div class="nature-inspired">
-                <h3> Nature-Inspired Algorithm</h3>
-                <p><strong>irefly Algorithm is inspired by firefly behavior:</strong></p>
+                <h3>🌟 Nature-Inspired Algorithm</h3>
+                <p><strong>Firefly Algorithm is inspired by firefly behavior:</strong></p>
                 <ul>
-                    <li>✨ <strong>Bioluminescence:</strong> ireflies communicate through light signals</li>
-                    <li> <strong>Attractiveness:</strong> Brighter fireflies attract dimmer ones</li>
+                    <li>✨ <strong>Bioluminescence:</strong> Fireflies communicate through light signals</li>
+                    <li>🎯 <strong>Attractiveness:</strong> Brighter fireflies attract dimmer ones</li>
                     <li>📏 <strong>Distance Decay:</strong> Light intensity decreases with distance</li>
-                    <li> <strong>Random Movement:</strong> Eploration when no brighter fireflies eist</li>
+                    <li>🔍 <strong>Random Movement:</strong> Exploration when no brighter fireflies exist</li>
                 </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
-                <p>See irefly Algorithm in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <p>See Firefly Algorithm in action on 3D optimization surfaces:</p>
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -213,10 +246,10 @@
                             <strong>Xin-She Yang</strong><br>
                             Bio-inspired optimization algorithm<br>
                             Based on flashing patterns and behavior of fireflies<br>
-                            <em>Published: 28</em>
+                            <em>Published: 2008</em>
                         </td>
                         <td>
-                            <a href="https://ariv.org/abs/3." target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://arxiv.org/abs/1003.1464" target="_blank" class="link-button paper">📄 Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -224,23 +257,23 @@
                         <td>
                             <strong>Custom Research Implementations</strong><br>
                             Various academic and open-source implementations<br>
-                            No single standard package (multiple variants eist)<br>
+                            No single standard package (multiple variants exist)<br>
                             <em>Reference: Academic literature implementations</em>
                         </td>
                         <td>
-                            <a href="https://github.com/topics/firefly-algorithm" target="_blank" class="link-button python"> GitHub Eamples</a>
+                            <a href="https://github.com/topics/firefly-algorithm" target="_blank" class="link-button python">🔍 GitHub Examples</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Humpday Python Implementation</td>
                         <td>
-                            <strong>Humpday irefly Algorithm</strong><br>
+                            <strong>Humpday Firefly Algorithm</strong><br>
                             Custom implementation following Yang's original paper<br>
                             Attractiveness-based movement with randomization<br>
-                            <em>ile: humpday/optimizers/firefly*.py</em>
+                            <em>File: humpday/optimizers/firefly*.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -249,10 +282,10 @@
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript firefly algorithm<br>
                             Light intensity, attractiveness, and movement modeling<br>
-                            <em>Class: ireflyAlgorithm</em>
+                            <em>Class: FireflyAlgorithm</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
                         </td>
                     </tr>
                     <tr>
@@ -263,7 +296,7 @@
                             <strong>Humpday JS:</strong> None (pure JavaScript)
                         </td>
                         <td>
-                            <span style="color: #95a5a;">✨ No eternal dependencies</span>
+                            <span style="color: #95a5a6;">✨ No external dependencies</span>
                         </td>
                     </tr>
                 </tbody>
@@ -272,99 +305,110 @@
             <div class="performance-notes">
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Multimodal optimization, continuous problems, eploration-heavy tasks</li>
-                    <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~5)</li>
-                    <li><strong>unction evaluations:</strong> Population-based, n_fireflies × generations</li>
-                    <li><strong>Convergence:</strong> Good eploration, may converge slowly to global optimum</li>
+                    <li><strong>Best for:</strong> Multimodal optimization, continuous problems, exploration-heavy tasks</li>
+                    <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~50)</li>
+                    <li><strong>Function evaluations:</strong> Population-based, n_fireflies × generations</li>
+                    <li><strong>Convergence:</strong> Good exploration, may converge slowly to global optimum</li>
                     <li><strong>Robustness:</strong> Handles multimodal landscapes well due to swarm diversity</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation of firefly algorithm implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing against theoretical expectations and literature results</li>
+                    <li>🎯 Target: Proper swarm behavior and convergence patterns</li>
+                    <li>📊 Metrics: Population diversity, exploration capability, final objective values</li>
+                    <li>🔧 Reference: Yang's original paper and established benchmark results</li>
+                </ul>
+                <p><em>Multiple reference implementations exist - validation against established benchmarks.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
                 <div id="moreContent" class="more-content">
                     <h3>📚 Educational Resources</h3>
                     <ul>
-                        <li><a href="https://en.wikipedia.org/wiki/irefly_algorithm" target="_blank">irefly Algorithm Wikipedia</a></li>
-                        <li><a href="https://ariv.org/abs/3." target="_blank">Original irefly Algorithm Paper (Yang, 28)</a></li>
-                        <li><a href="https://link.springer.com/chapter/.7/978-3-2-9-_" target="_blank">Nature-Inspired Metaheuristic Algorithms</a></li>
-                        <li><a href="https://www.researchgate.net/publication/2289_irefly_Algorithms_for_Multimodal_Optimization" target="_blank">A for Multimodal Optimization</a></li>
-                        <li><a href="https://github.com/topics/firefly-algorithm" target="_blank">GitHub irefly Algorithm Implementations</a></li>
+                        <li><a href="https://en.wikipedia.org/wiki/Firefly_algorithm" target="_blank">Firefly Algorithm Wikipedia</a></li>
+                        <li><a href="https://arxiv.org/abs/1003.1464" target="_blank">Original Firefly Algorithm Paper (Yang, 2008)</a></li>
+                        <li><a href="https://link.springer.com/chapter/10.1007/978-3-642-04944-6_14" target="_blank">Nature-Inspired Metaheuristic Algorithms</a></li>
+                        <li><a href="https://www.researchgate.net/publication/228446900_Firefly_Algorithms_for_Multimodal_Optimization" target="_blank">FA for Multimodal Optimization</a></li>
+                        <li><a href="https://github.com/topics/firefly-algorithm" target="_blank">GitHub Firefly Algorithm Implementations</a></li>
                     </ul>
 
-                    <h3> Algorithm Components</h3>
+                    <h3>🔬 Algorithm Components</h3>
                     <ul>
                         <li><strong>Light Intensity:</strong> I(r) = I₀ × e^(-γr²) where r is distance</li>
-                        <li><strong>Attractiveness:</strong> β(r) = β₀ × e^(-γr²) where β₀ is attractiveness at r=</li>
-                        <li><strong>Movement Rule:</strong> _i = _i + β(r_ij)(_j - _i) + α(rand - .5)</li>
+                        <li><strong>Attractiveness:</strong> β(r) = β₀ × e^(-γr²) where β₀ is attractiveness at r=0</li>
+                        <li><strong>Movement Rule:</strong> x_i = x_i + β(r_ij)(x_j - x_i) + α(rand - 0.5)</li>
                         <li><strong>Randomization:</strong> α controls random walk component</li>
                         <li><strong>Light Absorption:</strong> γ controls light absorption coefficient</li>
                     </ul>
 
-                    <h3>📐 Mathematical oundation</h3>
+                    <h3>📐 Mathematical Foundation</h3>
                     <ul>
-                        <li><strong>Objective unction:</strong> f() directly relates to light intensity I ∝ f()</li>
-                        <li><strong>Distance Metric:</strong> Typically Euclidean: r_ij = ||_i - _j||</li>
-                        <li><strong>Movement Equation:</strong> _i^(t+) = _i^t + β₀e^(-γr²)(_j^t - _i^t) + αε_i^t</li>
-                        <li><strong>Parameter Ranges:</strong> α ∈ [,], β₀ ∈ [,], γ ∈ [,∞)</li>
+                        <li><strong>Objective Function:</strong> f(x) directly relates to light intensity I ∝ f(x)</li>
+                        <li><strong>Distance Metric:</strong> Typically Euclidean: r_ij = ||x_i - x_j||</li>
+                        <li><strong>Movement Equation:</strong> x_i^(t+1) = x_i^t + β₀e^(-γr²)(x_j^t - x_i^t) + αε_i^t</li>
+                        <li><strong>Parameter Ranges:</strong> α ∈ [0,1], β₀ ∈ [0,1], γ ∈ [0,∞)</li>
                     </ul>
 
                     <h3>⚙️ Key Parameters</h3>
                     <ul>
-                        <li><strong>Population Size:</strong> Typically 2-5 fireflies</li>
-                        <li><strong>α (Randomization):</strong> Usually .2-.5, decreases over time</li>
-                        <li><strong>β₀ (Attractiveness):</strong> Usually . (maimum attractiveness)</li>
-                        <li><strong>γ (Absorption):</strong> Usually .-, controls eploitation vs eploration</li>
+                        <li><strong>Population Size:</strong> Typically 20-50 fireflies</li>
+                        <li><strong>α (Randomization):</strong> Usually 0.2-0.5, decreases over time</li>
+                        <li><strong>β₀ (Attractiveness):</strong> Usually 1.0 (maximum attractiveness)</li>
+                        <li><strong>γ (Absorption):</strong> Usually 0.01-10, controls exploitation vs exploration</li>
                         <li><strong>Generations:</strong> Stopping criteria based on evaluations or convergence</li>
                     </ul>
 
-                    <h3> irefly Algorithm Pseudocode</h3>
-                    <pre style="background: #f8f9fa; padding: 5p; border-radius: 8p; font-family: monospace;">
-function fireflyAlgorithm(problem, n_fireflies, ma_generations):
+                    <h3>🎯 Firefly Algorithm Pseudocode</h3>
+                    <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
+function fireflyAlgorithm(problem, n_fireflies, max_generations):
     // Initialize firefly population randomly
     fireflies = initializePopulation(n_fireflies)
 
-    for generation in  to ma_generations:
+    for generation in 1 to max_generations:
         for each firefly i:
             for each firefly j:
                 if light_intensity(j) > light_intensity(i):
                     r = distance(i, j)
-                    attractiveness = β₀ * ep(-γ * r²)
+                    attractiveness = β₀ * exp(-γ * r²)
                     move firefly i towards j with attractiveness
-                    add random component α * (rand - .5)
+                    add random component α * (rand - 0.5)
 
             evaluate new position and update light intensity
 
     return best firefly
                     </pre>
 
-                    <h3> irefly Algorithm Variants</h3>
+                    <h3>🔧 Firefly Algorithm Variants</h3>
                     <ul>
-                        <li><strong>Standard A:</strong> Original Yang formulation</li>
-                        <li><strong>Discrete A:</strong> Adapted for combinatorial problems</li>
-                        <li><strong>Multi-Objective A:</strong> MOA for Pareto optimization</li>
-                        <li><strong>Chaotic A:</strong> Chaotic maps for parameter control</li>
-                        <li><strong>Hybrid A:</strong> Combined with local search or other methods</li>
-                        <li><strong>Adaptive A:</strong> Self-adjusting parameters during search</li>
+                        <li><strong>Standard FA:</strong> Original Yang formulation</li>
+                        <li><strong>Discrete FA:</strong> Adapted for combinatorial problems</li>
+                        <li><strong>Multi-Objective FA:</strong> MOFA for Pareto optimization</li>
+                        <li><strong>Chaotic FA:</strong> Chaotic maps for parameter control</li>
+                        <li><strong>Hybrid FA:</strong> Combined with local search or other methods</li>
+                        <li><strong>Adaptive FA:</strong> Self-adjusting parameters during search</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🚀 Applications</h3>
                     <ul>
                         <li><strong>Engineering Design:</strong> Structural optimization, antenna design</li>
-                        <li><strong>Image Processing:</strong> eature selection, clustering</li>
+                        <li><strong>Image Processing:</strong> Feature selection, clustering</li>
                         <li><strong>Neural Networks:</strong> Training weights and architecture</li>
                         <li><strong>Scheduling:</strong> Task scheduling and resource allocation</li>
                         <li><strong>Data Mining:</strong> Classification and clustering problems</li>
                         <li><strong>Economics:</strong> Portfolio optimization and forecasting</li>
                     </ul>
 
-                    <h3> Advantages of irefly Algorithm</h3>
+                    <h3>💡 Advantages of Firefly Algorithm</h3>
                     <ul>
                         <li><strong>Automatic Subdivision:</strong> Swarm can naturally divide into subgroups</li>
                         <li><strong>Multimodal Capability:</strong> Can find multiple optima simultaneously</li>
-                        <li><strong>Parameter leibility:</strong> ew parameters to tune</li>
-                        <li><strong>Local Attraction:</strong> ireflies mainly interact with nearby neighbors</li>
+                        <li><strong>Parameter Flexibility:</strong> Few parameters to tune</li>
+                        <li><strong>Local Attraction:</strong> Fireflies mainly interact with nearby neighbors</li>
                         <li><strong>Global Communication:</strong> Brightest firefly influences entire swarm</li>
                     </ul>
 
@@ -382,65 +426,65 @@ function fireflyAlgorithm(problem, n_fireflies, ma_generations):
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/genetic-algorithm.html
+++ b/docs/algorithms/genetic-algorithm.html
@@ -1,164 +1,184 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Genetic Algorithm - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #8ead;
+        .header {
+            background: #8e44ad;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
-            background: #ebdef;
-            border-left: p solid #8ead;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #ebdef0;
+            border-left: 4px solid #8e44ad;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Genetic Algorithm (DEAP)</h1>
+            <p>Evolutionary Computing Global Optimizer</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,21 +186,21 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Genetic Algorithms (GA)</strong> are population-based metaheuristics inspired by the process of natural selection. Introduced by John Holland in the 97s, GAs evolve a population of candidate solutions using selection, crossover, and mutation operators. They're particularly effective for combinatorial optimization and problems where the search space is large and comple.
+                <strong>Genetic Algorithms (GA)</strong> are population-based metaheuristics inspired by the process of natural selection. Introduced by John Holland in the 1970s, GAs evolve a population of candidate solutions using selection, crossover, and mutation operators. They're particularly effective for combinatorial optimization and problems where the search space is large and complex.
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Genetic Algorithm in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -202,10 +222,10 @@
                             <strong>John Holland</strong><br>
                             Evolutionary computation inspired by natural selection<br>
                             Population-based search with genetic operators<br>
-                            <em>Published: 97s</em>
+                            <em>Published: 1970s</em>
                         </td>
                         <td>
-                            <a href="https://mitpress.mit.edu/9782258/adaptation-in-natural-and-artificial-systems/" target="_blank" class="link-button paper">📖 Holland's Book</a>
+                            <a href="https://mitpress.mit.edu/9780262581110/adaptation-in-natural-and-artificial-systems/" target="_blank" class="link-button paper">📖 Holland's Book</a>
                         </td>
                     </tr>
                     <tr>
@@ -213,24 +233,24 @@
                         <td>
                             <strong>DEAP (Distributed Evolutionary Algorithms in Python)</strong><br>
                             Comprehensive evolutionary computation framework<br>
-                            leible GA with customizable operators<br>
+                            Flexible GA with customizable operators<br>
                             <em>Package: deap</em>
                         </td>
                         <td>
                             <a href="https://deap.readthedocs.io/" target="_blank" class="link-button python">📦 DEAP Docs</a>
-                            <a href="https://github.com/DEAP/deap" target="_blank" class="link-button python"> GitHub</a>
+                            <a href="https://github.com/DEAP/deap" target="_blank" class="link-button python">🔍 GitHub</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">HumpDay Python Implementation</td>
+                        <td class="category">Humpday Python Wrapper</td>
                         <td>
                             <strong>Humpday Integration</strong><br>
                             Uses DEAP's genetic algorithm framework<br>
                             Pre-configured for continuous optimization<br>
-                            <em>ile: humpday/optimizers/deapopt.py</em>
+                            <em>File: humpday/optimizers/deapopt.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Implementation</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -242,7 +262,7 @@
                             <em>Class: GeneticAlgorithm</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
                         </td>
                     </tr>
                     <tr>
@@ -264,12 +284,23 @@
                 <ul>
                     <li><strong>Best for:</strong> Combinatorial optimization, multimodal landscapes, large search spaces</li>
                     <li><strong>Dimensions:</strong> Scales to hundreds of dimensions</li>
-                    <li><strong>unction evaluations:</strong> Population size × generations</li>
-                    <li><strong>Convergence:</strong> Good global eploration, premature convergence possible</li>
+                    <li><strong>Function evaluations:</strong> Population size × generations</li>
+                    <li><strong>Convergence:</strong> Good global exploration, premature convergence possible</li>
                     <li><strong>Robustness:</strong> Robust to noise, handles discontinuous functions well</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation against DEAP reference implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing JavaScript vs DEAP GA implementation</li>
+                    <li>🎯 Target: Statistical equivalence with standard GA operators</li>
+                    <li>📊 Metrics: Population diversity, convergence rate, final fitness values</li>
+                    <li>🔧 Challenge: Matching DEAP's operator implementations and parameters</li>
+                </ul>
+                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
@@ -278,12 +309,12 @@
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Genetic_algorithm" target="_blank">Genetic Algorithm Wikipedia</a></li>
                         <li><a href="https://deap.readthedocs.io/" target="_blank">DEAP Documentation</a></li>
-                        <li><a href="https://mitpress.mit.edu/978223952/an-introduction-to-genetic-algorithms/" target="_blank">Melanie Mitchell's GA Introduction</a></li>
-                        <li><a href="https://link.springer.com/book/.7/978-3-2-72-" target="_blank">Handbook of Evolutionary Computation</a></li>
+                        <li><a href="https://mitpress.mit.edu/9780262631952/an-introduction-to-genetic-algorithms/" target="_blank">Melanie Mitchell's GA Introduction</a></li>
+                        <li><a href="https://link.springer.com/book/10.1007/978-3-662-07426-1" target="_blank">Handbook of Evolutionary Computation</a></li>
                         <li><a href="https://www.obitko.com/tutorials/genetic-algorithms/" target="_blank">GA Tutorial by Marek Obitko</a></li>
                     </ul>
 
-                    <h3> Algorithm Components</h3>
+                    <h3>🔬 Algorithm Components</h3>
                     <ul>
                         <li><strong>Selection:</strong> Tournament, roulette wheel, rank-based selection</li>
                         <li><strong>Crossover:</strong> Single/multi-point, uniform, simulated binary (SBX)</li>
@@ -292,7 +323,7 @@
                         <li><strong>Encoding:</strong> Binary, real-valued, permutation representations</li>
                     </ul>
 
-                    <h3> GA Variants</h3>
+                    <h3>🧬 GA Variants</h3>
                     <ul>
                         <li><strong>Simple GA:</strong> Holland's original binary-encoded GA</li>
                         <li><strong>Real-Coded GA:</strong> Direct real number representation</li>
@@ -302,20 +333,20 @@
                         <li><strong>Multi-Objective GA:</strong> NSGA-II, SPEA-2 for Pareto optimization</li>
                     </ul>
 
-                    <h3> GA Applications</h3>
+                    <h3>🎯 GA Applications</h3>
                     <ul>
                         <li><strong>Scheduling:</strong> Job shop, vehicle routing, timetabling</li>
                         <li><strong>Design Optimization:</strong> Antenna design, circuit layout</li>
-                        <li><strong>Machine Learning:</strong> eature selection, neural network topology</li>
+                        <li><strong>Machine Learning:</strong> Feature selection, neural network topology</li>
                         <li><strong>Bioinformatics:</strong> Sequence alignment, protein folding</li>
-                        <li><strong>inance:</strong> Portfolio optimization, trading strategies</li>
+                        <li><strong>Finance:</strong> Portfolio optimization, trading strategies</li>
                         <li><strong>Game AI:</strong> Strategy evolution, procedural content generation</li>
                     </ul>
 
-                    <h3>📐 Mathematical oundation</h3>
+                    <h3>📐 Mathematical Foundation</h3>
                     <ul>
                         <li><strong>Schema Theory:</strong> Building blocks and convergence analysis</li>
-                        <li><strong>No ree Lunch:</strong> Performance bounds across problem classes</li>
+                        <li><strong>No Free Lunch:</strong> Performance bounds across problem classes</li>
                         <li><strong>Markov Chain Analysis:</strong> Convergence proofs for GA variants</li>
                         <li><strong>Population Dynamics:</strong> Selection pressure and diversity maintenance</li>
                     </ul>
@@ -325,65 +356,65 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/harmony-search.html
+++ b/docs/algorithms/harmony-search.html
@@ -1,151 +1,185 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Harmony Search (pyHarmonySearch) - Implementation Details</title>
     <style>
-        body 
-            font-family: -apple-system, BlinkMacSystemont, "Segoe UI", Roboto, sans-serif;
-            line-height: .;
-            margin: ;
-            padding: 2p;
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 20px;
             background: #ffffff;
             color: #333;
-        
+        }
 
-        .container 
-            ma-width: 9p;
-            margin:  auto;
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
             background: white;
-            border: p solid #ddd;
-            bo-shadow:  2p p rgba(,,,.5);
-        
+            border: 1px solid #ddd;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+        }
 
-        .header 
+        .header {
             background: #f8f9fa;
-            padding: 2p;
-            border-bottom: p solid #ddd;
-        
+            padding: 20px;
+            border-bottom: 1px solid #ddd;
+        }
 
-        .header h 
-            margin:   5p ;
-            font-size: .8em;
-            font-weight: ;
+        .header h1 {
+            margin: 0 0 5px 0;
+            font-size: 1.8em;
+            font-weight: 600;
             color: #333;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: em;
-            color: #;
-        
+        .header p {
+            margin: 0;
+            font-size: 1em;
+            color: #666;
+        }
 
-        .content 
-            padding: 2p;
-        
+        .content {
+            padding: 20px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 2p ;
-            border: p solid #ddd;
-        
+            margin: 20px 0;
+            border: 1px solid #ddd;
+        }
 
-        .implementation-table th 
+        .implementation-table th {
             background: #f8f9fa;
-            padding: 2p;
-            tet-align: left;
-            font-weight: ;
+            padding: 12px;
+            text-align: left;
+            font-weight: 600;
             color: #333;
-            border-bottom: p solid #ddd;
-        
+            border-bottom: 1px solid #ddd;
+        }
 
-        .implementation-table td 
-            padding: 2p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 12px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
+        .implementation-table .category {
+            font-weight: 600;
             color: #333;
             background: #f8f9fa;
-        
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: p 2p;
-            background: #7bff;
+            padding: 6px 12px;
+            background: #007bff;
             color: white;
-            tet-decoration: none;
-            border-radius: 3p;
-            font-size: .9em;
-            margin: 2p;
-        
+            text-decoration: none;
+            border-radius: 3px;
+            font-size: 0.9em;
+            margin: 2px;
+        }
 
-        .link-button:hover 
-            background: #5b3;
-        
+        .link-button:hover {
+            background: #0056b3;
+        }
 
-        .algorithm-description 
+        .algorithm-description {
             background: #f8f9fa;
-            border: p solid #ddd;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #7bff;
-            tet-decoration: none;
-        
+        .back-nav a {
+            color: #007bff;
+            text-decoration: none;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #f8f9fa;
-            border: p solid #ddd;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
+        .performance-notes h3 {
+            margin-top: 0;
             color: #333;
-        
+        }
 
-        .more-section 
-            margin-top: 2p;
-            border-top: p solid #ddd;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 20px;
+            border-top: 1px solid #ddd;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #7bff;
+        .more-toggle {
+            background: #007bff;
             color: white;
             border: none;
-            padding: 8p p;
-            border-radius: 3p;
+            padding: 8px 16px;
+            border-radius: 3px;
             cursor: pointer;
-            font-size: .9em;
-        
+            font-size: 0.9em;
+        }
 
-        .more-toggle:hover 
-            background: #5b3;
-        
+        .more-toggle:hover {
+            background: #0056b3;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 5p;
-        
+            margin-top: 15px;
+        }
 
+        .validation-pending {
+            background: #f8f9fa;
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #333;
+        }
+
+        .harmony-note {
+            background: #f8f9fa;
+            border: 1px solid #ddd;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .harmony-note h3 {
+            margin-top: 0;
+            color: #333;
+        }
+    </style>
+    <!-- Three.js for 3D visualization -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Harmony Search (pyHarmonySearch)</h1>
+            <p>Music-Inspired Metaheuristic Algorithm</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -153,7 +187,7 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Harmony Search (HS)</strong> is a nature-inspired metaheuristic algorithm based on the improvisation process of musicians. Developed by Zong Woo Geem in 2, it mimics how musicians compose harmonies by combining eisting melodies with new variations. The algorithm maintains a harmony memory of good solutions and generates new candidates through musical improvisation rules.
+                <strong>Harmony Search (HS)</strong> is a nature-inspired metaheuristic algorithm based on the improvisation process of musicians. Developed by Zong Woo Geem in 2001, it mimics how musicians compose harmonies by combining existing melodies with new variations. The algorithm maintains a harmony memory of good solutions and generates new candidates through musical improvisation rules.
             </div>
 
             <div class="harmony-note">
@@ -161,7 +195,7 @@
                 <p><strong>Harmony Search mimics musical composition process:</strong></p>
                 <ul>
                     <li><strong>Harmony Memory:</strong> Collection of good musical pieces (solutions)</li>
-                    <li><strong>Memory Consideration:</strong> Play a note from eisting harmonies</li>
+                    <li><strong>Memory Consideration:</strong> Play a note from existing harmonies</li>
                     <li><strong>Pitch Adjustment:</strong> Slightly modify a selected note</li>
                     <li><strong>Random Selection:</strong> Play a completely new note</li>
                 </ul>
@@ -170,17 +204,17 @@
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Harmony Search in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
-                    <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process. Each step shows where the algorithm decides to move net.
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
+                    <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process. Each step shows where the algorithm decides to move next.
                 </p>
             </div>
 
@@ -200,10 +234,10 @@
                             <strong>Zong Woo Geem</strong><br>
                             Music-inspired optimization metaheuristic<br>
                             Based on musical improvisation and harmony composition<br>
-                            <em>Published: 2</em>
+                            <em>Published: 2001</em>
                         </td>
                         <td>
-                            <a href="https://link.springer.com/article/.23/A:9283" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://link.springer.com/article/10.1023/A:1010928611306" target="_blank" class="link-button paper">📄 Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -211,7 +245,7 @@
                         <td>
                             <strong>pyHarmonySearch</strong><br>
                             Tested against pyHarmonySearch package<br>
-                            Optional eternal dependency for validation<br>
+                            Optional external dependency for validation<br>
                             <em>Reference: PyPI harmony search implementation</em>
                         </td>
                         <td>
@@ -224,10 +258,10 @@
                             <strong>Humpday Harmony Search</strong><br>
                             Custom implementation with classical HS operators<br>
                             Harmony memory, pitch adjustment, and randomization<br>
-                            <em>ile: humpday/optimizers/harmonysearch.py</em>
+                            <em>File: humpday/optimizers/harmonysearch.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -239,7 +273,7 @@
                             <em>Class: HarmonySearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
                         </td>
                     </tr>
                     <tr>
@@ -250,7 +284,7 @@
                             <strong>Humpday JS:</strong> None (pure JavaScript)
                         </td>
                         <td>
-                            <span style="color: #95a5a;">✨ No eternal dependencies</span>
+                            <span style="color: #95a5a6;">✨ No external dependencies</span>
                         </td>
                     </tr>
                 </tbody>
@@ -261,9 +295,9 @@
                 <ul>
                     <li><strong>Best for:</strong> Continuous optimization, parameter tuning, engineering design</li>
                     <li><strong>Dimensions:</strong> Handles moderate to high dimensions well</li>
-                    <li><strong>unction evaluations:</strong> Memory-based, HMS × generations</li>
-                    <li><strong>Convergence:</strong> Steady improvement through memory eploitation</li>
-                    <li><strong>Robustness:</strong> Balance between eploitation and eploration through HS operators</li>
+                    <li><strong>Function evaluations:</strong> Memory-based, HMS × generations</li>
+                    <li><strong>Convergence:</strong> Steady improvement through memory exploitation</li>
+                    <li><strong>Robustness:</strong> Balance between exploitation and exploration through HS operators</li>
                 </ul>
             </div>
 
@@ -273,13 +307,13 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Harmony_search" target="_blank">Harmony Search Wikipedia</a></li>
-                        <li><a href="https://link.springer.com/article/.23/A:9283" target="_blank">Original HS Paper (Geem et al., 2)</a></li>
-                        <li><a href="https://www.springer.com/gp/book/978327378" target="_blank">Music-Inspired Harmony Search Algorithm</a></li>
-                        <li><a href="https://ieeeplore.ieee.org/document/53873" target="_blank">Improved Harmony Search Algorithm</a></li>
-                        <li><a href="https://link.springer.com/journal/287" target="_blank">International Journal of Optimization</a></li>
+                        <li><a href="https://link.springer.com/article/10.1023/A:1010928611306" target="_blank">Original HS Paper (Geem et al., 2001)</a></li>
+                        <li><a href="https://www.springer.com/gp/book/9783642007378" target="_blank">Music-Inspired Harmony Search Algorithm</a></li>
+                        <li><a href="https://ieeexplore.ieee.org/document/4531873" target="_blank">Improved Harmony Search Algorithm</a></li>
+                        <li><a href="https://link.springer.com/journal/10287" target="_blank">International Journal of Optimization</a></li>
                     </ul>
 
-                    <h3> Core Algorithm Components</h3>
+                    <h3>🔬 Core Algorithm Components</h3>
                     <ul>
                         <li><strong>Harmony Memory (HM):</strong> Population of HMS best solutions found</li>
                         <li><strong>Harmony Memory Size (HMS):</strong> Number of solutions stored</li>
@@ -289,46 +323,46 @@
                         <li><strong>Random Selection:</strong> Generate completely new value</li>
                     </ul>
 
-                    <h3>📐 Mathematical ormulation</h3>
+                    <h3>📐 Mathematical Formulation</h3>
                     <ul>
-                        <li><strong>Memory Selection:</strong> 'ᵢ = HMⱼ(i) with probability HMCR</li>
-                        <li><strong>Pitch Adjustment:</strong> 'ᵢ = 'ᵢ ± rand() × bw with probability PAR</li>
-                        <li><strong>Random Selection:</strong> 'ᵢ ~ Uniform(LBᵢ, UBᵢ) with probability (-HMCR)</li>
+                        <li><strong>Memory Selection:</strong> x'ᵢ = HMⱼ(i) with probability HMCR</li>
+                        <li><strong>Pitch Adjustment:</strong> x'ᵢ = x'ᵢ ± rand() × bw with probability PAR</li>
+                        <li><strong>Random Selection:</strong> x'ᵢ ~ Uniform(LBᵢ, UBᵢ) with probability (1-HMCR)</li>
                         <li><strong>Memory Update:</strong> Replace worst harmony if new harmony is better</li>
                     </ul>
 
                     <h3>⚙️ Key Parameters</h3>
                     <ul>
-                        <li><strong>HMS:</strong> Harmony Memory Size, typically -5</li>
-                        <li><strong>HMCR:</strong> Memory Consideration Rate, usually .7-.95</li>
-                        <li><strong>PAR:</strong> Pitch Adjusting Rate, usually .-.5</li>
+                        <li><strong>HMS:</strong> Harmony Memory Size, typically 10-50</li>
+                        <li><strong>HMCR:</strong> Memory Consideration Rate, usually 0.7-0.95</li>
+                        <li><strong>PAR:</strong> Pitch Adjusting Rate, usually 0.1-0.5</li>
                         <li><strong>bw:</strong> Bandwidth for pitch adjustment</li>
-                        <li><strong>Termination:</strong> Maimum iterations or convergence criteria</li>
+                        <li><strong>Termination:</strong> Maximum iterations or convergence criteria</li>
                     </ul>
 
-                    <h3> Harmony Search Algorithm Pseudocode</h3>
-                    <pre style="background: #f8f9fa; padding: 5p; border-radius: 8p; font-family: monospace;">
-function harmonySearch(objectiveunction, HMS, HMCR, PAR, maIter):
-    // Step : Initialize Harmony Memory
+                    <h3>🎯 Harmony Search Algorithm Pseudocode</h3>
+                    <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
+function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
+    // Step 1: Initialize Harmony Memory
     HM = []
-    for i in  to HMS:
+    for i in 1 to HMS:
         harmony = generateRandomSolution()
-        HM.add(harmony, objectiveunction(harmony))
+        HM.add(harmony, objectiveFunction(harmony))
 
-    sortByitness(HM)
+    sortByFitness(HM)
 
     // Step 2: Improvise New Harmony
-    for iteration in  to maIter:
+    for iteration in 1 to maxIter:
         newHarmony = []
 
-        for j in  to problemDimension:
+        for j in 1 to problemDimension:
             if random() < HMCR:  // Memory consideration
                 // Choose value from memory
-                randomHarmonyInde = randomInt(, HMS-)
-                newValue = HM[randomHarmonyInde][j]
+                randomHarmonyIndex = randomInt(0, HMS-1)
+                newValue = HM[randomHarmonyIndex][j]
 
                 if random() < PAR:  // Pitch adjustment
-                    newValue += (random() - .5) * 2 * bandwidth
+                    newValue += (random() - 0.5) * 2 * bandwidth
                     newValue = clip(newValue, lowerBound, upperBound)
 
             else:  // Random selection
@@ -337,18 +371,18 @@ function harmonySearch(objectiveunction, HMS, HMCR, PAR, maIter):
             newHarmony[j] = newValue
 
         // Step 3: Update Harmony Memory
-        newitness = objectiveunction(newHarmony)
+        newFitness = objectiveFunction(newHarmony)
 
-        if newitness < HM[HMS-].fitness:  // Better than worst
-            HM[HMS-] = (newHarmony, newitness)
-            sortByitness(HM)
+        if newFitness < HM[HMS-1].fitness:  // Better than worst
+            HM[HMS-1] = (newHarmony, newFitness)
+            sortByFitness(HM)
 
-    return HM[]  // Best harmony
+    return HM[0]  // Best harmony
                     </pre>
 
-                    <h3> Harmony Search Variants</h3>
+                    <h3>🔧 Harmony Search Variants</h3>
                     <ul>
-                        <li><strong>Classical HS:</strong> Original algorithm with fied parameters</li>
+                        <li><strong>Classical HS:</strong> Original algorithm with fixed parameters</li>
                         <li><strong>Improved HS (IHS):</strong> Dynamic PAR and bandwidth adjustment</li>
                         <li><strong>Self-Adaptive HS:</strong> Automatic parameter tuning</li>
                         <li><strong>Global-Best HS:</strong> Use best harmony for pitch adjustment</li>
@@ -366,24 +400,24 @@ function harmonySearch(objectiveunction, HMS, HMCR, PAR, maIter):
                         <li><strong>Aesthetic Quality:</strong> Objective function value</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🚀 Applications</h3>
                     <ul>
                         <li><strong>Engineering Design:</strong> Structural optimization, water distribution</li>
                         <li><strong>Energy Systems:</strong> Power system optimization, renewable energy</li>
                         <li><strong>Manufacturing:</strong> Production scheduling, resource allocation</li>
                         <li><strong>Transportation:</strong> Vehicle routing, traffic optimization</li>
-                        <li><strong>Machine Learning:</strong> eature selection, neural network training</li>
+                        <li><strong>Machine Learning:</strong> Feature selection, neural network training</li>
                         <li><strong>Economics:</strong> Portfolio optimization, supply chain management</li>
                     </ul>
 
-                    <h3> Advantages of Harmony Search</h3>
+                    <h3>💡 Advantages of Harmony Search</h3>
                     <ul>
                         <li><strong>Simplicity:</strong> Easy to understand and implement</li>
-                        <li><strong>ew Parameters:</strong> Only HMS, HMCR, PAR to tune</li>
+                        <li><strong>Few Parameters:</strong> Only HMS, HMCR, PAR to tune</li>
                         <li><strong>Memory-Based:</strong> Maintains population of good solutions</li>
-                        <li><strong>leibility:</strong> Adapts to continuous and discrete problems</li>
-                        <li><strong>Balance:</strong> Good trade-off between eploration and eploitation</li>
-                        <li><strong>No Gradient Needed:</strong> Works with black-bo functions</li>
+                        <li><strong>Flexibility:</strong> Adapts to continuous and discrete problems</li>
+                        <li><strong>Balance:</strong> Good trade-off between exploration and exploitation</li>
+                        <li><strong>No Gradient Needed:</strong> Works with black-box functions</li>
                     </ul>
 
                     <h3>⚠️ Limitations</h3>
@@ -392,29 +426,29 @@ function harmonySearch(objectiveunction, HMS, HMCR, PAR, maIter):
                         <li><strong>Premature Convergence:</strong> May converge too quickly with wrong parameters</li>
                         <li><strong>Slow Convergence:</strong> Can be slow on some problem types</li>
                         <li><strong>Local Search Ability:</strong> Limited fine-tuning capability</li>
-                        <li><strong>Memory Management:</strong> ied memory size may be suboptimal</li>
+                        <li><strong>Memory Management:</strong> Fixed memory size may be suboptimal</li>
                     </ul>
 
                     <h3>🔄 Parameter Guidelines</h3>
                     <ul>
-                        <li><strong>HMCR = .9:</strong> High memory consideration for eploitation</li>
-                        <li><strong>HMCR = .:</strong> Low memory consideration for eploration</li>
-                        <li><strong>PAR = .3:</strong> Moderate pitch adjustment</li>
-                        <li><strong>HMS = -3:</strong> Small memory for fast convergence</li>
-                        <li><strong>HMS = 5-:</strong> Large memory for diverse population</li>
+                        <li><strong>HMCR = 0.9:</strong> High memory consideration for exploitation</li>
+                        <li><strong>HMCR = 0.1:</strong> Low memory consideration for exploration</li>
+                        <li><strong>PAR = 0.3:</strong> Moderate pitch adjustment</li>
+                        <li><strong>HMS = 10-30:</strong> Small memory for fast convergence</li>
+                        <li><strong>HMS = 50-100:</strong> Large memory for diverse population</li>
                         <li><strong>Dynamic Parameters:</strong> Adapt HMCR, PAR during search</li>
                     </ul>
 
-                    <h3> Creative Aspects</h3>
+                    <h3>🎨 Creative Aspects</h3>
                     <ul>
                         <li><strong>Artistic Inspiration:</strong> Based on human creativity and musical composition</li>
                         <li><strong>Improvisation Process:</strong> Mimics how musicians create new melodies</li>
                         <li><strong>Harmony Aesthetics:</strong> Better solutions are like more beautiful music</li>
                         <li><strong>Cultural Bridge:</strong> Connects optimization with arts and music</li>
-                        <li><strong>Intuitive Understanding:</strong> Easy to eplain through musical metaphor</li>
+                        <li><strong>Intuitive Understanding:</strong> Easy to explain through musical metaphor</li>
                     </ul>
 
-                    <h3> Comparison with Other Metaheuristics</h3>
+                    <h3>📊 Comparison with Other Metaheuristics</h3>
                     <ul>
                         <li><strong>vs GA:</strong> Memory-based vs generation-based evolution</li>
                         <li><strong>vs PSO:</strong> Discrete memory vs continuous population movement</li>
@@ -428,67 +462,67 @@ function harmonySearch(objectiveunction, HMS, HMCR, PAR, maIter):
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = 'Less Resources';
-             else 
+                button.textContent = 'Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = 'More Resources';
-            
-        
+                button.textContent = 'More Resources';
+            }
+        }
 
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-            script.onload = function() 
+            script.onload = function() {
                 // Check for WebGL support
-                function webglAvailable() 
-                    try 
+                function webglAvailable() {
+                    try {
                         const canvas = document.createElement('canvas');
-                        return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                     catch (e) 
+                        return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                    } catch (e) {
                         return false;
-                    
-                
+                    }
+                }
 
-                if (webglAvailable()) 
-                    const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                        onReady: () => 
+                if (webglAvailable()) {
+                    const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                        onReady: () => {
                             // Clear loading message once visualization is ready
                             const loadingMsg = document.getElementById('loadingMessage');
-                            if (loadingMsg) 
+                            if (loadingMsg) {
                                 loadingMsg.style.display = 'none';
-                            
-                        
-                    );
-                 else 
+                            }
+                        }
+                    });
+                } else {
                     document.getElementById('loadingMessage').innerHTML =
-                        '<h>WebGL Not Supported</h>' +
+                        '<h4>WebGL Not Supported</h4>' +
                         '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                        '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                
-            ;
-            script.onerror = function() 
+                        '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                }
+            };
+            script.onerror = function() {
                 document.getElementById('algorithmDemo').innerHTML =
-                    '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                    '<h>Visualization Unavailable</h>' +
+                    '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                    '<h4>Visualization Unavailable</h4>' +
                     '<p>Could not load 3D visualization component.</p>' +
                     '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -1,164 +1,197 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Hill Climbing - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #e7c3c;
+        .header {
+            background: #e74c3c;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
+        .algorithm-description {
             background: #fadbd8;
-            border-left: p solid #e7c3c;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+            border-left: 4px solid #e74c3c;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+
+        .local-search-note {
+            background: #fff5f5;
+            border: 1px solid #fed7d7;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .local-search-note h3 {
+            margin-top: 0;
+            color: #c53030;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Hill Climbing (Local Search)</h1>
+            <p>Simple Greedy Local Search Algorithm</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,32 +199,32 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Hill Climbing</strong> is one of the simplest local search optimization algorithms. It repeatedly moves to neighboring solutions that improve the objective function, stopping when no better neighbors eist. Despite its simplicity, hill climbing forms the foundation for many more sophisticated optimization methods and serves as an important baseline for local search techniques.
+                <strong>Hill Climbing</strong> is one of the simplest local search optimization algorithms. It repeatedly moves to neighboring solutions that improve the objective function, stopping when no better neighbors exist. Despite its simplicity, hill climbing forms the foundation for many more sophisticated optimization methods and serves as an important baseline for local search techniques.
             </div>
 
             <div class="local-search-note">
                 <h3>⚠️ Local Search Algorithm Notice</h3>
                 <p><strong>Hill Climbing is a pure local search method:</strong></p>
                 <ul>
-                    <li> <strong>Local Optima:</strong> Gets trapped in local minima - no global search capability</li>
-                    <li>🔄 <strong>Starting Point Dependent:</strong> inal solution depends heavily on initialization</li>
-                    <li> <strong>ast Convergence:</strong> Very efficient for local refinement</li>
-                    <li> <strong>Baseline Method:</strong> Useful as starting point or component in hybrid algorithms</li>
+                    <li>🎯 <strong>Local Optima:</strong> Gets trapped in local minima - no global search capability</li>
+                    <li>🔄 <strong>Starting Point Dependent:</strong> Final solution depends heavily on initialization</li>
+                    <li>⚡ <strong>Fast Convergence:</strong> Very efficient for local refinement</li>
+                    <li>🔧 <strong>Baseline Method:</strong> Useful as starting point or component in hybrid algorithms</li>
                 </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Hill Climbing in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -213,7 +246,7 @@
                             <strong>Classic Local Search</strong><br>
                             Greedy improvement of current solution<br>
                             Move to best neighbor until local optimum reached<br>
-                            <em>Concept: Ancient (95s AI research)</em>
+                            <em>Concept: Ancient (1950s AI research)</em>
                         </td>
                         <td>
                             <a href="https://en.wikipedia.org/wiki/Hill_climbing" target="_blank" class="link-button info">📖 Wikipedia</a>
@@ -228,7 +261,7 @@
                             <em>Self-reference: Algorithm-specific implementation</em>
                         </td>
                         <td>
-                            <a href="https://artint.info/html/ArtInt_7.html" target="_blank" class="link-button info">🎓 AI Tetbook</a>
+                            <a href="https://artint.info/html/ArtInt_71.html" target="_blank" class="link-button info">🎓 AI Textbook</a>
                         </td>
                     </tr>
                     <tr>
@@ -237,10 +270,10 @@
                             <strong>Humpday Hill Climbing</strong><br>
                             Custom local search with neighborhood generation<br>
                             Steepest ascent or first improvement strategies<br>
-                            <em>ile: humpday/optimizers/localsearch*.py</em>
+                            <em>File: humpday/optimizers/localsearch*.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -252,7 +285,7 @@
                             <em>Class: HillClimbing</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
                         </td>
                     </tr>
                     <tr>
@@ -263,7 +296,7 @@
                             <strong>Humpday JS:</strong> None (pure JavaScript)
                         </td>
                         <td>
-                            <span style="color: #95a5a;">✨ No eternal dependencies</span>
+                            <span style="color: #95a5a6;">✨ No external dependencies</span>
                         </td>
                     </tr>
                 </tbody>
@@ -274,12 +307,23 @@
                 <ul>
                     <li><strong>Best for:</strong> Local refinement, unimodal functions, quick improvements</li>
                     <li><strong>Dimensions:</strong> Scalable to any dimension</li>
-                    <li><strong>unction evaluations:</strong> Very efficient, minimal evaluations per step</li>
-                    <li><strong>Convergence:</strong> ast local convergence, no global guarantees</li>
+                    <li><strong>Function evaluations:</strong> Very efficient, minimal evaluations per step</li>
+                    <li><strong>Convergence:</strong> Fast local convergence, no global guarantees</li>
                     <li><strong>Robustness:</strong> Simple and reliable, but limited by local optima</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation of hill climbing implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing behavior against theoretical expectations</li>
+                    <li>🎯 Target: Proper local search behavior and convergence to local optima</li>
+                    <li>📊 Metrics: Local optimality verification, convergence speed</li>
+                    <li>🔧 Reference: Self-validation against algorithm specification</li>
+                </ul>
+                <p><em>Hill climbing is simple enough that correct implementation is the primary validation.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
@@ -287,13 +331,13 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Hill_climbing" target="_blank">Hill Climbing Wikipedia</a></li>
-                        <li><a href="https://artint.info/html/ArtInt_7.html" target="_blank">Artificial Intelligence: oundations of Computational Agents</a></li>
+                        <li><a href="https://artint.info/html/ArtInt_71.html" target="_blank">Artificial Intelligence: Foundations of Computational Agents</a></li>
                         <li><a href="http://aima.cs.berkeley.edu/" target="_blank">AI: A Modern Approach (Russell & Norvig)</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Heuristic_algorithms" target="_blank">Heuristic Algorithms Overview</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Heuristic_algorithms" target="_blank">Heuristic Algorithms Overview</a></li>
                         <li><a href="https://www.cs.cmu.edu/~awm/tutorials/" target="_blank">CMU Local Search Tutorials</a></li>
                     </ul>
 
-                    <h3> Algorithm Variants</h3>
+                    <h3>🔬 Algorithm Variants</h3>
                     <ul>
                         <li><strong>Simple Hill Climbing:</strong> Move to first improving neighbor</li>
                         <li><strong>Steepest-Ascent:</strong> Evaluate all neighbors, choose best improvement</li>
@@ -307,12 +351,12 @@
                         <li><strong>Continuous:</strong> Small perturbations in real-valued variables</li>
                         <li><strong>Discrete:</strong> Bit-flips, swaps, insertions for combinatorial problems</li>
                         <li><strong>Gaussian:</strong> Normal distribution around current point</li>
-                        <li><strong>Uniform:</strong> Uniform sampling within fied radius</li>
+                        <li><strong>Uniform:</strong> Uniform sampling within fixed radius</li>
                         <li><strong>Adaptive:</strong> Step size changes based on success rate</li>
                     </ul>
 
                     <h3>⚙️ Algorithm Pseudocode</h3>
-                    <pre style="background: #f8f9fa; padding: 5p; border-radius: 8p; font-family: monospace;">
+                    <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
 function hillClimbing(problem, initialSolution):
     current = initialSolution
     currentValue = evaluate(current)
@@ -321,7 +365,7 @@ function hillClimbing(problem, initialSolution):
         neighbor = generateNeighbor(current)
         neighborValue = evaluate(neighbor)
 
-        if neighborValue > currentValue:  // for maimization
+        if neighborValue > currentValue:  // for maximization
             current = neighbor
             currentValue = neighborValue
         else:
@@ -330,7 +374,7 @@ function hillClimbing(problem, initialSolution):
     return current
                     </pre>
 
-                    <h3> When Hill Climbing Works Well</h3>
+                    <h3>💡 When Hill Climbing Works Well</h3>
                     <ul>
                         <li><strong>Unimodal Problems:</strong> Single global optimum with no local optima</li>
                         <li><strong>Local Refinement:</strong> Polishing solutions from other algorithms</li>
@@ -344,11 +388,11 @@ function hillClimbing(problem, initialSolution):
                         <li><strong>Local Optima:</strong> Cannot escape local minima</li>
                         <li><strong>Plateaus:</strong> Gets stuck on flat regions</li>
                         <li><strong>Ridges:</strong> Difficulty with narrow valleys</li>
-                        <li><strong>Starting Point Sensitive:</strong> inal result depends on initialization</li>
+                        <li><strong>Starting Point Sensitive:</strong> Final result depends on initialization</li>
                         <li><strong>No Global View:</strong> Purely greedy approach</li>
                     </ul>
 
-                    <h3> Improvements and Etensions</h3>
+                    <h3>🔧 Improvements and Extensions</h3>
                     <ul>
                         <li><strong>Random Restart:</strong> Run multiple times with different starts</li>
                         <li><strong>Simulated Annealing:</strong> Allow occasional uphill moves</li>
@@ -357,11 +401,11 @@ function hillClimbing(problem, initialSolution):
                         <li><strong>Iterated Local Search:</strong> Perturb and restart periodically</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🎯 Applications</h3>
                     <ul>
                         <li><strong>Traveling Salesman:</strong> 2-opt, 3-opt local search moves</li>
                         <li><strong>Scheduling:</strong> Local improvements to task assignments</li>
-                        <li><strong>Neural Networks:</strong> ine-tuning network weights</li>
+                        <li><strong>Neural Networks:</strong> Fine-tuning network weights</li>
                         <li><strong>Game Playing:</strong> Position evaluation and move refinement</li>
                         <li><strong>Parameter Tuning:</strong> Local optimization of system parameters</li>
                         <li><strong>Image Processing:</strong> Local enhancement operations</li>
@@ -372,65 +416,65 @@ function hillClimbing(problem, initialSolution):
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -333,9 +333,7 @@
                         <li><a href="https://en.wikipedia.org/wiki/Hill_climbing" target="_blank">Hill Climbing Wikipedia</a></li>
                         <li><a href="https://artint.info/html/ArtInt_71.html" target="_blank">Artificial Intelligence: Foundations of Computational Agents</a></li>
                         <li><a href="http://aima.cs.berkeley.edu/" target="_blank">AI: A Modern Approach (Russell & Norvig)</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Heuristic_algorithms" target="_blank">Heuristic Algorithms Overview</a></li>
-                        <li><a href="https://www.cs.cmu.edu/~awm/tutorials/" target="_blank">CMU Local Search Tutorials</a></li>
-                    </ul>
+                        </ul>
 
                     <h3>🔬 Algorithm Variants</h3>
                     <ul>

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -262,7 +262,7 @@
                         </td>
                         <td>
                             <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-lbfgsb.html" target="_blank" class="link-button python">🐍 SciPy Docs</a>
-                            <a href="https://github.com/scipy/scipy/tree/main/scipy/optimize/_lbfgsb_py" target="_blank" class="link-button python">🔍 Source</a>
+                            <a href="https://github.com/scipy/scipy/tree/main/scipy/optimize" target="_blank" class="link-button python">🔍 Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -271,10 +271,10 @@
                             <strong>Humpday Integration</strong><br>
                             Calls scipy.optimize.minimize(method='L-BFGS-B')<br>
                             Automatic finite difference gradients<br>
-                            <em>File: humpday/optimizers/scipyopt.py</em>
+                            <em>File: humpday/optimizers/scipy_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipyopt.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -335,8 +335,7 @@
                         <li><a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html" target="_blank">SciPy minimize Documentation</a></li>
                         <li><a href="https://dl.acm.org/doi/10.1145/279232.279236" target="_blank">L-BFGS-B Original Paper</a></li>
                         <li><a href="https://users.iems.northwestern.edu/~nocedal/lbfgsb.html" target="_blank">L-BFGS-B Software Page</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Limited-memory_BFGS" target="_blank">L-BFGS Tutorial</a></li>
-                    </ul>
+                        </ul>
 
                     <h3>🔬 Algorithm Components</h3>
                     <ul>

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -1,164 +1,197 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
-    <title>L-BGS-B - Implementation Details</title>
+    <title>L-BFGS-B - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #9b59b;
+        .header {
+            background: #9b59b6;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
-            background: #ffff;
-            border-left: p solid #9b59b;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #f4f1ff;
+            border-left: 4px solid #9b59b6;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+
+        .gradient-note {
+            background: #fff5f5;
+            border: 1px solid #fed7d7;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .gradient-note h3 {
+            margin-top: 0;
+            color: #c53030;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>L-BFGS-B (SciPy)</h1>
+            <p>Limited-memory BFGS with Box Constraints</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,32 +199,32 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>L-BGS-B</strong> is a limited-memory quasi-Newton method for bound-constrained optimization. Developed by Byrd, Lu, Nocedal, and Zhu, it etends the popular L-BGS algorithm to handle simple bounds on variables. The algorithm is widely used for large-scale optimization problems where gradient information is available or can be approimated.
+                <strong>L-BFGS-B</strong> is a limited-memory quasi-Newton method for bound-constrained optimization. Developed by Byrd, Lu, Nocedal, and Zhu, it extends the popular L-BFGS algorithm to handle simple bounds on variables. The algorithm is widely used for large-scale optimization problems where gradient information is available or can be approximated.
             </div>
 
             <div class="gradient-note">
                 <h3>⚠️ Gradient-Based Algorithm Notice</h3>
-                <p><strong>L-BGS-B requires gradient information:</strong></p>
+                <p><strong>L-BFGS-B requires gradient information:</strong></p>
                 <ul>
-                    <li> <strong>Analytical Gradients:</strong> Best performance with eact gradients</li>
-                    <li> <strong>inite Differences:</strong> Can approimate gradients automatically</li>
-                    <li> <strong>Optimization Contet:</strong> May not be suitable for black-bo problems without gradients</li>
-                    <li> <strong>Humpday Usage:</strong> Likely uses finite difference approimation in [,]ⁿ hypercube</li>
+                    <li>🔍 <strong>Analytical Gradients:</strong> Best performance with exact gradients</li>
+                    <li>📊 <strong>Finite Differences:</strong> Can approximate gradients automatically</li>
+                    <li>⚡ <strong>Optimization Context:</strong> May not be suitable for black-box problems without gradients</li>
+                    <li>🎯 <strong>Humpday Usage:</strong> Likely uses finite difference approximation in [0,1]ⁿ hypercube</li>
                 </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
-                <p>See L-BGS-B in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <p>See L-BFGS-B in action on 3D optimization surfaces:</p>
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -211,49 +244,49 @@
                         <td class="category">Original Algorithm</td>
                         <td>
                             <strong>Byrd, Lu, Nocedal & Zhu</strong><br>
-                            Limited-memory BGS with bound constraints<br>
+                            Limited-memory BFGS with bound constraints<br>
                             Quasi-Newton method for large-scale problems<br>
-                            <em>Published: 995</em>
+                            <em>Published: 1995</em>
                         </td>
                         <td>
-                            <a href="https://dl.acm.org/doi/.5/279232.27923" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://dl.acm.org/doi/10.1145/279232.279236" target="_blank" class="link-button paper">📄 Original Paper</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Reference Implementation</td>
                         <td>
                             <strong>SciPy optimize.minimize</strong><br>
-                            Method: 'L-BGS-B'<br>
-                            scipy.optimize.minimize(method='L-BGS-B')<br>
+                            Method: 'L-BFGS-B'<br>
+                            scipy.optimize.minimize(method='L-BFGS-B')<br>
                             <em>Package: scipy</em>
                         </td>
                         <td>
-                            <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-lbfgsb.html" target="_blank" class="link-button python"> SciPy Docs</a>
-                            <a href="https://github.com/scipy/scipy/tree/main/scipy/optimize/_lbfgsb_py" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-lbfgsb.html" target="_blank" class="link-button python">🐍 SciPy Docs</a>
+                            <a href="https://github.com/scipy/scipy/tree/main/scipy/optimize/_lbfgsb_py" target="_blank" class="link-button python">🔍 Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">HumpDay Python Implementation</td>
+                        <td class="category">Humpday Python Wrapper</td>
                         <td>
                             <strong>Humpday Integration</strong><br>
-                            Calls scipy.optimize.minimize(method='L-BGS-B')<br>
+                            Calls scipy.optimize.minimize(method='L-BFGS-B')<br>
                             Automatic finite difference gradients<br>
-                            <em>ile: humpday/optimizers/scipyopt.py</em>
+                            <em>File: humpday/optimizers/scipyopt.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipyopt.py" target="_blank" class="link-button python"> Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipyopt.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Humpday JavaScript Port</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
-                            JavaScript L-BGS-B with finite difference gradients<br>
-                            Limited-memory Hessian approimation<br>
-                            <em>Class: LBGSB</em>
+                            JavaScript L-BFGS-B with finite difference gradients<br>
+                            Limited-memory Hessian approximation<br>
+                            <em>Class: LBFGSB</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
                         </td>
                     </tr>
                     <tr>
@@ -274,77 +307,88 @@
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Large-scale smooth optimization with bound constraints</li>
-                    <li><strong>Dimensions:</strong> Ecellent for high dimensions (hundreds to thousands)</li>
-                    <li><strong>unction evaluations:</strong> Very efficient, typically O(n) per iteration</li>
+                    <li><strong>Dimensions:</strong> Excellent for high dimensions (hundreds to thousands)</li>
+                    <li><strong>Function evaluations:</strong> Very efficient, typically O(n) per iteration</li>
                     <li><strong>Convergence:</strong> Superlinear convergence on smooth problems</li>
                     <li><strong>Memory:</strong> Limited memory - only stores recent gradient information</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation against SciPy L-BFGS-B reference implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing JavaScript vs scipy.optimize.minimize(method='L-BFGS-B')</li>
+                    <li>🎯 Target: Similar convergence with automatic gradient approximation</li>
+                    <li>📊 Metrics: Final objective values, convergence speed, gradient norm</li>
+                    <li>🔧 Challenge: Implementing limited-memory updates and bound projection correctly</li>
+                </ul>
+                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
                 <div id="moreContent" class="more-content">
                     <h3>📚 Educational Resources</h3>
                     <ul>
-                        <li><a href="https://en.wikipedia.org/wiki/Limited-memory_BGS" target="_blank">L-BGS Wikipedia</a></li>
+                        <li><a href="https://en.wikipedia.org/wiki/Limited-memory_BFGS" target="_blank">L-BFGS Wikipedia</a></li>
                         <li><a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html" target="_blank">SciPy minimize Documentation</a></li>
-                        <li><a href="https://dl.acm.org/doi/.5/279232.27923" target="_blank">L-BGS-B Original Paper</a></li>
-                        <li><a href="https://users.iems.northwestern.edu/~nocedal/lbfgsb.html" target="_blank">L-BGS-B Software Page</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Limited-memory_BGS" target="_blank">L-BGS Tutorial</a></li>
+                        <li><a href="https://dl.acm.org/doi/10.1145/279232.279236" target="_blank">L-BFGS-B Original Paper</a></li>
+                        <li><a href="https://users.iems.northwestern.edu/~nocedal/lbfgsb.html" target="_blank">L-BFGS-B Software Page</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Limited-memory_BFGS" target="_blank">L-BFGS Tutorial</a></li>
                     </ul>
 
-                    <h3> Algorithm Components</h3>
+                    <h3>🔬 Algorithm Components</h3>
                     <ul>
                         <li><strong>Limited Memory:</strong> Store only m recent (s,y) pairs instead of full Hessian</li>
-                        <li><strong>BGS Update:</strong> Quasi-Newton Hessian approimation using gradients</li>
+                        <li><strong>BFGS Update:</strong> Quasi-Newton Hessian approximation using gradients</li>
                         <li><strong>Two-Loop Recursion:</strong> Efficient computation of search direction</li>
-                        <li><strong>Bound Constraints:</strong> Active set method for bo constraints</li>
+                        <li><strong>Bound Constraints:</strong> Active set method for box constraints</li>
                         <li><strong>Line Search:</strong> Wolfe conditions for step length selection</li>
                     </ul>
 
-                    <h3>📐 Mathematical oundation</h3>
+                    <h3>📐 Mathematical Foundation</h3>
                     <ul>
-                        <li><strong>BGS ormula:</strong> H_k+ = H_k + ( + (y^T H_k y)/(s^T y)) * (s s^T)/(s^T y) - (s y^T H_k + H_k y s^T)/(s^T y)</li>
+                        <li><strong>BFGS Formula:</strong> H_{k+1} = H_k + (1 + (y^T H_k y)/(s^T y)) * (s s^T)/(s^T y) - (s y^T H_k + H_k y s^T)/(s^T y)</li>
                         <li><strong>Two-Loop:</strong> q = ∇f_k, then backwards and forwards loops over stored vectors</li>
-                        <li><strong>Initial Hessian:</strong> H_ = γI where γ = (s^T y)/(y^T y)</li>
+                        <li><strong>Initial Hessian:</strong> H_0 = γI where γ = (s^T y)/(y^T y)</li>
                         <li><strong>Bound Projection:</strong> Project gradient onto feasible cone</li>
                         <li><strong>Cauchy Point:</strong> Piecewise linear minimizer along projected gradient</li>
                     </ul>
 
                     <h3>⚙️ Key Parameters</h3>
                     <ul>
-                        <li><strong>Memory Size (m):</strong> Usually 5-2 (s,y) pairs stored</li>
-                        <li><strong>Line Search:</strong> Wolfe conditions c=e-, c2=.9</li>
-                        <li><strong>Gradient Tolerance:</strong> ||∇f|| < gtol (typically e-5)</li>
-                        <li><strong>unction Tolerance:</strong> Relative change in f < ftol</li>
-                        <li><strong>Ma Iterations:</strong> Prevent infinite loops</li>
+                        <li><strong>Memory Size (m):</strong> Usually 5-20 (s,y) pairs stored</li>
+                        <li><strong>Line Search:</strong> Wolfe conditions c1=1e-4, c2=0.9</li>
+                        <li><strong>Gradient Tolerance:</strong> ||∇f|| < gtol (typically 1e-5)</li>
+                        <li><strong>Function Tolerance:</strong> Relative change in f < ftol</li>
+                        <li><strong>Max Iterations:</strong> Prevent infinite loops</li>
                     </ul>
 
-                    <h3> L-BGS vs L-BGS-B</h3>
+                    <h3>🎯 L-BFGS vs L-BFGS-B</h3>
                     <ul>
-                        <li><strong>L-BGS:</strong> Unconstrained optimization only</li>
-                        <li><strong>L-BGS-B:</strong> Etends to simple bound constraints</li>
-                        <li><strong>Active Set:</strong> L-BGS-B identifies and handles active bounds</li>
+                        <li><strong>L-BFGS:</strong> Unconstrained optimization only</li>
+                        <li><strong>L-BFGS-B:</strong> Extends to simple bound constraints</li>
+                        <li><strong>Active Set:</strong> L-BFGS-B identifies and handles active bounds</li>
                         <li><strong>Subspace:</strong> Optimization in subspace of free variables</li>
-                        <li><strong>Compleity:</strong> Similar O(mn) compleity per iteration</li>
+                        <li><strong>Complexity:</strong> Similar O(mn) complexity per iteration</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🚀 Applications</h3>
                     <ul>
                         <li><strong>Machine Learning:</strong> Training large neural networks</li>
-                        <li><strong>Parameter Estimation:</strong> Maimum likelihood estimation</li>
+                        <li><strong>Parameter Estimation:</strong> Maximum likelihood estimation</li>
                         <li><strong>Signal Processing:</strong> Sparse signal reconstruction</li>
                         <li><strong>Engineering Design:</strong> Structural optimization with bounds</li>
                         <li><strong>Portfolio Optimization:</strong> Asset allocation with constraints</li>
                         <li><strong>Image Processing:</strong> Image restoration and deconvolution</li>
                     </ul>
 
-                    <h3> Why L-BGS-B is Popular</h3>
+                    <h3>⚡ Why L-BFGS-B is Popular</h3>
                     <ul>
                         <li><strong>Memory Efficient:</strong> O(mn) storage vs O(n²) for full Newton</li>
-                        <li><strong>ast Convergence:</strong> Superlinear on smooth problems</li>
-                        <li><strong>Handles Bounds:</strong> Natural bo constraint support</li>
+                        <li><strong>Fast Convergence:</strong> Superlinear on smooth problems</li>
+                        <li><strong>Handles Bounds:</strong> Natural box constraint support</li>
                         <li><strong>Robust Implementation:</strong> Well-tested in SciPy</li>
                         <li><strong>Scalable:</strong> Works well on high-dimensional problems</li>
                         <li><strong>Default Choice:</strong> Often first choice for smooth bounded optimization</li>
@@ -355,65 +399,65 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/nelder-mead-scipy.html
+++ b/docs/algorithms/nelder-mead-scipy.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Nelder-Mead (SciPy) - HumpDay Optimization</title>
     <link rel="stylesheet" href="../academic.css">
 </head>
 <body>
     <nav class="breadcrumb">
-        <a href="../inde.html">HumpDay</a> >
+        <a href="../index.html">HumpDay</a> >
         <a href="../contest.html">Contest</a> >
         <span>Nelder-Mead</span>
     </nav>
 
     <div class="container">
-        <h>Nelder-Mead (SciPy)</h>
-        <h2>Simple Method for Unconstrained Optimization</h2>
+        <h1>Nelder-Mead (SciPy)</h1>
+        <h2>Simplex Method for Unconstrained Optimization</h2>
 
         <div class="algorithm-meta">
             <div class="meta-grid">
@@ -23,7 +23,7 @@
                     <strong>Authors:</strong> Nelder & Mead
                 </div>
                 <div class="meta-item">
-                    <strong>Year:</strong> 95
+                    <strong>Year:</strong> 1965
                 </div>
                 <div class="meta-item">
                     <strong>Type:</strong> Geometric derivative-free
@@ -36,39 +36,39 @@
 
         <section>
             <h3>Overview</h3>
-            <p>The Nelder-Mead method, also known as the simple method, is one of the most widely used derivative-free optimization algorithms. It maintains a simple (a geometric shape with n+ vertices in n dimensions) and iteratively improves it through reflection, epansion, contraction, and shrinkage operations.</p>
+            <p>The Nelder-Mead method, also known as the simplex method, is one of the most widely used derivative-free optimization algorithms. It maintains a simplex (a geometric shape with n+1 vertices in n dimensions) and iteratively improves it through reflection, expansion, contraction, and shrinkage operations.</p>
         </section>
 
         <section>
             <h3>Algorithm Operations</h3>
-            <p>The method uses four fundamental operations to transform the simple:</p>
+            <p>The method uses four fundamental operations to transform the simplex:</p>
 
             <div class="algorithm-operations">
                 <div class="operation">
                     <strong>Reflection:</strong> Mirror the worst point through the centroid
-                    <div class="math-block"><sub>r</sub> = ̄ + α(̄ - <sub>n+</sub>)</div>
+                    <div class="math-block">x<sub>r</sub> = x̄ + α(x̄ - x<sub>n+1</sub>)</div>
                 </div>
 
                 <div class="operation">
-                    <strong>Epansion:</strong> Etend further if reflection is successful
-                    <div class="math-block"><sub>e</sub> = ̄ + γ(<sub>r</sub> - ̄)</div>
+                    <strong>Expansion:</strong> Extend further if reflection is successful
+                    <div class="math-block">x<sub>e</sub> = x̄ + γ(x<sub>r</sub> - x̄)</div>
                 </div>
 
                 <div class="operation">
                     <strong>Contraction:</strong> Pull back toward centroid if needed
-                    <div class="math-block"><sub>c</sub> = ̄ + β(<sub>worst</sub> - ̄)</div>
+                    <div class="math-block">x<sub>c</sub> = x̄ + β(x<sub>worst</sub> - x̄)</div>
                 </div>
 
                 <div class="operation">
-                    <strong>Shrinkage:</strong> Reduce entire simple toward best point
-                    <div class="math-block"><sub>i</sub> = <sub></sub> + σ(<sub>i</sub> - <sub></sub>)</div>
+                    <strong>Shrinkage:</strong> Reduce entire simplex toward best point
+                    <div class="math-block">x<sub>i</sub> = x<sub>1</sub> + σ(x<sub>i</sub> - x<sub>1</sub>)</div>
                 </div>
             </div>
         </section>
 
         <section>
             <h3>Algorithm Characteristics</h3>
-            <h>Strengths:</h>
+            <h4>Strengths:</h4>
             <ul>
                 <li>Simple to implement and understand</li>
                 <li>Robust across many problem types</li>
@@ -77,11 +77,11 @@
                 <li>Good general-purpose performance</li>
             </ul>
 
-            <h>Limitations:</h>
+            <h4>Limitations:</h4>
             <ul>
                 <li>No convergence guarantees</li>
                 <li>Can be slow near optimum</li>
-                <li>Sensitive to initial simple construction</li>
+                <li>Sensitive to initial simplex construction</li>
                 <li>May struggle with high-dimensional problems</li>
                 <li>Can stagnate on ridges or valleys</li>
             </ul>
@@ -91,47 +91,47 @@
             <h3>Implementation Details</h3>
             <p>Our HumpDay implementation includes:</p>
             <ul>
-                <li><strong>Python:</strong> <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L7" target="_blank">Pure Python implementation</a></li>
+                <li><strong>Python:</strong> <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L17" target="_blank">Pure Python implementation</a></li>
                 <li><strong>JavaScript:</strong> <a href="../js/optimizers.js" target="_blank">Browser-compatible version</a></li>
                 <li><strong>Validation:</strong> Cross-validated against <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-neldermead.html" target="_blank">SciPy reference</a></li>
-                <li><strong>Parameters:</strong> α=., γ=2., β=.5, σ=.5 (standard values)</li>
+                <li><strong>Parameters:</strong> α=1.0, γ=2.0, β=0.5, σ=0.5 (standard values)</li>
             </ul>
         </section>
 
         <section>
             <h3>References</h3>
             <div class="references">
-                <p><strong>Primary Paper:</strong> Nelder, J.A., and Mead, R. (95). "A simple method for function minimization." The Computer Journal, 7(), 38-33. <a href="https://doi.org/.93/comjnl/7..38" target="_blank">[DOI]</a></p>
+                <p><strong>Primary Paper:</strong> Nelder, J.A., and Mead, R. (1965). "A simplex method for function minimization." The Computer Journal, 7(4), 308-313. <a href="https://doi.org/10.1093/comjnl/7.4.308" target="_blank">[DOI]</a></p>
 
                 <p><strong>Reference Implementation:</strong> <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-neldermead.html" target="_blank">SciPy optimize.minimize</a></p>
 
                 <p><strong>Additional Resources:</strong></p>
                 <ul>
                     <li><a href="https://github.com/scipy/scipy" target="_blank">SciPy GitHub Repository</a></li>
-                    <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Nelder-Mead_method" target="_blank">Northwestern Optimization Course Notes</a></li>
+                    <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Nelder-Mead_method" target="_blank">Northwestern Optimization Course Notes</a></li>
                 </ul>
             </div>
         </section>
 
         <section>
-            <h3>Usage Eample</h3>
+            <h3>Usage Example</h3>
             <div class="code-block">
                 <pre><code>from humpday import minimize
 import numpy as np
 
 # Optimize Rosenbrock function
-def rosenbrock():
-    return sum(.*([:] - [:-]**2)**2 + ( - [:-])**2)
+def rosenbrock(x):
+    return sum(100.0*(x[1:] - x[:-1]**2)**2 + (1 - x[:-1])**2)
 
 # Use Nelder-Mead via HumpDay interface
 result = minimize(rosenbrock,
-                 =np.array([-.2, .]),
+                 x0=np.array([-1.2, 1.0]),
                  method='NelderMead',
-                 options='mafev': 2)
+                 options={'maxfev': 200})
 
-print(f"Optimum: result.")
-print(f"Value: result.fun")
-print(f"Iterations: result.nfev")</code></pre>
+print(f"Optimum: {result.x}")
+print(f"Value: {result.fun}")
+print(f"Iterations: {result.nfev}")</code></pre>
             </div>
         </section>
 

--- a/docs/algorithms/nelder-mead-scipy.html
+++ b/docs/algorithms/nelder-mead-scipy.html
@@ -108,8 +108,7 @@
                 <p><strong>Additional Resources:</strong></p>
                 <ul>
                     <li><a href="https://github.com/scipy/scipy" target="_blank">SciPy GitHub Repository</a></li>
-                    <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Nelder-Mead_method" target="_blank">Northwestern Optimization Course Notes</a></li>
-                </ul>
+                        </ul>
             </div>
         </section>
 

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -268,7 +268,6 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method" target="_blank">Nelder-Mead Wikipedia</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Nelder-Mead_method" target="_blank">Northwestern Optimization Course</a></li>
                         <li><a href="https://codesachin.wordpress.com/2016/01/16/nelder-mead-optimization/" target="_blank">Visual Tutorial</a></li>
                         <li><a href="https://www.mathworks.com/help/matlab/math/optimizing-nonlinear-functions.html" target="_blank">MATLAB Documentation</a></li>
                     </ul>

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -1,169 +1,169 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Nelder-Mead (SciPy) - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #2c3e5;
+        .header {
+            background: #2c3e50;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
 
-        .algorithm-description 
-            background: #e8ff3;
-            border-left: p solid #27ae;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #e8f6f3;
+            border-left: 4px solid #27ae60;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
     </style>
 </head>
 <body>
     <div class="container">
         <div class="header">
-            <h>Nelder-Mead (SciPy)</h>
-            <p>Downhill Simple Method</p>
+            <h1>Nelder-Mead (SciPy)</h1>
+            <p>Downhill Simplex Method</p>
         </div>
 
         <div class="content">
@@ -172,21 +172,21 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Nelder-Mead</strong> is a classic derivative-free optimization method that uses a simple (n+ vertices in n dimensions) to search the parameter space. It's remarkably robust and intuitive, using geometric operations like reflection, epansion, and contraction to navigate toward the optimum.
+                <strong>Nelder-Mead</strong> is a classic derivative-free optimization method that uses a simplex (n+1 vertices in n dimensions) to search the parameter space. It's remarkably robust and intuitive, using geometric operations like reflection, expansion, and contraction to navigate toward the optimum.
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Nelder-Mead in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -206,12 +206,12 @@
                         <td class="category">Original Algorithm</td>
                         <td>
                             <strong>John Nelder & Roger Mead</strong><br>
-                            Simple-based direct search method<br>
-                            Uses geometric transformations of n+ vertices<br>
-                            <em>Published: 95</em>
+                            Simplex-based direct search method<br>
+                            Uses geometric transformations of n+1 vertices<br>
+                            <em>Published: 1965</em>
                         </td>
                         <td>
-                            <a href="https://doi.org/.93/comjnl/7..38" target="_blank" class="link-button paper">📄 Paper</a>
+                            <a href="https://doi.org/10.1093/comjnl/7.4.308" target="_blank" class="link-button paper">📄 Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -220,22 +220,22 @@
                             <strong>Python Implementation</strong><br>
                             Uses SciPy's optimize.minimize with method='Nelder-Mead'<br>
                             Well-tested and numerically stable implementation<br>
-                            <em>ile: humpday/optimizers/scipy_algorithms.py</em>
+                            <em>File: humpday/optimizers/scipy_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python"> Python Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">🐍 Python Code</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
-                            Pure JavaScript port with simple operations<br>
+                            Pure JavaScript port with simplex operations<br>
                             Maintains geometric transformation logic<br>
                             <em>Class: NelderMead</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js" target="_blank" class="link-button javascript"> JavaScript Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js" target="_blank" class="link-button javascript">🌐 JavaScript Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -254,11 +254,11 @@
             <div class="performance-notes">
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Low to medium dimensions (2-2D), robust across function types</li>
-                    <li><strong>Dimensions:</strong> Performance degrades significantly above -2 dimensions</li>
-                    <li><strong>unction evaluations:</strong> Typically O(n) evaluations per iteration</li>
+                    <li><strong>Best for:</strong> Low to medium dimensions (2-20D), robust across function types</li>
+                    <li><strong>Dimensions:</strong> Performance degrades significantly above 10-20 dimensions</li>
+                    <li><strong>Function evaluations:</strong> Typically O(n) evaluations per iteration</li>
                     <li><strong>Convergence:</strong> Reliable but can be slow on ill-conditioned problems</li>
-                    <li><strong>Robustness:</strong> Ecellent on noisy, discontinuous, and multimodal functions</li>
+                    <li><strong>Robustness:</strong> Excellent on noisy, discontinuous, and multimodal functions</li>
                 </ul>
             </div>
 
@@ -267,19 +267,19 @@
                 <div id="moreContent" class="more-content">
                     <h3>📚 Educational Resources</h3>
                     <ul>
-                        <li><a href="https://en.wikipedia.org/wiki/Nelder%E2%8%93Mead_method" target="_blank">Nelder-Mead Wikipedia</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Nelder-Mead_method" target="_blank">Northwestern Optimization Course</a></li>
-                        <li><a href="https://codesachin.wordpress.com/2///nelder-mead-optimization/" target="_blank">Visual Tutorial</a></li>
+                        <li><a href="https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method" target="_blank">Nelder-Mead Wikipedia</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Nelder-Mead_method" target="_blank">Northwestern Optimization Course</a></li>
+                        <li><a href="https://codesachin.wordpress.com/2016/01/16/nelder-mead-optimization/" target="_blank">Visual Tutorial</a></li>
                         <li><a href="https://www.mathworks.com/help/matlab/math/optimizing-nonlinear-functions.html" target="_blank">MATLAB Documentation</a></li>
                     </ul>
 
-                    <h> Algorithm Visualization</h>
-                    <p>The Nelder-Mead method is one of the most visually intuitive optimization algorithms. The simple (triangle in 2D) moves through the parameter space by:</p>
+                    <h4>🔍 Algorithm Visualization</h4>
+                    <p>The Nelder-Mead method is one of the most visually intuitive optimization algorithms. The simplex (triangle in 2D) moves through the parameter space by:</p>
                     <ul>
                         <li><strong>Reflection:</strong> Mirror the worst point across the centroid</li>
-                        <li><strong>Epansion:</strong> If reflection improves, try going further</li>
+                        <li><strong>Expansion:</strong> If reflection improves, try going further</li>
                         <li><strong>Contraction:</strong> If reflection fails, contract toward the best point</li>
-                        <li><strong>Shrinkage:</strong> If all else fails, shrink the entire simple</li>
+                        <li><strong>Shrinkage:</strong> If all else fails, shrink the entire simplex</li>
                     </ul>
                 </div>
             </div>
@@ -287,65 +287,65 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -308,9 +308,7 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/NEWUOA" target="_blank">NEWUOA Wikipedia</a></li>
-                        <li><a href="https://www.pdfo.net/docs/" target="_blank">PDFO Documentation</a></li>
-                        <li><a href="https://www.damtp.cam.ac.uk/user/na/NA_papers/NA2004_08.pdf" target="_blank">Powell's NEWUOA Paper (2004)</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Trust_region_methods" target="_blank">Trust Region Methods Overview</a></li>
+                        <li><a href="https://www.pdfo.net/" target="_blank">PDFO Documentation</a></li>
                         <li><a href="https://link.springer.com/chapter/10.1007/978-0-387-30065-5_17" target="_blank">Derivative-Free Optimization Methods</a></li>
                     </ul>
 

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -1,183 +1,183 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>NEWUOA (Prima) - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #2c3e5;
+        .header {
+            background: #2c3e50;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
-            background: #e8ff3;
-            border-left: p solid #27ae;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #e8f6f3;
+            border-left: 4px solid #27ae60;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
-        .validation-issues 
+        .validation-issues {
             background: #f8d7da;
-            border: p solid #dc355;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #dc3545;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .validation-issues h3 
-            margin-top: ;
-            color: #72c2;
-        
+        .validation-issues h3 {
+            margin-top: 0;
+            color: #721c24;
+        }
     </style>
 </head>
 <body>
     <div class="container">
         <div class="header">
-            <h>NEWUOA (PDO)</h>
-            <p>New Unconstrained Optimization by Quadratic Approimation</p>
+            <h1>NEWUOA (PDFO)</h1>
+            <p>New Unconstrained Optimization by Quadratic Approximation</p>
         </div>
 
         <div class="content">
@@ -186,21 +186,21 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>NEWUOA</strong> is an advanced trust-region method that builds underdetermined quadratic models using fewer interpolation points than UOBYQA. Developed by M.J.D. Powell as an improvement over UOBYQA, it uses 2n+ interpolation points instead of the full (n+)(n+2)/2, making it more efficient for higher-dimensional problems while maintaining good approimation quality.
+                <strong>NEWUOA</strong> is an advanced trust-region method that builds underdetermined quadratic models using fewer interpolation points than UOBYQA. Developed by M.J.D. Powell as an improvement over UOBYQA, it uses 2n+1 interpolation points instead of the full (n+1)(n+2)/2, making it more efficient for higher-dimensional problems while maintaining good approximation quality.
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See NEWUOA in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -222,53 +222,53 @@
                             <strong>M.J.D. Powell</strong><br>
                             Underdetermined quadratic models with trust regions<br>
                             Improved efficiency over UOBYQA for higher dimensions<br>
-                            <em>Published: 2</em>
+                            <em>Published: 2004</em>
                         </td>
                         <td>
-                            <a href="https://www.damtp.cam.ac.uk/user/na/NA_papers/NA2_8.pdf" target="_blank" class="link-button paper">📄 Paper</a>
+                            <a href="https://www.damtp.cam.ac.uk/user/na/NA_papers/NA2004_08.pdf" target="_blank" class="link-button paper">📄 Paper</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Reference Package</td>
                         <td>
-                            <strong>PDO (Python Derivative-ree Optimization)</strong><br>
-                            Wraps Powell's original ortran implementation<br>
+                            <strong>PDFO (Python Derivative-Free Optimization)</strong><br>
+                            Wraps Powell's original Fortran implementation<br>
                             Authoritative implementation with numerical robustness<br>
                             <em>Package: pdfo</em>
                         </td>
                         <td>
-                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">📦 PDO</a>
-                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">📦 PDFO</a>
+                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python">🐍 Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">HumpDay Python Implementation</td>
+                        <td class="category">Humpday Python Wrapper</td>
                         <td>
                             <strong>Humpday Integration</strong><br>
-                            Calls PDO's NEWUOA implementation<br>
+                            Calls PDFO's NEWUOA implementation<br>
                             Standardized interface for optimization contests<br>
-                            <em>ile: humpday/optimizers/prima_algorithms.py</em>
+                            <em>File: humpday/optimizers/prima_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python"> Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Humpday JavaScript Port</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
-                            JavaScript port attempting to match PDO behavior<br>
+                            JavaScript port attempting to match PDFO behavior<br>
                             Underdetermined quadratic model building<br>
                             <em>Class: PRIMA_NEWUOA</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Dependencies</td>
                         <td>
-                            <strong>Reference:</strong> PDO package (wraps Powell's ortran)<br>
+                            <strong>Reference:</strong> PDFO package (wraps Powell's Fortran)<br>
                             <strong>Humpday Python:</strong> pdfo, numpy<br>
                             <strong>Humpday JS:</strong> None (standalone port)
                         </td>
@@ -283,10 +283,10 @@
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Smooth, unconstrained problems in moderate to high dimensions</li>
-                    <li><strong>Dimensions:</strong> Particularly effective for n >  where UOBYQA becomes epensive</li>
-                    <li><strong>unction evaluations:</strong> Uses 2n+ points, more efficient than UOBYQA's (n+)(n+2)/2</li>
-                    <li><strong>Convergence:</strong> Ecellent convergence on smooth functions</li>
-                    <li><strong>Robustness:</strong> Handles moderate noise, good balance of eploration and eploitation</li>
+                    <li><strong>Dimensions:</strong> Particularly effective for n > 10 where UOBYQA becomes expensive</li>
+                    <li><strong>Function evaluations:</strong> Uses 2n+1 points, more efficient than UOBYQA's (n+1)(n+2)/2</li>
+                    <li><strong>Convergence:</strong> Excellent convergence on smooth functions</li>
+                    <li><strong>Robustness:</strong> Handles moderate noise, good balance of exploration and exploitation</li>
                 </ul>
             </div>
 
@@ -294,12 +294,12 @@
                 <h3>❌ Validation Status: IMPLEMENTATION ISSUES</h3>
                 <p><strong>JavaScript implementation currently has errors preventing proper validation:</strong></p>
                 <ul>
-                    <li><strong>Error Detected:</strong> "Pts is not defined" in JavaScript implementation</li>
-                    <li><strong>Test Results:</strong> /3 test functions complete successfully</li>
-                    <li><strong>PDO Reference:</strong> Working perfectly (achieves f = . on test functions)</li>
-                    <li><strong>Required i:</strong> Variable naming and initialization issues need resolution</li>
+                    <li><strong>Error Detected:</strong> "xPts is not defined" in JavaScript implementation</li>
+                    <li><strong>Test Results:</strong> 0/3 test functions complete successfully</li>
+                    <li><strong>PDFO Reference:</strong> Working perfectly (achieves f = 0.000000 on test functions)</li>
+                    <li><strong>Required Fix:</strong> Variable naming and initialization issues need resolution</li>
                 </ul>
-                <p><em>Latest test: 22-5-2 - JavaScript implementation needs debugging before validation possible</em></p>
+                <p><em>Latest test: 2026-05-21 - JavaScript implementation needs debugging before validation possible</em></p>
             </div>
 
             <div class="more-section">
@@ -308,16 +308,16 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/NEWUOA" target="_blank">NEWUOA Wikipedia</a></li>
-                        <li><a href="https://www.pdfo.net/docs/" target="_blank">PDO Documentation</a></li>
-                        <li><a href="https://www.damtp.cam.ac.uk/user/na/NA_papers/NA2_8.pdf" target="_blank">Powell's NEWUOA Paper (2)</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Trust_region_methods" target="_blank">Trust Region Methods Overview</a></li>
-                        <li><a href="https://link.springer.com/chapter/.7/978--387-35-5_7" target="_blank">Derivative-ree Optimization Methods</a></li>
+                        <li><a href="https://www.pdfo.net/docs/" target="_blank">PDFO Documentation</a></li>
+                        <li><a href="https://www.damtp.cam.ac.uk/user/na/NA_papers/NA2004_08.pdf" target="_blank">Powell's NEWUOA Paper (2004)</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Trust_region_methods" target="_blank">Trust Region Methods Overview</a></li>
+                        <li><a href="https://link.springer.com/chapter/10.1007/978-0-387-30065-5_17" target="_blank">Derivative-Free Optimization Methods</a></li>
                     </ul>
 
-                    <h3> Algorithm Theory</h3>
+                    <h3>🔬 Algorithm Theory</h3>
                     <ul>
-                        <li><strong>Interpolation Set:</strong> 2n+ points vs UOBYQA's (n+)(n+2)/2 points</li>
-                        <li><strong>Quadratic Models:</strong> Underdetermined system solved with minimum robenius norm</li>
+                        <li><strong>Interpolation Set:</strong> 2n+1 points vs UOBYQA's (n+1)(n+2)/2 points</li>
+                        <li><strong>Quadratic Models:</strong> Underdetermined system solved with minimum Frobenius norm</li>
                         <li><strong>Trust Region:</strong> Adaptive radius based on model agreement</li>
                         <li><strong>Lagrange Basis:</strong> Efficient update of interpolation functions</li>
                         <li><strong>Geometry Improvement:</strong> Automatic point replacement for better conditioning</li>
@@ -332,18 +332,18 @@
                         <li><strong>Dimension Limit:</strong> NEWUOA practical for much higher dimensions</li>
                     </ul>
 
-                    <h3> When to Use NEWUOA</h3>
+                    <h3>🎯 When to Use NEWUOA</h3>
                     <ul>
-                        <li><strong>High Dimensions:</strong> n >  where UOBYQA becomes prohibitive</li>
-                        <li><strong>Limited Budget:</strong> When function evaluations are very epensive</li>
-                        <li><strong>Smooth unctions:</strong> Continuous, differentiable (but derivatives unknown)</li>
+                        <li><strong>High Dimensions:</strong> n > 10 where UOBYQA becomes prohibitive</li>
+                        <li><strong>Limited Budget:</strong> When function evaluations are very expensive</li>
+                        <li><strong>Smooth Functions:</strong> Continuous, differentiable (but derivatives unknown)</li>
                         <li><strong>Unconstrained:</strong> No bounds or constraints (use BOBYQA for bounds)</li>
                         <li><strong>Global Search:</strong> Combined with multi-start for global optimization</li>
                     </ul>
 
-                    <h3> Implementation Details</h3>
+                    <h3>🔧 Implementation Details</h3>
                     <ul>
-                        <li><strong>Initial Geometry:</strong> 2n+ points around starting point</li>
+                        <li><strong>Initial Geometry:</strong> 2n+1 points around starting point</li>
                         <li><strong>Model Building:</strong> Minimum norm solution for underdetermined system</li>
                         <li><strong>Trust Region Subproblem:</strong> Dogleg or conjugate gradient methods</li>
                         <li><strong>Point Replacement:</strong> Replace worst-conditioned points</li>
@@ -355,65 +355,65 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/particle-swarm.html
+++ b/docs/algorithms/particle-swarm.html
@@ -1,185 +1,185 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Particle Swarm Optimization - HumpDay Implementation</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/kate@../dist/kate.min.css" crossorigin="anonymous">
-    <script defer src="https://cdn.jsdelivr.net/npm/kate@../dist/kate.min.js" crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/kate@../dist/contrib/auto-render.min.js" crossorigin="anonymous"
-        onload="renderMathInElement(document.body, delimiters:[left:'$$',right:'$$',display:true,left:'$',right:'$',display:false]);"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" crossorigin="anonymous">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js" crossorigin="anonymous"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" crossorigin="anonymous"
+        onload="renderMathInElement(document.body, {delimiters:[{left:'$$',right:'$$',display:true},{left:'$',right:'$',display:false}]});"></script>
     <style>
-        body 
+        body {
             font-family: 'Times New Roman', Times, serif;
-            font-size: p;
-            line-height: .;
-            color: #;
+            font-size: 16px;
+            line-height: 1.6;
+            color: #000;
             background: #fff;
-            margin: ;
-            padding: p 2p;
-            ma-width: 8p;
-            margin:  auto;
-        
+            margin: 0;
+            padding: 40px 20px;
+            max-width: 800px;
+            margin: 0 auto;
+        }
 
-        .paper-header 
-            tet-align: center;
-            margin-bottom: p;
-            border-bottom: 2p solid #;
-            padding-bottom: 2p;
-        
+        .paper-header {
+            text-align: center;
+            margin-bottom: 40px;
+            border-bottom: 2px solid #000;
+            padding-bottom: 20px;
+        }
 
-        .paper-title 
-            font-size: 2p;
+        .paper-title {
+            font-size: 24px;
             font-weight: bold;
-            margin:   p ;
-            letter-spacing: .5p;
-        
+            margin: 0 0 10px 0;
+            letter-spacing: 0.5px;
+        }
 
-        .paper-subtitle 
-            font-size: p;
+        .paper-subtitle {
+            font-size: 14px;
             font-style: italic;
             color: #333;
-            margin: ;
-        
+            margin: 0;
+        }
 
-        .abstract 
+        .abstract {
             background: #f9f9f9;
-            border-left: p solid #333;
-            padding: 2p;
-            margin: 3p ;
+            border-left: 4px solid #333;
+            padding: 20px;
+            margin: 30px 0;
             font-style: italic;
-        
+        }
 
-        .abstract h3 
-            margin:   p ;
-            font-size: p;
+        .abstract h3 {
+            margin: 0 0 10px 0;
+            font-size: 14px;
             font-weight: bold;
-            tet-transform: uppercase;
-            letter-spacing: p;
-        
+            text-transform: uppercase;
+            letter-spacing: 1px;
+        }
 
-        h2 
-            font-size: 8p;
+        h2 {
+            font-size: 18px;
             font-weight: bold;
-            margin: p  2p ;
-            border-bottom: p solid #ccc;
-            padding-bottom: 5p;
-        
+            margin: 40px 0 20px 0;
+            border-bottom: 1px solid #ccc;
+            padding-bottom: 5px;
+        }
 
-        h3 
-            font-size: p;
+        h3 {
+            font-size: 16px;
             font-weight: bold;
-            margin: 3p  5p ;
-        
+            margin: 30px 0 15px 0;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 2p ;
-            border: p solid #333;
-        
+            margin: 20px 0;
+            border: 1px solid #333;
+        }
 
-        .implementation-table th 
-            background: #fff;
-            border: p solid #333;
-            padding: 2p;
-            tet-align: left;
+        .implementation-table th {
+            background: #f0f0f0;
+            border: 1px solid #333;
+            padding: 12px;
+            text-align: left;
             font-weight: bold;
-            font-size: p;
-        
+            font-size: 14px;
+        }
 
-        .implementation-table td 
-            border: p solid #333;
-            padding: 2p;
+        .implementation-table td {
+            border: 1px solid #333;
+            padding: 12px;
             vertical-align: top;
-            font-size: p;
-        
+            font-size: 14px;
+        }
 
-        .code-ref 
+        .code-ref {
             font-family: 'Courier New', monospace;
             background: #f5f5f5;
-            padding: 2p p;
-            border: p solid #ccc;
-        
+            padding: 2px 4px;
+            border: 1px solid #ccc;
+        }
 
-        .citation 
+        .citation {
             font-style: italic;
-            font-size: p;
-        
+            font-size: 14px;
+        }
 
-        a 
-            color: #;
-            tet-decoration: underline;
-        
+        a {
+            color: #000;
+            text-decoration: underline;
+        }
 
-        a:hover 
-            tet-decoration: none;
-        
+        a:hover {
+            text-decoration: none;
+        }
 
-        .nav-link 
+        .nav-link {
             display: inline-block;
-            margin-bottom: 2p;
-            font-size: p;
-        
+            margin-bottom: 20px;
+            font-size: 14px;
+        }
 
-        .algorithm-details 
-            margin: 3p ;
-        
+        .algorithm-details {
+            margin: 30px 0;
+        }
 
-        .mathematical-formulation 
+        .mathematical-formulation {
             background: #fafafa;
-            border: p solid #ddd;
-            padding: 2p;
-            margin: 2p ;
-        
+            border: 1px solid #ddd;
+            padding: 20px;
+            margin: 20px 0;
+        }
 
-        .references 
-            margin-top: 5p;
-            border-top: 2p solid #;
-            padding-top: 2p;
-        
+        .references {
+            margin-top: 50px;
+            border-top: 2px solid #000;
+            padding-top: 20px;
+        }
 
-        .references h2 
+        .references h2 {
             border: none;
-            margin-bottom: 2p;
-        
+            margin-bottom: 20px;
+        }
 
-        .reference-list 
+        .reference-list {
             list-style: none;
-            padding: ;
-        
+            padding: 0;
+        }
 
-        .reference-list li 
-            margin: p ;
-            padding-left: 2p;
+        .reference-list li {
+            margin: 10px 0;
+            padding-left: 20px;
             position: relative;
-        
+        }
 
-        .reference-list li:before 
+        .reference-list li:before {
             content: "[" counter(item) "]";
             counter-increment: item;
             position: absolute;
-            left: ;
+            left: 0;
             font-weight: bold;
-        
+        }
 
-        .reference-list ol 
+        .reference-list ol {
             counter-reset: item;
-        
+        }
 
-        .performance-note 
+        .performance-note {
             background: #f9f9f9;
-            border-left: 3p solid #;
-            padding: 5p;
-            margin: 2p ;
-            font-size: p;
-        
+            border-left: 3px solid #666;
+            padding: 15px;
+            margin: 20px 0;
+            font-size: 14px;
+        }
     </style>
 </head>
 <body>
     <div class="paper-header">
-        <h class="paper-title">Particle Swarm Optimization</h>
+        <h1 class="paper-title">Particle Swarm Optimization</h1>
         <p class="paper-subtitle">HumpDay Implementation Documentation</p>
     </div>
 
@@ -187,27 +187,27 @@
 
     <div class="abstract">
         <h3>Abstract</h3>
-        <p>Particle Swarm Optimization (PSO) is a population-based stochastic optimization technique inspired by the social behavior of bird flocking and fish schooling. Originally developed by Kennedy and Eberhart (995), PSO optimizes a problem by iteratively improving candidate solutions (particles) with regard to a given measure of quality. Each particle adjusts its position based on its own best-known position and the swarm's best-known position, guided by velocity vectors that balance eploration and eploitation.</p>
+        <p>Particle Swarm Optimization (PSO) is a population-based stochastic optimization technique inspired by the social behavior of bird flocking and fish schooling. Originally developed by Kennedy and Eberhart (1995), PSO optimizes a problem by iteratively improving candidate solutions (particles) with regard to a given measure of quality. Each particle adjusts its position based on its own best-known position and the swarm's best-known position, guided by velocity vectors that balance exploration and exploitation.</p>
     </div>
 
     <h2>Algorithm Description</h2>
 
-    <p>The Particle Swarm Optimization algorithm maintains a swarm of particles, where each particle $i$ has a position $mathbf_i$ and velocity $mathbfv_i$ in the $D$-dimensional search space. The algorithm updates these parameters according to the following equations:</p>
+    <p>The Particle Swarm Optimization algorithm maintains a swarm of particles, where each particle $i$ has a position $\mathbf{x}_i$ and velocity $\mathbf{v}_i$ in the $D$-dimensional search space. The algorithm updates these parameters according to the following equations:</p>
 
     <div class="mathematical-formulation">
         <p><strong>Velocity Update:</strong></p>
-        <p>$$mathbfv_i^t+ = wmathbfv_i^t + c_r_(mathbfp_i - mathbf_i^t) + c_2r_2(mathbfg - mathbf_i^t)$$</p>
+        <p>$$\mathbf{v}_i^{t+1} = w\mathbf{v}_i^t + c_1r_1(\mathbf{p}_i - \mathbf{x}_i^t) + c_2r_2(\mathbf{g} - \mathbf{x}_i^t)$$</p>
 
         <p><strong>Position Update:</strong></p>
-        <p>$$mathbf_i^t+ = mathbf_i^t + mathbfv_i^t+$$</p>
+        <p>$$\mathbf{x}_i^{t+1} = \mathbf{x}_i^t + \mathbf{v}_i^{t+1}$$</p>
 
         <p>where:</p>
         <ul>
             <li>$w$ is the inertia weight</li>
-            <li>$c_, c_2$ are acceleration coefficients (cognitive and social parameters)</li>
-            <li>$r_, r_2$ are random numbers in [,]</li>
-            <li>$mathbfp_i$ is the personal best position of particle $i$</li>
-            <li>$mathbfg$ is the global best position found by the swarm</li>
+            <li>$c_1, c_2$ are acceleration coefficients (cognitive and social parameters)</li>
+            <li>$r_1, r_2$ are random numbers in [0,1]</li>
+            <li>$\mathbf{p}_i$ is the personal best position of particle $i$</li>
+            <li>$\mathbf{g}$ is the global best position found by the swarm</li>
         </ul>
     </div>
 
@@ -224,8 +224,8 @@
         <tbody>
             <tr>
                 <td><strong>Original Algorithm</strong></td>
-                <td>Kennedy, J. & Eberhart, R. (995). Particle swarm optimization technique introduced as population-based stochastic optimization inspired by social behavior of bird flocking.</td>
-                <td><a href="https://doi.org/.9/ICNN.995.8898">Kennedy & Eberhart (995)</a></td>
+                <td>Kennedy, J. & Eberhart, R. (1995). Particle swarm optimization technique introduced as population-based stochastic optimization inspired by social behavior of bird flocking.</td>
+                <td><a href="https://doi.org/10.1109/ICNN.1995.488968">Kennedy & Eberhart (1995)</a></td>
             </tr>
             <tr>
                 <td><strong>Python Implementation</strong></td>
@@ -262,27 +262,27 @@
         <tbody>
             <tr>
                 <td>Swarm Size</td>
-                <td>min(, ma(5, 3×D))</td>
+                <td>min(40, max(15, 3×D))</td>
                 <td>Number of particles, scaled by problem dimension</td>
             </tr>
             <tr>
                 <td>Inertia Weight ($w$)</td>
-                <td>.9 → .</td>
+                <td>0.9 → 0.4</td>
                 <td>Decreasing linearly with iteration progress</td>
             </tr>
             <tr>
-                <td>Cognitive Coefficient ($c_$)</td>
-                <td>2.5 → .5</td>
+                <td>Cognitive Coefficient ($c_1$)</td>
+                <td>2.5 → 1.5</td>
                 <td>Decreasing emphasis on personal best</td>
             </tr>
             <tr>
                 <td>Social Coefficient ($c_2$)</td>
-                <td>.5 → 2.5</td>
+                <td>1.5 → 2.5</td>
                 <td>Increasing emphasis on global best</td>
             </tr>
             <tr>
                 <td>Velocity Clamping</td>
-                <td>±2% of search range</td>
+                <td>±20% of search range</td>
                 <td>Decreasing with iteration progress</td>
             </tr>
         </tbody>
@@ -291,15 +291,15 @@
     <div class="references">
         <h2>References</h2>
         <ol class="reference-list">
-            <li>Kennedy, J., & Eberhart, R. (995). Particle swarm optimization. <em>Proceedings of ICNN'95 - International Conference on Neural Networks</em>, , 92-98. IEEE.</li>
-            <li>Shi, Y., & Eberhart, R. (998). A modified particle swarm optimizer. <em>998 IEEE international conference on evolutionary computation proceedings</em>, 9-73. IEEE.</li>
-            <li>Clerc, M., & Kennedy, J. (22). The particle swarm-eplosion, stability, and convergence in a multidimensional comple space. <em>IEEE transactions on Evolutionary Computation</em>, (), 58-73.</li>
-            <li>Poli, R., Kennedy, J., & Blackwell, T. (27). Particle swarm optimization: an overview. <em>Swarm intelligence</em>, (), 33-57.</li>
+            <li>Kennedy, J., & Eberhart, R. (1995). Particle swarm optimization. <em>Proceedings of ICNN'95 - International Conference on Neural Networks</em>, 4, 1942-1948. IEEE.</li>
+            <li>Shi, Y., & Eberhart, R. (1998). A modified particle swarm optimizer. <em>1998 IEEE international conference on evolutionary computation proceedings</em>, 69-73. IEEE.</li>
+            <li>Clerc, M., & Kennedy, J. (2002). The particle swarm-explosion, stability, and convergence in a multidimensional complex space. <em>IEEE transactions on Evolutionary Computation</em>, 6(1), 58-73.</li>
+            <li>Poli, R., Kennedy, J., & Blackwell, T. (2007). Particle swarm optimization: an overview. <em>Swarm intelligence</em>, 1(1), 33-57.</li>
         </ol>
     </div>
 
-    <div style="margin-top: 5p; padding-top: 2p; border-top: p solid #ccc; tet-align: center; font-size: 2p; color: #;">
-        <p>Part of the HumpDay optimization library | <a href="../inde.html">Documentation</a> | <a href="https://github.com/microprediction/humpday">Source Code</a></p>
+    <div style="margin-top: 50px; padding-top: 20px; border-top: 1px solid #ccc; text-align: center; font-size: 12px; color: #666;">
+        <p>Part of the HumpDay optimization library | <a href="../index.html">Documentation</a> | <a href="https://github.com/microprediction/humpday">Source Code</a></p>
     </div>
 
     <!-- Load JavaScript for any interactive elements -->
@@ -307,14 +307,14 @@
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>
-    <script src="../js/modules/inde.js"></script>
+    <script src="../js/modules/index.js"></script>
     <script src="../js/algorithm-visualizer.js"></script>
 
     <script>
         // Initialize any interactive components if needed
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             console.log('Particle Swarm Optimization page loaded');
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -1,164 +1,184 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Pattern Search - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #f39c2;
+        .header {
+            background: #f39c12;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
+        .algorithm-description {
             background: #fef9e7;
-            border-left: p solid #f39c2;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+            border-left: 4px solid #f39c12;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Pattern Search (MATLAB/Custom)</h1>
+            <p>Direct Search with Coordinate Patterns</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,21 +186,21 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Pattern Search</strong> is a family of derivative-free optimization methods that eplore the search space using a structured pattern of points around the current best solution. These algorithms use a set of polling directions to systematically search for improvements, making them particularly effective for problems with discontinuities or noise where gradient information is unreliable.
+                <strong>Pattern Search</strong> is a family of derivative-free optimization methods that explore the search space using a structured pattern of points around the current best solution. These algorithms use a set of polling directions to systematically search for improvements, making them particularly effective for problems with discontinuities or noise where gradient information is unreliable.
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Pattern Search in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -197,40 +217,40 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td class="category">Algorithmic amily</td>
+                        <td class="category">Algorithmic Family</td>
                         <td>
                             <strong>Direct Search Methods</strong><br>
                             Generalized Pattern Search (GPS), Mesh Adaptive Direct Search<br>
                             Coordinate search with adaptive step sizes<br>
-                            <em>Developed: 95s-99s (Hooke-Jeeves, Torczon, etc.)</em>
+                            <em>Developed: 1950s-1990s (Hooke-Jeeves, Torczon, etc.)</em>
                         </td>
                         <td>
-                            <a href="https://epubs.siam.org/doi/book/.37/.978972" target="_blank" class="link-button paper">📖 Direct Search Book</a>
+                            <a href="https://epubs.siam.org/doi/book/10.1137/1.9781611971200" target="_blank" class="link-button paper">📖 Direct Search Book</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Reference Implementation</td>
                         <td>
-                            <strong>MATLAB Global Optimization Toolbo</strong><br>
+                            <strong>MATLAB Global Optimization Toolbox</strong><br>
                             patternsearch() function with multiple pattern types<br>
                             Also available in specialized direct search packages<br>
                             <em>Reference: MATLAB/Octave implementations</em>
                         </td>
                         <td>
-                            <a href="https://www.mathworks.com/help/gads/patternsearch.html" target="_blank" class="link-button info"> MATLAB Docs</a>
-                            <a href="https://github.com/PythonOptimizers/pysearch" target="_blank" class="link-button python"> PySearch</a>
+                            <a href="https://www.mathworks.com/help/gads/patternsearch.html" target="_blank" class="link-button info">🔍 MATLAB Docs</a>
+                            <a href="https://github.com/PythonOptimizers/pysearch" target="_blank" class="link-button python">🐍 PySearch</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">HumpDay Python Implementation</td>
+                        <td class="category">Humpday Python Wrapper</td>
                         <td>
                             <strong>Humpday Integration</strong><br>
                             Custom pattern search implementation<br>
                             Coordinate-based polling with adaptive mesh<br>
-                            <em>ile: humpday/optimizers/patternsearch.py</em>
+                            <em>File: humpday/optimizers/patternsearch.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Custom Implementation</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Custom Implementation</a>
                         </td>
                     </tr>
                     <tr>
@@ -238,22 +258,22 @@
                         <td>
                             <strong>Browser Implementation</strong><br>
                             JavaScript pattern search with coordinate polling<br>
-                            Adaptive mesh refinement and pattern epansion<br>
+                            Adaptive mesh refinement and pattern expansion<br>
                             <em>Class: PatternSearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Dependencies</td>
                         <td>
-                            <strong>Reference:</strong> MATLAB Global Optimization Toolbo<br>
+                            <strong>Reference:</strong> MATLAB Global Optimization Toolbox<br>
                             <strong>Humpday Python:</strong> numpy (custom implementation)<br>
                             <strong>Humpday JS:</strong> None (standalone port)
                         </td>
                         <td>
-                            <a href="https://www.mathworks.com/products/global-optimization.html" target="_blank" class="link-button info">📦 MATLAB Toolbo</a>
+                            <a href="https://www.mathworks.com/products/global-optimization.html" target="_blank" class="link-button info">📦 MATLAB Toolbox</a>
                         </td>
                     </tr>
                 </tbody>
@@ -263,13 +283,24 @@
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Discontinuous functions, noisy problems, constrained optimization</li>
-                    <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~5)</li>
-                    <li><strong>unction evaluations:</strong> Typically 2n evaluations per iteration</li>
+                    <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~50)</li>
+                    <li><strong>Function evaluations:</strong> Typically 2n evaluations per iteration</li>
                     <li><strong>Convergence:</strong> Reliable local convergence, mesh refinement guarantees</li>
-                    <li><strong>Robustness:</strong> Ecellent for problems where gradients don't eist</li>
+                    <li><strong>Robustness:</strong> Excellent for problems where gradients don't exist</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation against reference pattern search implementations in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing JavaScript vs MATLAB patternsearch() or custom Python</li>
+                    <li>🎯 Target: Similar convergence behavior and mesh adaptation</li>
+                    <li>📊 Metrics: Final objective values, mesh size evolution, polling efficiency</li>
+                    <li>🔧 Challenge: Multiple pattern search variants - need to specify which reference</li>
+                </ul>
+                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
@@ -278,12 +309,12 @@
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Pattern_search_(optimization)" target="_blank">Pattern Search Wikipedia</a></li>
                         <li><a href="https://www.mathworks.com/help/gads/patternsearch.html" target="_blank">MATLAB Pattern Search Documentation</a></li>
-                        <li><a href="https://epubs.siam.org/doi/book/.37/.978972" target="_blank">Introduction to Derivative-ree Optimization</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Pattern_search_methods" target="_blank">Pattern Search Methods Tutorial</a></li>
-                        <li><a href="https://link.springer.com/article/.7/B585997" target="_blank">Hooke-Jeeves Original Paper</a></li>
+                        <li><a href="https://epubs.siam.org/doi/book/10.1137/1.9781611971200" target="_blank">Introduction to Derivative-Free Optimization</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Pattern_search_methods" target="_blank">Pattern Search Methods Tutorial</a></li>
+                        <li><a href="https://link.springer.com/article/10.1007/BF01585997" target="_blank">Hooke-Jeeves Original Paper</a></li>
                     </ul>
 
-                    <h3> Algorithm Components</h3>
+                    <h3>🔬 Algorithm Components</h3>
                     <ul>
                         <li><strong>Mesh:</strong> Discrete set of points where function is evaluated</li>
                         <li><strong>Pattern:</strong> Set of directions defining search pattern</li>
@@ -294,55 +325,55 @@
 
                     <h3>📐 Pattern Types</h3>
                     <ul>
-                        <li><strong>Coordinate Patterns:</strong> ±eᵢ directions (ais-aligned)</li>
-                        <li><strong>Maimal Basis:</strong> 2n directions ensuring positive spanning</li>
-                        <li><strong>Minimal Basis:</strong> n+ directions forming simple</li>
+                        <li><strong>Coordinate Patterns:</strong> ±eᵢ directions (axis-aligned)</li>
+                        <li><strong>Maximal Basis:</strong> 2n directions ensuring positive spanning</li>
+                        <li><strong>Minimal Basis:</strong> n+1 directions forming simplex</li>
                         <li><strong>GPS Patterns:</strong> Generalized pattern search conforming patterns</li>
                         <li><strong>Custom Patterns:</strong> Problem-specific direction sets</li>
                     </ul>
 
                     <h3>⚙️ Pattern Search Variants</h3>
                     <ul>
-                        <li><strong>Hooke-Jeeves:</strong> Eploratory + pattern moves</li>
+                        <li><strong>Hooke-Jeeves:</strong> Exploratory + pattern moves</li>
                         <li><strong>Coordinate Search:</strong> Simple alternating coordinate directions</li>
                         <li><strong>GPS (Generalized Pattern Search):</strong> Theoretical framework</li>
                         <li><strong>MADS (Mesh Adaptive Direct Search):</strong> Dense direction sets</li>
                         <li><strong>GSS (Generating Set Search):</strong> Positive basis guarantee</li>
                     </ul>
 
-                    <h3> Convergence Theory</h3>
+                    <h3>🎯 Convergence Theory</h3>
                     <ul>
                         <li><strong>Clarke Stationarity:</strong> GPS converges to Clarke stationary points</li>
-                        <li><strong>Mesh Size Limit:</strong> lim inf Δₘ =  under standard conditions</li>
+                        <li><strong>Mesh Size Limit:</strong> lim inf Δₘ = 0 under standard conditions</li>
                         <li><strong>Sufficient Decrease:</strong> Armijo-like conditions for step acceptance</li>
                         <li><strong>Positive Spanning:</strong> Pattern directions must positively span ℝⁿ</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🚀 Applications</h3>
                     <ul>
                         <li><strong>Engineering Design:</strong> When objective function has discontinuities</li>
-                        <li><strong>Simulation Optimization:</strong> Noisy, epensive function evaluations</li>
+                        <li><strong>Simulation Optimization:</strong> Noisy, expensive function evaluations</li>
                         <li><strong>Control System Tuning:</strong> Parameter optimization with constraints</li>
-                        <li><strong>inancial Modeling:</strong> Portfolio optimization with discrete constraints</li>
+                        <li><strong>Financial Modeling:</strong> Portfolio optimization with discrete constraints</li>
                         <li><strong>Environmental Modeling:</strong> Parameter estimation in climate models</li>
                     </ul>
 
                     <h3>⚙️ Implementation Details</h3>
                     <ul>
-                        <li><strong>Initial Mesh Size:</strong> Δ₀ typically . or problem-scaled</li>
-                        <li><strong>Mesh Epansion:</strong> Δₖ₊₁ = τΔₖ where τ >  (often τ = 2)</li>
+                        <li><strong>Initial Mesh Size:</strong> Δ₀ typically 1.0 or problem-scaled</li>
+                        <li><strong>Mesh Expansion:</strong> Δₖ₊₁ = τΔₖ where τ > 1 (often τ = 2)</li>
                         <li><strong>Mesh Contraction:</strong> Δₖ₊₁ = Δₖ/τ when no improvement</li>
                         <li><strong>Polling Order:</strong> Opportunistic vs complete polling</li>
-                        <li><strong>Termination:</strong> Δₖ < tolerance or ma evaluations</li>
+                        <li><strong>Termination:</strong> Δₖ < tolerance or max evaluations</li>
                     </ul>
 
-                    <h3> When to Use Pattern Search</h3>
+                    <h3>💡 When to Use Pattern Search</h3>
                     <ul>
                         <li><strong>Discontinuous Objectives:</strong> Traditional methods fail on non-smooth functions</li>
-                        <li><strong>Epensive Evaluations:</strong> Systematic eploration reduces waste</li>
+                        <li><strong>Expensive Evaluations:</strong> Systematic exploration reduces waste</li>
                         <li><strong>Constrained Problems:</strong> Natural handling of bound constraints</li>
-                        <li><strong>Black-Bo unctions:</strong> No gradient or Hessian information available</li>
-                        <li><strong>Integer Variables:</strong> Can be adapted for mied-integer problems</li>
+                        <li><strong>Black-Box Functions:</strong> No gradient or Hessian information available</li>
+                        <li><strong>Integer Variables:</strong> Can be adapted for mixed-integer problems</li>
                     </ul>
                 </div>
             </div>
@@ -350,65 +381,65 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -238,7 +238,6 @@
                         </td>
                         <td>
                             <a href="https://www.mathworks.com/help/gads/patternsearch.html" target="_blank" class="link-button info">🔍 MATLAB Docs</a>
-                            <a href="https://github.com/PythonOptimizers/pysearch" target="_blank" class="link-button python">🐍 PySearch</a>
                         </td>
                     </tr>
                     <tr>
@@ -247,7 +246,7 @@
                             <strong>Humpday Integration</strong><br>
                             Custom pattern search implementation<br>
                             Coordinate-based polling with adaptive mesh<br>
-                            <em>File: humpday/optimizers/patternsearch.py</em>
+                            <em>File: humpday/optimizers/search_algorithms.py</em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Custom Implementation</a>
@@ -310,7 +309,6 @@
                         <li><a href="https://en.wikipedia.org/wiki/Pattern_search_(optimization)" target="_blank">Pattern Search Wikipedia</a></li>
                         <li><a href="https://www.mathworks.com/help/gads/patternsearch.html" target="_blank">MATLAB Pattern Search Documentation</a></li>
                         <li><a href="https://epubs.siam.org/doi/book/10.1137/1.9781611971200" target="_blank">Introduction to Derivative-Free Optimization</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Pattern_search_methods" target="_blank">Pattern Search Methods Tutorial</a></li>
                         <li><a href="https://link.springer.com/article/10.1007/BF01585997" target="_blank">Hooke-Jeeves Original Paper</a></li>
                     </ul>
 

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -1,164 +1,184 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Powell's Method - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #27ae;
+        .header {
+            background: #27ae60;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
-            background: #e8ff3;
-            border-left: p solid #27ae;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #e8f6f3;
+            border-left: 4px solid #27ae60;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Powell's Method (SciPy)</h1>
+            <p>Powell's Conjugate Direction Method</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,21 +186,21 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Powell's Method</strong> is a derivative-free optimization algorithm that builds a set of conjugate search directions. Developed by Michael J.D. Powell in the 9s, it's particularly effective for quadratic functions and doesn't require gradient information. The method iteratively optimizes along coordinate aes and then along constructed conjugate directions.
+                <strong>Powell's Method</strong> is a derivative-free optimization algorithm that builds a set of conjugate search directions. Developed by Michael J.D. Powell in the 1960s, it's particularly effective for quadratic functions and doesn't require gradient information. The method iteratively optimizes along coordinate axes and then along constructed conjugate directions.
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Powell in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -202,7 +222,7 @@
                             <strong>Michael J.D. Powell</strong><br>
                             Conjugate direction method for unconstrained optimization<br>
                             Derivative-free approach using line searches<br>
-                            <em>Published: 9</em>
+                            <em>Published: 1964</em>
                         </td>
                         <td>
                             <a href="https://en.wikipedia.org/wiki/Powell%27s_method" target="_blank" class="link-button info">📖 Wikipedia</a>
@@ -217,20 +237,20 @@
                             <em>Package: scipy</em>
                         </td>
                         <td>
-                            <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-powell.html" target="_blank" class="link-button python"> SciPy Docs</a>
-                            <a href="https://github.com/scipy/scipy/blob/main/scipy/optimize/_optimize.py" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-powell.html" target="_blank" class="link-button python">🐍 SciPy Docs</a>
+                            <a href="https://github.com/scipy/scipy/blob/main/scipy/optimize/_optimize.py" target="_blank" class="link-button python">🔍 Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">HumpDay Python Implementation</td>
+                        <td class="category">Humpday Python Wrapper</td>
                         <td>
                             <strong>Humpday Integration</strong><br>
                             Calls scipy.optimize.minimize(method='powell')<br>
                             Standardized interface for optimization contests<br>
-                            <em>ile: humpday/optimizers/scipyopt.py</em>
+                            <em>File: humpday/optimizers/scipyopt.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipyopt.py" target="_blank" class="link-button python"> Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipyopt.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -242,7 +262,7 @@
                             <em>Class: Powell</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
                         </td>
                     </tr>
                     <tr>
@@ -263,13 +283,23 @@
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Quadratic functions and smooth, unimodal problems</li>
-                    <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~2-5)</li>
-                    <li><strong>unction evaluations:</strong> Typically O(n²) evaluations per iteration</li>
-                    <li><strong>Convergence:</strong> Ecellent on quadratic functions, linear convergence</li>
+                    <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~20-50)</li>
+                    <li><strong>Function evaluations:</strong> Typically O(n²) evaluations per iteration</li>
+                    <li><strong>Convergence:</strong> Excellent on quadratic functions, linear convergence</li>
                     <li><strong>Robustness:</strong> Can be sensitive to poorly conditioned problems</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation against SciPy reference implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing JavaScript vs scipy.optimize.minimize(method='powell')</li>
+                    <li>🎯 Target: Perfect match or statistical equivalence on benchmark functions</li>
+                    <li>📊 Metrics: Convergence accuracy, function evaluations, solution quality</li>
+                </ul>
+                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
@@ -278,17 +308,17 @@
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Powell%27s_method" target="_blank">Powell's Method Wikipedia</a></li>
                         <li><a href="https://docs.scipy.org/doc/scipy/reference/optimize.html" target="_blank">SciPy Optimization Guide</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Powell%27s_method" target="_blank">Powell's Method Tutorial</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Powell%27s_method" target="_blank">Powell's Method Tutorial</a></li>
                         <li><a href="https://numerical.recipes/" target="_blank">Numerical Recipes (Chapter on Multidimensional Minimization)</a></li>
                         <li><a href="https://mathworld.wolfram.com/ConjugateDirectionMethod.html" target="_blank">Conjugate Direction Methods - Wolfram MathWorld</a></li>
                     </ul>
 
-                    <h3> Algorithm Theory</h3>
+                    <h3>🔬 Algorithm Theory</h3>
                     <ul>
                         <li><strong>Conjugate Directions:</strong> Method builds orthogonal search directions</li>
-                        <li><strong>Line Search:</strong> Uses golden section or Brent's method for D optimization</li>
+                        <li><strong>Line Search:</strong> Uses golden section or Brent's method for 1D optimization</li>
                         <li><strong>Direction Updates:</strong> Replaces oldest direction with new conjugate direction</li>
-                        <li><strong>Quadratic Convergence:</strong> inite termination on quadratic functions in n steps</li>
+                        <li><strong>Quadratic Convergence:</strong> Finite termination on quadratic functions in n steps</li>
                     </ul>
                 </div>
             </div>
@@ -296,65 +326,65 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -247,10 +247,10 @@
                             <strong>Humpday Integration</strong><br>
                             Calls scipy.optimize.minimize(method='powell')<br>
                             Standardized interface for optimization contests<br>
-                            <em>File: humpday/optimizers/scipyopt.py</em>
+                            <em>File: humpday/optimizers/scipy_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipyopt.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -308,10 +308,8 @@
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Powell%27s_method" target="_blank">Powell's Method Wikipedia</a></li>
                         <li><a href="https://docs.scipy.org/doc/scipy/reference/optimize.html" target="_blank">SciPy Optimization Guide</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Powell%27s_method" target="_blank">Powell's Method Tutorial</a></li>
                         <li><a href="https://numerical.recipes/" target="_blank">Numerical Recipes (Chapter on Multidimensional Minimization)</a></li>
-                        <li><a href="https://mathworld.wolfram.com/ConjugateDirectionMethod.html" target="_blank">Conjugate Direction Methods - Wolfram MathWorld</a></li>
-                    </ul>
+                        </ul>
 
                     <h3>🔬 Algorithm Theory</h3>
                     <ul>

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -247,7 +247,7 @@
                             <strong>Humpday Integration</strong><br>
                             Calls scipy.optimize.dual_annealing()<br>
                             Standardized interface for optimization contests<br>
-                            <em>File: humpday/optimizers/scipyopt.py</em>
+                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Wrapper Code</a>
@@ -311,8 +311,7 @@
                         <li><a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.dual_annealing.html" target="_blank">SciPy Dual Annealing</a></li>
                         <li><a href="https://www.cs.cmu.edu/afs/cs.cmu.edu/project/learn-43/lib/photoz/.g/web/glossary/anneal.html" target="_blank">CMU SA Tutorial</a></li>
                         <li><a href="http://mathworld.wolfram.com/SimulatedAnnealing.html" target="_blank">Wolfram MathWorld SA</a></li>
-                        <li><a href="https://towardsdatascience.com/simulated-annealing-from-scratch-in-python-7c4b3a0a5e9d" target="_blank">SA from Scratch Tutorial</a></li>
-                    </ul>
+                        </ul>
 
                     <h3>🔬 Algorithm Components</h3>
                     <ul>

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -1,164 +1,184 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Simulated Annealing - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #e7e22;
+        .header {
+            background: #e67e22;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
-            background: #fdebd;
-            border-left: p solid #e7e22;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #fdebd0;
+            border-left: 4px solid #e67e22;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Simulated Annealing (SciPy)</h1>
+            <p>Thermodynamic-Inspired Global Optimizer</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,21 +186,21 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Simulated Annealing</strong> is a probabilistic optimization technique inspired by the annealing process in metallurgy. Developed by Kirkpatrick, Gelatt, and Vecchi in 983, it allows for occasional uphill moves that decrease with a "temperature" parameter, enabling escape from local optima. The algorithm gradually reduces the temperature, converging to a global optimum.
+                <strong>Simulated Annealing</strong> is a probabilistic optimization technique inspired by the annealing process in metallurgy. Developed by Kirkpatrick, Gelatt, and Vecchi in 1983, it allows for occasional uphill moves that decrease with a "temperature" parameter, enabling escape from local optima. The algorithm gradually reduces the temperature, converging to a global optimum.
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Simulated Annealing in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -202,10 +222,10 @@
                             <strong>Kirkpatrick, Gelatt & Vecchi</strong><br>
                             Probabilistic optimization inspired by statistical mechanics<br>
                             Temperature-controlled acceptance of uphill moves<br>
-                            <em>Published: 983</em>
+                            <em>Published: 1983</em>
                         </td>
                         <td>
-                            <a href="https://science.sciencemag.org/content/22/598/7" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://science.sciencemag.org/content/220/4598/671" target="_blank" class="link-button paper">📄 Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -217,20 +237,20 @@
                             <em>Package: scipy</em>
                         </td>
                         <td>
-                            <a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.dual_annealing.html" target="_blank" class="link-button python"> SciPy Docs</a>
-                            <a href="https://github.com/scipy/scipy/blob/main/scipy/optimize/_dual_annealing.py" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.dual_annealing.html" target="_blank" class="link-button python">🐍 SciPy Docs</a>
+                            <a href="https://github.com/scipy/scipy/blob/main/scipy/optimize/_dual_annealing.py" target="_blank" class="link-button python">🔍 Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">HumpDay Python Implementation</td>
+                        <td class="category">Humpday Python Wrapper</td>
                         <td>
                             <strong>Humpday Integration</strong><br>
                             Calls scipy.optimize.dual_annealing()<br>
                             Standardized interface for optimization contests<br>
-                            <em>ile: humpday/optimizers/scipyopt.py</em>
+                            <em>File: humpday/optimizers/scipyopt.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Implementation</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -242,7 +262,7 @@
                             <em>Class: SimulatedAnnealing</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
                         </td>
                     </tr>
                     <tr>
@@ -264,12 +284,23 @@
                 <ul>
                     <li><strong>Best for:</strong> Discrete optimization, traveling salesman, combinatorial problems</li>
                     <li><strong>Dimensions:</strong> Scalable to moderate dimensions, works on any space</li>
-                    <li><strong>unction evaluations:</strong> Typically requires many evaluations for good results</li>
+                    <li><strong>Function evaluations:</strong> Typically requires many evaluations for good results</li>
                     <li><strong>Convergence:</strong> Asymptotic global convergence with proper cooling</li>
-                    <li><strong>Robustness:</strong> Ecellent at escaping local minima</li>
+                    <li><strong>Robustness:</strong> Excellent at escaping local minima</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation against SciPy dual_annealing reference implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing JavaScript vs scipy.optimize.dual_annealing()</li>
+                    <li>🎯 Target: Similar optimization performance and cooling behavior</li>
+                    <li>📊 Metrics: Final objective value, temperature schedule, acceptance rates</li>
+                    <li>🔧 Challenge: Matching advanced cooling schedules and neighborhood generation</li>
+                </ul>
+                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
@@ -278,17 +309,17 @@
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Simulated_annealing" target="_blank">Simulated Annealing Wikipedia</a></li>
                         <li><a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.dual_annealing.html" target="_blank">SciPy Dual Annealing</a></li>
-                        <li><a href="https://www.cs.cmu.edu/afs/cs.cmu.edu/project/learn-3/lib/photoz/.g/web/glossary/anneal.html" target="_blank">CMU SA Tutorial</a></li>
+                        <li><a href="https://www.cs.cmu.edu/afs/cs.cmu.edu/project/learn-43/lib/photoz/.g/web/glossary/anneal.html" target="_blank">CMU SA Tutorial</a></li>
                         <li><a href="http://mathworld.wolfram.com/SimulatedAnnealing.html" target="_blank">Wolfram MathWorld SA</a></li>
-                        <li><a href="https://towardsdatascience.com/simulated-annealing-from-scratch-in-python-7cb3aa5e9d" target="_blank">SA from Scratch Tutorial</a></li>
+                        <li><a href="https://towardsdatascience.com/simulated-annealing-from-scratch-in-python-7c4b3a0a5e9d" target="_blank">SA from Scratch Tutorial</a></li>
                     </ul>
 
-                    <h3> Algorithm Components</h3>
+                    <h3>🔬 Algorithm Components</h3>
                     <ul>
                         <li><strong>Temperature Schedule:</strong> T(k) = T₀ × α^k (geometric cooling)</li>
-                        <li><strong>Metropolis Criterion:</strong> P(accept) = ep(-ΔE/T) if ΔE > </li>
-                        <li><strong>Neighborhood unction:</strong> Local perturbation strategy</li>
-                        <li><strong>Initial Temperature:</strong> T₀ set to accept ~8% of moves initially</li>
+                        <li><strong>Metropolis Criterion:</strong> P(accept) = exp(-ΔE/T) if ΔE > 0</li>
+                        <li><strong>Neighborhood Function:</strong> Local perturbation strategy</li>
+                        <li><strong>Initial Temperature:</strong> T₀ set to accept ~80% of moves initially</li>
                         <li><strong>Stopping Criteria:</strong> Temperature threshold or equilibrium detection</li>
                     </ul>
 
@@ -296,44 +327,44 @@
                     <ul>
                         <li><strong>Linear:</strong> T(k) = T₀ - α × k</li>
                         <li><strong>Geometric:</strong> T(k) = T₀ × α^k (most common)</li>
-                        <li><strong>Logarithmic:</strong> T(k) = T₀ / log( + k)</li>
-                        <li><strong>Eponential:</strong> T(k) = T₀ × ep(-α × k)</li>
+                        <li><strong>Logarithmic:</strong> T(k) = T₀ / log(1 + k)</li>
+                        <li><strong>Exponential:</strong> T(k) = T₀ × exp(-α × k)</li>
                         <li><strong>Adaptive:</strong> Temperature adjusted based on acceptance rates</li>
                     </ul>
 
-                    <h3> SA Variants</h3>
+                    <h3>🎯 SA Variants</h3>
                     <ul>
                         <li><strong>Classical SA:</strong> Single-point neighborhood search</li>
-                        <li><strong>ast SA:</strong> Modified acceptance probability for faster cooling</li>
-                        <li><strong>Very ast SA:</strong> Cauchy distribution for neighbor generation</li>
+                        <li><strong>Fast SA:</strong> Modified acceptance probability for faster cooling</li>
+                        <li><strong>Very Fast SA:</strong> Cauchy distribution for neighbor generation</li>
                         <li><strong>Parallel SA:</strong> Multiple chains with periodic communication</li>
                         <li><strong>Hybrid SA:</strong> Combined with local search or GA</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🚀 Applications</h3>
                     <ul>
                         <li><strong>Traveling Salesman:</strong> Classic combinatorial optimization</li>
                         <li><strong>VLSI Design:</strong> Circuit layout and placement</li>
                         <li><strong>Scheduling:</strong> Job shop and resource allocation</li>
                         <li><strong>Image Processing:</strong> Image restoration and segmentation</li>
-                        <li><strong>Protein olding:</strong> Molecular conformation prediction</li>
+                        <li><strong>Protein Folding:</strong> Molecular conformation prediction</li>
                         <li><strong>Network Design:</strong> Communication and transportation networks</li>
                     </ul>
 
-                    <h3>📐 Theoretical oundation</h3>
+                    <h3>📐 Theoretical Foundation</h3>
                     <ul>
                         <li><strong>Statistical Mechanics:</strong> Boltzmann distribution and thermal equilibrium</li>
                         <li><strong>Markov Chains:</strong> Detailed balance and ergodicity</li>
                         <li><strong>Convergence Theory:</strong> Asymptotic convergence under logarithmic cooling</li>
-                        <li><strong>inite-Time Analysis:</strong> Approimation guarantees for practical schedules</li>
+                        <li><strong>Finite-Time Analysis:</strong> Approximation guarantees for practical schedules</li>
                     </ul>
 
                     <h3>⚙️ Parameter Tuning</h3>
                     <ul>
-                        <li><strong>Initial Temperature:</strong> Set to accept 8-95% of initial moves</li>
-                        <li><strong>Cooling Rate:</strong> α = .85-.95 for geometric schedule</li>
+                        <li><strong>Initial Temperature:</strong> Set to accept 80-95% of initial moves</li>
+                        <li><strong>Cooling Rate:</strong> α = 0.85-0.95 for geometric schedule</li>
                         <li><strong>Markov Chain Length:</strong> Number of moves at each temperature</li>
-                        <li><strong>inal Temperature:</strong> Stop when T < . × initial cost variance</li>
+                        <li><strong>Final Temperature:</strong> Stop when T < 0.01 × initial cost variance</li>
                     </ul>
                 </div>
             </div>
@@ -341,65 +372,65 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/tabu-search.html
+++ b/docs/algorithms/tabu-search.html
@@ -1,164 +1,197 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Tabu Search - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #8ead;
+        .header {
+            background: #8e44ad;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
-            background: #ffff;
-            border-left: p solid #8ead;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #f4f1ff;
+            border-left: 4px solid #8e44ad;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
 
+        .validation-pending {
+            background: #ffeaa7;
+            border: 1px solid #fdcb6e;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .validation-pending h3 {
+            margin-top: 0;
+            color: #d63031;
+        }
+
+        .memory-note {
+            background: #f0f4ff;
+            border: 1px solid #c7d2fe;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
+
+        .memory-note h3 {
+            margin-top: 0;
+            color: #3730a3;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Tabu Search (Custom)</h1>
+            <p>Memory-Based Local Search Metaheuristic</p>
+        </div>
 
         <div class="content">
             <div class="back-nav">
@@ -166,32 +199,32 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Tabu Search</strong> is a sophisticated local search metaheuristic that uses memory structures to guide the optimization process. Developed by red Glover in the 98s, it overcomes local optima by maintaining a "tabu list" of recently visited solutions or moves, forcing the algorithm to eplore new areas even when they temporarily worsen the objective function.
+                <strong>Tabu Search</strong> is a sophisticated local search metaheuristic that uses memory structures to guide the optimization process. Developed by Fred Glover in the 1980s, it overcomes local optima by maintaining a "tabu list" of recently visited solutions or moves, forcing the algorithm to explore new areas even when they temporarily worsen the objective function.
             </div>
 
             <div class="memory-note">
                 <h3>🧠 Memory-Guided Search</h3>
-                <p><strong>Tabu Search uses intelligent memory to guide eploration:</strong></p>
+                <p><strong>Tabu Search uses intelligent memory to guide exploration:</strong></p>
                 <ul>
-                    <li> <strong>Tabu List:</strong> Remembers recent moves to avoid cycling</li>
-                    <li>🚫 <strong>orbidden Moves:</strong> Prevents returning to recently visited solutions</li>
-                    <li>⭐ <strong>Aspiration Criteria:</strong> Override tabu status for eceptional solutions</li>
-                    <li> <strong>Strategic Oscillation:</strong> Systematically eplore around best-found solutions</li>
+                    <li>📋 <strong>Tabu List:</strong> Remembers recent moves to avoid cycling</li>
+                    <li>🚫 <strong>Forbidden Moves:</strong> Prevents returning to recently visited solutions</li>
+                    <li>⭐ <strong>Aspiration Criteria:</strong> Override tabu status for exceptional solutions</li>
+                    <li>🎯 <strong>Strategic Oscillation:</strong> Systematically explore around best-found solutions</li>
                 </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See Tabu Search in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -210,13 +243,13 @@
                     <tr>
                         <td class="category">Original Algorithm</td>
                         <td>
-                            <strong>red Glover</strong><br>
+                            <strong>Fred Glover</strong><br>
                             Memory-based local search metaheuristic<br>
-                            Intelligent eploration using tabu restrictions<br>
-                            <em>Published: 98-989</em>
+                            Intelligent exploration using tabu restrictions<br>
+                            <em>Published: 1986-1989</em>
                         </td>
                         <td>
-                            <a href="https://link.springer.com/article/.7/B973" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://link.springer.com/article/10.1007/BF01096763" target="_blank" class="link-button paper">📄 Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -228,7 +261,7 @@
                             <em>Reference: Academic literature and specialized libraries</em>
                         </td>
                         <td>
-                            <a href="https://github.com/topics/tabu-search" target="_blank" class="link-button python"> GitHub Eamples</a>
+                            <a href="https://github.com/topics/tabu-search" target="_blank" class="link-button python">🔍 GitHub Examples</a>
                         </td>
                     </tr>
                     <tr>
@@ -237,10 +270,10 @@
                             <strong>Humpday Tabu Search</strong><br>
                             Custom implementation with adaptive tabu tenure<br>
                             Continuous optimization variant with neighborhood generation<br>
-                            <em>ile: humpday/optimizers/tabusearch.py</em>
+                            <em>File: humpday/optimizers/tabusearch.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -252,7 +285,7 @@
                             <em>Class: TabuSearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript"> JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
                         </td>
                     </tr>
                     <tr>
@@ -263,7 +296,7 @@
                             <strong>Humpday JS:</strong> None (pure JavaScript)
                         </td>
                         <td>
-                            <span style="color: #95a5a;">✨ No eternal dependencies</span>
+                            <span style="color: #95a5a6;">✨ No external dependencies</span>
                         </td>
                     </tr>
                 </tbody>
@@ -272,14 +305,25 @@
             <div class="performance-notes">
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Combinatorial optimization, discrete problems, comple neighborhoods</li>
-                    <li><strong>Dimensions:</strong> Ecellent for discrete spaces, adaptable to continuous</li>
-                    <li><strong>unction evaluations:</strong> Moderate, depends on neighborhood size</li>
-                    <li><strong>Convergence:</strong> Good escape from local optima, strategic eploration</li>
-                    <li><strong>Robustness:</strong> Memory prevents cycling, handles comple constraint landscapes</li>
+                    <li><strong>Best for:</strong> Combinatorial optimization, discrete problems, complex neighborhoods</li>
+                    <li><strong>Dimensions:</strong> Excellent for discrete spaces, adaptable to continuous</li>
+                    <li><strong>Function evaluations:</strong> Moderate, depends on neighborhood size</li>
+                    <li><strong>Convergence:</strong> Good escape from local optima, strategic exploration</li>
+                    <li><strong>Robustness:</strong> Memory prevents cycling, handles complex constraint landscapes</li>
                 </ul>
             </div>
 
+            <div class="validation-pending">
+                <h3>⏳ Validation Status: PENDING</h3>
+                <p><strong>Validation of tabu search implementation in progress.</strong></p>
+                <ul>
+                    <li>📋 Test framework: Comparing against established tabu search behavior</li>
+                    <li>🎯 Target: Proper tabu list management and neighborhood exploration</li>
+                    <li>📊 Metrics: Solution quality, memory utilization, escape from local optima</li>
+                    <li>🔧 Reference: Classical tabu search literature and benchmarks</li>
+                </ul>
+                <p><em>Tabu search effectiveness measured by exploration quality and constraint adherence.</em></p>
+            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
@@ -287,17 +331,17 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Tabu_search" target="_blank">Tabu Search Wikipedia</a></li>
-                        <li><a href="https://link.springer.com/article/.7/B973" target="_blank">Tabu Search - Part I (Glover, 989)</a></li>
-                        <li><a href="https://link.springer.com/article/.7/B973" target="_blank">Tabu Search - Part II (Glover, 99)</a></li>
-                        <li><a href="https://www.springer.com/gp/book/97837578" target="_blank">Tabu Search Handbook (Glover & Laguna)</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Tabu_search" target="_blank">Tabu Search Tutorial</a></li>
+                        <li><a href="https://link.springer.com/article/10.1007/BF01096763" target="_blank">Tabu Search - Part I (Glover, 1989)</a></li>
+                        <li><a href="https://link.springer.com/article/10.1007/BF01097403" target="_blank">Tabu Search - Part II (Glover, 1990)</a></li>
+                        <li><a href="https://www.springer.com/gp/book/9781461375784" target="_blank">Tabu Search Handbook (Glover & Laguna)</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Tabu_search" target="_blank">Tabu Search Tutorial</a></li>
                     </ul>
 
-                    <h3> Core Components</h3>
+                    <h3>🔬 Core Components</h3>
                     <ul>
                         <li><strong>Current Solution:</strong> s ∈ S (current position in solution space)</li>
-                        <li><strong>Neighborhood:</strong> N(s) = s' | s' is reachable from s in one move</li>
-                        <li><strong>Tabu List:</strong> T = forbidden moves or solutions</li>
+                        <li><strong>Neighborhood:</strong> N(s) = {s' | s' is reachable from s in one move}</li>
+                        <li><strong>Tabu List:</strong> T = {forbidden moves or solutions}</li>
                         <li><strong>Tabu Tenure:</strong> Duration moves remain forbidden</li>
                         <li><strong>Aspiration Criteria:</strong> Conditions to override tabu restrictions</li>
                         <li><strong>Best Solution:</strong> s* = best solution found so far</li>
@@ -306,36 +350,36 @@
                     <h3>📐 Algorithm Structure</h3>
                     <ul>
                         <li><strong>Initialization:</strong> Start with initial solution s₀, empty tabu list T = ∅</li>
-                        <li><strong>Neighborhood Generation:</strong> Create candidate moves N(s)  T</li>
+                        <li><strong>Neighborhood Generation:</strong> Create candidate moves N(s) \ T</li>
                         <li><strong>Move Selection:</strong> Choose best non-tabu move (or aspiration override)</li>
-                        <li><strong>Tabu List Update:</strong> Add reverse move to T, remove epired entries</li>
+                        <li><strong>Tabu List Update:</strong> Add reverse move to T, remove expired entries</li>
                         <li><strong>Solution Update:</strong> Move to selected neighbor, update best if improved</li>
                         <li><strong>Termination:</strong> Stop based on iterations, time, or convergence</li>
                     </ul>
 
                     <h3>⚙️ Key Design Decisions</h3>
                     <ul>
-                        <li><strong>Tabu Tenure:</strong> ied (5-) vs adaptive vs random</li>
+                        <li><strong>Tabu Tenure:</strong> Fixed (5-10) vs adaptive vs random</li>
                         <li><strong>Tabu Structure:</strong> Moves vs solutions vs attributes</li>
                         <li><strong>Aspiration Criteria:</strong> Best solution, threshold, or frequency-based</li>
                         <li><strong>Neighborhood:</strong> Size vs quality trade-off</li>
-                        <li><strong>Diversification:</strong> Long-term memory for eploration</li>
+                        <li><strong>Diversification:</strong> Long-term memory for exploration</li>
                         <li><strong>Intensification:</strong> Return to promising regions</li>
                     </ul>
 
-                    <h3> Tabu Search Pseudocode</h3>
-                    <pre style="background: #f8f9fa; padding: 5p; border-radius: 8p; font-family: monospace;">
-function tabuSearch(initialSolution, maIterations):
+                    <h3>🎯 Tabu Search Pseudocode</h3>
+                    <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
+function tabuSearch(initialSolution, maxIterations):
     s = initialSolution
     bestSolution = s
     tabuList = []
 
-    for iter in  to maIterations:
+    for iter in 1 to maxIterations:
         neighborhood = generateNeighbors(s)
         candidateList = []
 
         for each neighbor in neighborhood:
-            move = getMoveromTo(s, neighbor)
+            move = getMoveFromTo(s, neighbor)
 
             if not isTabu(move, tabuList) or
                satisfiesAspiration(neighbor, bestSolution):
@@ -345,23 +389,23 @@ function tabuSearch(initialSolution, maIterations):
             break  // No valid moves
 
         // Select best candidate
-        (netSolution, bestMove) = selectBest(candidateList)
+        (nextSolution, bestMove) = selectBest(candidateList)
 
         // Update tabu list
         tabuList.add(reverseMove(bestMove), currentIteration)
-        removeEpiredMoves(tabuList, currentIteration)
+        removeExpiredMoves(tabuList, currentIteration)
 
-        // Move to net solution
-        s = netSolution
+        // Move to next solution
+        s = nextSolution
         if f(s) < f(bestSolution):
             bestSolution = s
 
     return bestSolution
                     </pre>
 
-                    <h3> Tabu Search Variants</h3>
+                    <h3>🔧 Tabu Search Variants</h3>
                     <ul>
-                        <li><strong>Simple Tabu Search:</strong> Basic tabu list with fied tenure</li>
+                        <li><strong>Simple Tabu Search:</strong> Basic tabu list with fixed tenure</li>
                         <li><strong>Reactive Tabu Search:</strong> Adaptive tabu tenure based on search history</li>
                         <li><strong>Robust Tabu Search:</strong> Multiple tabu lists and escape mechanisms</li>
                         <li><strong>Parallel Tabu Search:</strong> Multiple concurrent searches</li>
@@ -369,31 +413,31 @@ function tabuSearch(initialSolution, maIterations):
                         <li><strong>Granular Tabu Search:</strong> Restrict neighborhoods for large problems</li>
                     </ul>
 
-                    <h3> Memory Types</h3>
+                    <h3>🎯 Memory Types</h3>
                     <ul>
                         <li><strong>Short-Term (Recency):</strong> Tabu list preventing recent moves</li>
-                        <li><strong>Medium-Term (requency):</strong> Track frequently used moves/attributes</li>
-                        <li><strong>Long-Term (Diversification):</strong> Guide search to uneplored regions</li>
+                        <li><strong>Medium-Term (Frequency):</strong> Track frequently used moves/attributes</li>
+                        <li><strong>Long-Term (Diversification):</strong> Guide search to unexplored regions</li>
                         <li><strong>Strategic (Intensification):</strong> Return to promising solution regions</li>
                     </ul>
 
-                    <h3> Applications</h3>
+                    <h3>🚀 Applications</h3>
                     <ul>
                         <li><strong>Vehicle Routing:</strong> TSP, VRP, and delivery optimization</li>
                         <li><strong>Scheduling:</strong> Job shop, flow shop, and timetabling</li>
-                        <li><strong>acility Location:</strong> Warehouse and service center placement</li>
-                        <li><strong>Graph Coloring:</strong> requency assignment and conflict resolution</li>
-                        <li><strong>Portfolio Selection:</strong> inancial optimization with constraints</li>
+                        <li><strong>Facility Location:</strong> Warehouse and service center placement</li>
+                        <li><strong>Graph Coloring:</strong> Frequency assignment and conflict resolution</li>
+                        <li><strong>Portfolio Selection:</strong> Financial optimization with constraints</li>
                         <li><strong>VLSI Design:</strong> Circuit placement and routing</li>
                     </ul>
 
-                    <h3> Tabu Search Philosophy</h3>
+                    <h3>💡 Tabu Search Philosophy</h3>
                     <ul>
-                        <li><strong>Aggressive Eploration:</strong> Accept worse solutions to escape local optima</li>
+                        <li><strong>Aggressive Exploration:</strong> Accept worse solutions to escape local optima</li>
                         <li><strong>Intelligent Memory:</strong> Use history to guide future decisions</li>
                         <li><strong>Strategic Oscillation:</strong> Balance intensification and diversification</li>
-                        <li><strong>leible ramework:</strong> Adapt to problem-specific structures</li>
-                        <li><strong>No Randomness Required:</strong> Deterministic yet effective eploration</li>
+                        <li><strong>Flexible Framework:</strong> Adapt to problem-specific structures</li>
+                        <li><strong>No Randomness Required:</strong> Deterministic yet effective exploration</li>
                     </ul>
 
                     <h3>⚠️ Implementation Challenges</h3>
@@ -402,7 +446,7 @@ function tabuSearch(initialSolution, maIterations):
                         <li><strong>Tabu Tenure:</strong> Too short (cycling) vs too long (over-restriction)</li>
                         <li><strong>Memory Management:</strong> Efficient data structures for large problems</li>
                         <li><strong>Parameter Tuning:</strong> Problem-dependent parameter sensitivity</li>
-                        <li><strong>Aspiration Criteria:</strong> Balancing eploration vs eploitation</li>
+                        <li><strong>Aspiration Criteria:</strong> Balancing exploration vs exploitation</li>
                     </ul>
                 </div>
             </div>
@@ -410,65 +454,65 @@ function tabuSearch(initialSolution, maIterations):
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/tabu-search.html
+++ b/docs/algorithms/tabu-search.html
@@ -334,8 +334,7 @@
                         <li><a href="https://link.springer.com/article/10.1007/BF01096763" target="_blank">Tabu Search - Part I (Glover, 1989)</a></li>
                         <li><a href="https://link.springer.com/article/10.1007/BF01097403" target="_blank">Tabu Search - Part II (Glover, 1990)</a></li>
                         <li><a href="https://www.springer.com/gp/book/9781461375784" target="_blank">Tabu Search Handbook (Glover & Laguna)</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Tabu_search" target="_blank">Tabu Search Tutorial</a></li>
-                    </ul>
+                        </ul>
 
                     <h3>🔬 Core Components</h3>
                     <ul>

--- a/docs/algorithms/uobyqa-pdfo.html
+++ b/docs/algorithms/uobyqa-pdfo.html
@@ -1,21 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
-    <title>UOBYQA (PDO) - HumpDay Optimization</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>UOBYQA (PDFO) - HumpDay Optimization</title>
     <link rel="stylesheet" href="../academic.css">
 </head>
 <body>
     <nav class="breadcrumb">
-        <a href="../inde.html">HumpDay</a> >
+        <a href="../index.html">HumpDay</a> >
         <a href="../contest.html">Contest</a> >
         <span>UOBYQA</span>
     </nav>
 
     <div class="container">
-        <h>UOBYQA (PDO)</h>
-        <h2>Unconstrained Optimization BY Quadratic Approimation</h2>
+        <h1>UOBYQA (PDFO)</h1>
+        <h2>Unconstrained Optimization BY Quadratic Approximation</h2>
 
         <div class="algorithm-meta">
             <div class="meta-grid">
@@ -23,7 +23,7 @@
                     <strong>Author:</strong> M.J.D. Powell
                 </div>
                 <div class="meta-item">
-                    <strong>Year:</strong> 22
+                    <strong>Year:</strong> 2002
                 </div>
                 <div class="meta-item">
                     <strong>Type:</strong> Model-based derivative-free
@@ -36,21 +36,21 @@
 
         <section>
             <h3>Overview</h3>
-            <p>UOBYQA is a derivative-free optimization algorithm that constructs quadratic models using interpolation. It belongs to the PRIMA (Powell's Recent Interpolation Methods) family and is particularly effective for smooth, small-scale optimization problems where derivatives are not available or epensive to compute.</p>
+            <p>UOBYQA is a derivative-free optimization algorithm that constructs quadratic models using interpolation. It belongs to the PRIMA (Powell's Recent Interpolation Methods) family and is particularly effective for smooth, small-scale optimization problems where derivatives are not available or expensive to compute.</p>
         </section>
 
         <section>
-            <h3>Mathematical oundation</h3>
+            <h3>Mathematical Foundation</h3>
             <p>The algorithm constructs quadratic models of the objective function using interpolation points:</p>
             <div class="math-block">
-                m<sub>k</sub>() = a + g<sup>T</sup> + ½<sup>T</sup>G
+                m<sub>k</sub>(x) = a + g<sup>T</sup>x + ½x<sup>T</sup>Gx
             </div>
             <p>where the model is built from function values at carefully chosen interpolation points within a trust region of radius ρ.</p>
         </section>
 
         <section>
             <h3>Algorithm Characteristics</h3>
-            <h>Strengths:</h>
+            <h4>Strengths:</h4>
             <ul>
                 <li>Mathematically rigorous convergence guarantees</li>
                 <li>Efficient for smooth, well-behaved functions</li>
@@ -58,9 +58,9 @@
                 <li>Automatic trust region management</li>
             </ul>
 
-            <h>Limitations:</h>
+            <h4>Limitations:</h4>
             <ul>
-                <li>Scales poorly with dimension (best for n ≤ 5)</li>
+                <li>Scales poorly with dimension (best for n ≤ 50)</li>
                 <li>Sensitive to noise in function evaluations</li>
                 <li>Requires O(n²) interpolation points</li>
                 <li>May struggle with highly multimodal functions</li>
@@ -71,44 +71,44 @@
             <h3>Implementation Details</h3>
             <p>Our HumpDay implementation includes:</p>
             <ul>
-                <li><strong>Python:</strong> <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L" target="_blank">Pure Python implementation</a></li>
+                <li><strong>Python:</strong> <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L16" target="_blank">Pure Python implementation</a></li>
                 <li><strong>JavaScript:</strong> <a href="../js/optimizers.js" target="_blank">Browser-compatible version</a></li>
-                <li><strong>Validation:</strong> Cross-validated against <a href="https://www.pdfo.net/" target="_blank">PDO reference</a></li>
+                <li><strong>Validation:</strong> Cross-validated against <a href="https://www.pdfo.net/" target="_blank">PDFO reference</a></li>
             </ul>
         </section>
 
         <section>
             <h3>References</h3>
             <div class="references">
-                <p><strong>Primary Paper:</strong> Powell, M.J.D. (22). "UOBYQA: unconstrained optimization by quadratic approimation." Mathematical Programming, 92(3), 555-582. <a href="https://doi.org/.7/s729" target="_blank">[DOI]</a></p>
+                <p><strong>Primary Paper:</strong> Powell, M.J.D. (2002). "UOBYQA: unconstrained optimization by quadratic approximation." Mathematical Programming, 92(3), 555-582. <a href="https://doi.org/10.1007/s101070100290" target="_blank">[DOI]</a></p>
 
-                <p><strong>Reference Implementation:</strong> <a href="https://www.pdfo.net/" target="_blank">PDO - Powell's Derivative-ree Optimization solvers</a></p>
+                <p><strong>Reference Implementation:</strong> <a href="https://www.pdfo.net/" target="_blank">PDFO - Powell's Derivative-Free Optimization solvers</a></p>
 
                 <p><strong>Additional Resources:</strong></p>
                 <ul>
-                    <li><a href="https://ariv.org/abs/232.32" target="_blank">PDO: A Cross-Platform Package for Powell's Derivative-ree Optimization Solvers</a></li>
-                    <li><a href="https://github.com/pdfo/pdfo" target="_blank">PDO GitHub Repository</a></li>
+                    <li><a href="https://arxiv.org/abs/2302.13246" target="_blank">PDFO: A Cross-Platform Package for Powell's Derivative-Free Optimization Solvers</a></li>
+                    <li><a href="https://github.com/pdfo/pdfo" target="_blank">PDFO GitHub Repository</a></li>
                 </ul>
             </div>
         </section>
 
         <section>
-            <h3>Usage Eample</h3>
+            <h3>Usage Example</h3>
             <div class="code-block">
                 <pre><code>from humpday import minimize
 
 # Optimize a simple quadratic function
-def objective():
-    return sum((i - .3)**2 for i in )
+def objective(x):
+    return sum((xi - 0.3)**2 for xi in x)
 
 # Use UOBYQA via HumpDay interface
 result = minimize(objective,
-                 =[., .2],
+                 x0=[0.1, 0.2],
                  method='PRIMA_UOBYQA',
-                 options='mafev': )
+                 options={'maxfev': 100})
 
-print(f"Optimum: result.")
-print(f"Value: result.fun")</code></pre>
+print(f"Optimum: {result.x}")
+print(f"Value: {result.fun}")</code></pre>
             </div>
         </section>
 

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -1,170 +1,170 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UT-8">
-    <meta name="viewport" content="width=device-width, initial-scale=.">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>UOBYQA (Prima) - Implementation Details</title>
     <style>
-        body 
+        body {
             font-family: 'Georgia', 'Times New Roman', serif;
-            margin: ;
-            padding: 2p;
+            margin: 0;
+            padding: 20px;
             background: #f8f9fa;
-            color: #2c3e5;
-        
+            color: #2c3e50;
+        }
 
-        .container 
-            ma-width: p;
-            margin:  auto;
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
             background: white;
-            border-radius: 5p;
-            bo-shadow:  2p p rgba(,,,.);
+            border-radius: 15px;
+            box-shadow: 0 20px 40px rgba(0,0,0,0.1);
             overflow: hidden;
-        
+        }
 
-        .header 
-            background: #2c3e5;
+        .header {
+            background: #2c3e50;
             color: white;
-            padding: 3p;
-            tet-align: center;
-        
+            padding: 30px;
+            text-align: center;
+        }
 
-        .header h 
-            margin:   p ;
+        .header h1 {
+            margin: 0 0 10px 0;
             font-size: 2.2em;
-        
+        }
 
-        .header p 
-            margin: ;
-            font-size: .em;
-            opacity: .9;
-        
+        .header p {
+            margin: 0;
+            font-size: 1.1em;
+            opacity: 0.9;
+        }
 
-        .content 
-            padding: p;
-        
+        .content {
+            padding: 40px;
+        }
 
-        .implementation-table 
-            width: %;
+        .implementation-table {
+            width: 100%;
             border-collapse: collapse;
-            margin: 3p ;
-            border-radius: p;
+            margin: 30px 0;
+            border-radius: 10px;
             overflow: hidden;
-            bo-shadow:  p 8p rgba(,,,.);
-        
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
 
-        .implementation-table th 
-            background: #395e;
+        .implementation-table th {
+            background: #34495e;
             color: white;
-            padding: 5p;
-            tet-align: left;
-            font-weight: ;
-        
+            padding: 15px;
+            text-align: left;
+            font-weight: 600;
+        }
 
-        .implementation-table td 
-            padding: 5p;
-            border-bottom: p solid #eee;
+        .implementation-table td {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
             vertical-align: top;
-        
+        }
 
-        .implementation-table tr:hover 
+        .implementation-table tr:hover {
             background: #f8f9fa;
-        
+        }
 
-        .implementation-table .category 
-            font-weight: ;
-            color: #395e;
-            background: #ecff;
-        
+        .implementation-table .category {
+            font-weight: 600;
+            color: #34495e;
+            background: #ecf0f1;
+        }
 
-        .link-button 
+        .link-button {
             display: inline-block;
-            padding: 8p p;
-            background: #398db;
+            padding: 8px 16px;
+            background: #3498db;
             color: white;
-            tet-decoration: none;
-            border-radius: p;
-            font-size: .9em;
-            margin: 2p p;
-            transition: background .2s;
-        
+            text-decoration: none;
+            border-radius: 4px;
+            font-size: 0.9em;
+            margin: 2px 4px;
+            transition: background 0.2s;
+        }
 
-        .link-button:hover 
-            background: #298b9;
-        
+        .link-button:hover {
+            background: #2980b9;
+        }
 
-        .link-button.paper  background: #e7c3c; 
-        .link-button.python  background: #27ae; 
-        .link-button.javascript  background: #f39c2; 
-        .link-button.info  background: #9b59b; 
+        .link-button.paper { background: #e74c3c; }
+        .link-button.python { background: #27ae60; }
+        .link-button.javascript { background: #f39c12; }
+        .link-button.info { background: #9b59b6; }
 
-        .algorithm-description 
-            background: #e8ff3;
-            border-left: p solid #27ae;
-            padding: 2p;
-            border-radius: 5p;
-            margin: 2p ;
-        
+        .algorithm-description {
+            background: #e8f6f3;
+            border-left: 4px solid #27ae60;
+            padding: 20px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
 
-        .back-nav 
-            margin-bottom: 2p;
-        
+        .back-nav {
+            margin-bottom: 20px;
+        }
 
-        .back-nav a 
-            color: #398db;
-            tet-decoration: none;
-            font-size: .em;
-        
+        .back-nav a {
+            color: #3498db;
+            text-decoration: none;
+            font-size: 1.1em;
+        }
 
-        .back-nav a:hover 
-            tet-decoration: underline;
-        
+        .back-nav a:hover {
+            text-decoration: underline;
+        }
 
-        .performance-notes 
+        .performance-notes {
             background: #fff3cd;
-            border: p solid #ffc7;
-            border-radius: 8p;
-            padding: 5p;
-            margin: 2p ;
-        
+            border: 1px solid #ffc107;
+            border-radius: 8px;
+            padding: 15px;
+            margin: 20px 0;
+        }
 
-        .performance-notes h3 
-            margin-top: ;
-            color: #85;
-        
+        .performance-notes h3 {
+            margin-top: 0;
+            color: #856404;
+        }
 
-        .more-section 
-            margin-top: 3p;
-            border-top: 2p solid #ecff;
-            padding-top: 2p;
-        
+        .more-section {
+            margin-top: 30px;
+            border-top: 2px solid #ecf0f1;
+            padding-top: 20px;
+        }
 
-        .more-toggle 
-            background: #398db;
+        .more-toggle {
+            background: #3498db;
             color: white;
             border: none;
-            padding: p 2p;
-            border-radius: p;
+            padding: 10px 20px;
+            border-radius: 4px;
             cursor: pointer;
-            font-size: em;
-        
+            font-size: 1em;
+        }
 
-        .more-toggle:hover 
-            background: #298b9;
-        
+        .more-toggle:hover {
+            background: #2980b9;
+        }
 
-        .more-content 
+        .more-content {
             display: none;
-            margin-top: 2p;
-        
+            margin-top: 20px;
+        }
     </style>
 </head>
 <body>
     <div class="container">
         <div class="header">
-            <h>UOBYQA (PDO)</h>
-            <p>Unconstrained Optimization BY Quadratic Approimation</p>
+            <h1>UOBYQA (PDFO)</h1>
+            <p>Unconstrained Optimization BY Quadratic Approximation</p>
         </div>
 
         <div class="content">
@@ -178,16 +178,16 @@
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
                 <p>See UOBYQA in action on 3D optimization surfaces:</p>
-                <div id="algorithmDemo" style="width: %; height: p; border: p solid #ddd; border-radius: p; margin: 5p ; position: relative; background: #fafafa;">
-                    <div id="loadingMessage" style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center; color: #; z-inde: ; background: rgba(255,255,255,.9); padding: 2p; border-radius: p;">
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
                         <p>Loading 3D visualization...</p>
-                        <p style="font-size: .9em;">Requires WebGL support</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
                     </div>
                 </div>
-                <div id="visualizationControls" style="background: #f8f9fa; padding: 5p; border: p solid #ddd; border-radius: p; margin-top: p;">
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
                     <!-- Controls will be inserted here by the visualizer -->
                 </div>
-                <p style="font-size: .9em; color: #; margin-top: p;">
+                <p style="font-size: 0.9em; color: #666; margin-top: 10px;">
                     <strong>Instructions:</strong> Choose a test function and algorithm, then click Start to watch the step-by-step optimization process.
                 </p>
             </div>
@@ -209,35 +209,35 @@
                             <strong>M.J.D. Powell</strong><br>
                             Trust-region method using quadratic interpolation models<br>
                             Derivative-free optimization for unconstrained problems<br>
-                            <em>Published: 22</em>
+                            <em>Published: 2002</em>
                         </td>
                         <td>
-                            <a href="https://www.optimization-online.org/DB_HTML/29/2/29.html" target="_blank" class="link-button paper">📄 Paper</a>
+                            <a href="https://www.optimization-online.org/DB_HTML/2009/12/2490.html" target="_blank" class="link-button paper">📄 Paper</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Reference Package</td>
                         <td>
-                            <strong>PDO (Python Derivative-ree Optimization)</strong><br>
-                            Wraps Powell's original ortran implementation<br>
+                            <strong>PDFO (Python Derivative-Free Optimization)</strong><br>
+                            Wraps Powell's original Fortran implementation<br>
                             Authoritative implementation with numerical robustness<br>
                             <em>Package: pdfo</em>
                         </td>
                         <td>
-                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">📦 PDO</a>
-                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python"> Source</a>
+                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">📦 PDFO</a>
+                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python">🐍 Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">HumpDay Python Implementation</td>
+                        <td class="category">Humpday Python Wrapper</td>
                         <td>
                             <strong>Humpday Integration</strong><br>
-                            Calls PDO's UOBYQA implementation<br>
+                            Calls PDFO's UOBYQA implementation<br>
                             Standardized interface for optimization contests<br>
-                            <em>ile: humpday/optimizers/prima_algorithms.py</em>
+                            <em>File: humpday/optimizers/prima_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python"> Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -249,13 +249,13 @@
                             <em>Class: PRIMA_UOBYQA</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript"> JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Dependencies</td>
                         <td>
-                            <strong>Reference:</strong> PDO package (wraps Powell's ortran)<br>
+                            <strong>Reference:</strong> PDFO package (wraps Powell's Fortran)<br>
                             <strong>Humpday Python:</strong> pdfo, numpy<br>
                             <strong>Humpday JS:</strong> None (standalone port)
                         </td>
@@ -270,23 +270,23 @@
                 <h3>🏁 Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Smooth, unimodal functions with moderate noise tolerance</li>
-                    <li><strong>Dimensions:</strong> Works well up to ~5 dimensions</li>
-                    <li><strong>unction evaluations:</strong> Typically requires O(n²) evaluations for n dimensions</li>
-                    <li><strong>Convergence:</strong> ast local convergence on quadratic-like functions</li>
+                    <li><strong>Dimensions:</strong> Works well up to ~50 dimensions</li>
+                    <li><strong>Function evaluations:</strong> Typically requires O(n²) evaluations for n dimensions</li>
+                    <li><strong>Convergence:</strong> Fast local convergence on quadratic-like functions</li>
                     <li><strong>Robustness:</strong> Handles discontinuous derivatives but sensitive to high noise</li>
                 </ul>
             </div>
 
-            <div class="performance-notes" style="background: #dedda; border-color: #27ae;">
-                <h3>✅ Validation Results: PERECT MATCH vs PDO Reference</h3>
-                <p><strong>JavaScript implementation successfully matches PDO reference implementation:</strong></p>
+            <div class="performance-notes" style="background: #d4edda; border-color: #27ae60;">
+                <h3>✅ Validation Results: PERFECT MATCH vs PDFO Reference</h3>
+                <p><strong>JavaScript implementation successfully matches PDFO reference implementation:</strong></p>
                 <ul>
-                    <li><strong>2D Sphere unction:</strong> Both PDO and JavaScript achieve <code>f = .</code> </li>
-                    <li><strong>3D Sphere unction:</strong> Both PDO and JavaScript achieve <code>f = .</code> </li>
-                    <li><strong>Efficiency:</strong> JavaScript uses fewer function evaluations (2 vs 7, 7 vs 2)</li>
+                    <li><strong>2D Sphere Function:</strong> Both PDFO and JavaScript achieve <code>f = 0.000000</code> 🎯</li>
+                    <li><strong>3D Sphere Function:</strong> Both PDFO and JavaScript achieve <code>f = 0.000000</code> 🎯</li>
+                    <li><strong>Efficiency:</strong> JavaScript uses fewer function evaluations (12 vs 17, 17 vs 21)</li>
                     <li><strong>Success Rate:</strong> 2/3 perfect matches on test suite</li>
                 </ul>
-                <p><em>Test performed: 22-5-2 using PDO vs JavaScript PRIMA_UOBYQA implementation</em></p>
+                <p><em>Test performed: 2026-05-21 using PDFO vs JavaScript PRIMA_UOBYQA implementation</em></p>
             </div>
 
             <div class="more-section">
@@ -295,9 +295,9 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/NEWUOA" target="_blank">UOBYQA/NEWUOA Wikipedia</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/inde.php/Trust_region_methods" target="_blank">Trust Region Methods Overview</a></li>
-                        <li><a href="https://www.pdfo.net/docs/" target="_blank">PDO Documentation</a></li>
-                        <li><a href="https://citeseer.ist.psu.edu/document?repid=rep&type=pdf&doi=aff7eb2bc9bdc3e97b3a7aba7b3b8" target="_blank">Powell's Original UOBYQA Paper</a></li>
+                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Trust_region_methods" target="_blank">Trust Region Methods Overview</a></li>
+                        <li><a href="https://www.pdfo.net/docs/" target="_blank">PDFO Documentation</a></li>
+                        <li><a href="https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=10a1f4f7eb2b46c09bdc3e97b3a17a6b0a47b3b8" target="_blank">Powell's Original UOBYQA Paper</a></li>
                         <li><a href="https://ccom.ucsd.edu/~pcoleman/powellopt.pdf" target="_blank">Powell's Optimization Methods Tutorial</a></li>
                     </ul>
                 </div>
@@ -306,65 +306,65 @@
     </div>
 
     <script>
-        function toggleMore() 
+        function toggleMore() {
             const content = document.getElementById('moreContent');
             const button = document.querySelector('.more-toggle');
 
-            if (content.style.display === 'none' || content.style.display === '') 
+            if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.tetContent = '📚 Less Resources';
-             else 
+                button.textContent = '📚 Less Resources';
+            } else {
                 content.style.display = 'none';
-                button.tetContent = '📚 More Resources';
-            
+                button.textContent = '📚 More Resources';
+            }
         // Initialize 3D visualization when page loads
-        document.addEventListener('DOMContentLoaded', function() 
+        document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer
             const optimizersScript = document.createElement('script');
-            optimizersScript.src = '../js/modules/inde.js';
-            optimizersScript.onload = function() 
+            optimizersScript.src = '../js/modules/index.js';
+            optimizersScript.onload = function() {
                 // Load algorithm visualizer after optimizers are loaded
                 const script = document.createElement('script');
                 script.src = '../js/algorithm-visualizer.js';
-                script.onload = function() 
+                script.onload = function() {
                     // Check for WebGL support
-                    function webglAvailable() 
-                        try 
+                    function webglAvailable() {
+                        try {
                             const canvas = document.createElement('canvas');
-                            return !!(window.WebGLRenderingContet && canvas.getContet('webgl'));
-                         catch (e) 
+                            return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                        } catch (e) {
                             return false;
-                        
-                    
+                        }
+                    }
 
-                    if (webglAvailable()) 
-                        const visualizer = new AlgorithmVisualizer('algorithmDemo', 
-                            onReady: () => 
+                    if (webglAvailable()) {
+                        const visualizer = new AlgorithmVisualizer('algorithmDemo', {
+                            onReady: () => {
                                 // Clear loading message once visualization is ready
                                 const loadingMsg = document.getElementById('loadingMessage');
-                                if (loadingMsg) 
+                                if (loadingMsg) {
                                     loadingMsg.style.display = 'none';
-                                
-                            
-                        );
-                     else 
+                                }
+                            }
+                        });
+                    } else {
                         document.getElementById('loadingMessage').innerHTML =
-                            '<h>WebGL Not Supported</h>' +
+                            '<h4>WebGL Not Supported</h4>' +
                             '<p>Your browser does not support WebGL for 3D visualization.</p>' +
-                            '<p>Try a modern browser like Chrome, irefo, or Safari.</p>';
-                    
-                ;
-                script.onerror = function() 
+                            '<p>Try a modern browser like Chrome, Firefox, or Safari.</p>';
+                    }
+                };
+                script.onerror = function() {
                     document.getElementById('algorithmDemo').innerHTML =
-                        '<div style="position: absolute; top: 5%; left: 5%; transform: translate(-5%, -5%); tet-align: center;">' +
-                        '<h>Visualization Unavailable</h>' +
+                        '<div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center;">' +
+                        '<h4>Visualization Unavailable</h4>' +
                         '<p>Could not load 3D visualization component.</p>' +
                         '</div>';
-                ;
+                };
                 document.head.appendChild(script);
-            ;
+            };
             document.head.appendChild(optimizersScript);
-        );
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -295,11 +295,8 @@
                     <h3>📚 Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/NEWUOA" target="_blank">UOBYQA/NEWUOA Wikipedia</a></li>
-                        <li><a href="https://optimization.mccormick.northwestern.edu/index.php/Trust_region_methods" target="_blank">Trust Region Methods Overview</a></li>
-                        <li><a href="https://www.pdfo.net/docs/" target="_blank">PDFO Documentation</a></li>
-                        <li><a href="https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=10a1f4f7eb2b46c09bdc3e97b3a17a6b0a47b3b8" target="_blank">Powell's Original UOBYQA Paper</a></li>
-                        <li><a href="https://ccom.ucsd.edu/~pcoleman/powellopt.pdf" target="_blank">Powell's Optimization Methods Tutorial</a></li>
-                    </ul>
+                        <li><a href="https://www.pdfo.net/" target="_blank">PDFO Documentation</a></li>
+                        </ul>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes widespread documentation rot across all 22 algorithm doc pages
and adds the missing EvolutionStrategy page.

## What was wrong

Commit fc6a046 ("Remove confusing wrapper terminology throughout codebase",
May 23) applied a destructive regex pass that stripped specific characters
(F, 0, 1, x, {, }) from every algorithm doc page. Examples:

- `UTF-8` → `UT-8`
- `padding: 20px` → `padding: 2p`
- `body { ... }` → `body  ...` (CSS braces removed!)
- `initial-scale=1.0` → `initial-scale=.`
- `doi.org/10.1093/comjnl/7.4.308` → `doi.org/.93/comjnl/7..38`
- `Fortran` → `ortran`, `PERFECT` → `PERECT`, `PDFO` → `PDO`

The intent of fc6a046 was a minor wording change ("wrapper" → "pure
implementation") but the damage covered every `.html` file in
`docs/algorithms/`. All `<style>` blocks were broken because the curly
braces got eaten.

## Changes in this PR

### Commit 1: `Restore algorithm doc pages to pre-rot state`
22 files reverted to their state at `fc6a046~1`. Since `fc6a046` is the
*most recent* commit to touch `docs/algorithms/` (nothing else has
changed there since), this is a clean restore — no later changes to
preserve.

### Commit 2: `Remove broken external links and update stale file paths`
With the pages restored, ran a separate link audit to clean up genuine
dead links unrelated to the rot:

- Removed 14 `<li>` entries pointing to dead URLs:
  - `optimization.mccormick.northwestern.edu` (entire domain dead)
  - fake DOI-hash CiteSeerX URLs
  - 404s on `cs.cmu.edu`, `mathworld`, `towardsdatascience`, `PythonOptimizers/pysearch`, etc.
- Replaced 3 dead URLs with working alternatives:
  - `pdfo.net/docs/` → `pdfo.net/`
  - `github/.../scipyopt.py` → `github/.../scipy_algorithms.py` (renamed)
  - `scipy /optimize/_lbfgsb_py` → `/scipy/optimize` (restructured)
- Updated 4 stale `File: humpday/optimizers/<old>.py` references in
  the "Humpday Integration" rows of lbfgsb / powell / simulated-annealing
  / pattern-search pages.

403-blocked DOI / MathWorks / MIT Press / ResearchGate links are
*kept* — they're real links, just user-agent-blocked at audit time.
(Verified each manually with a browser user-agent.)

### Commit 3: `Add evolution-strategy.html documentation page`
The `EvolutionStrategy` class is one of the 22 PURE_OPTIMIZERS but
had no doc page — every link to it 404'd. Page follows the same
template as the other algorithm docs.

## Verification

Final audit (`/tmp/docs_link_audit.py`):

```
## Missing doc pages (0)
## Internal broken links (0 pages)
## External broken links: only 403-blocked false positives (real, browser-loadable URLs)
```