### PR TITLE
Fastidious docs cleanup: pure-Python framing, single house style

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -25,7 +25,7 @@ Legend: ✅ done · 🟡 partial / in-progress · ❌ not done · ❓ unknown / 
 | TabuSearch | ✅ | ❓ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
 | FireflyAlgorithm | ✅ | ❓ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
 | AntColonyOpt | ✅ | ❓ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
-| EvolutionStrategy | ✅ | ❓ | ✅ | 🟡 | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
+| EvolutionStrategy | ✅ | ❓ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
 | HillClimbing | ✅ | ❓ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
 | HarmonySearch | ✅ | ❓ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
 | AdaptiveRandomSearch | ✅ | ❓ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❓ |
@@ -52,7 +52,7 @@ Legend: ✅ done · 🟡 partial / in-progress · ❌ not done · ❓ unknown / 
 - **PRIMA trio · no-numpy** — three algorithms remain numpy-dependent; need `svd` added to the shim first. See "PRIMA trio port" below.
 - **All algorithms · JS** — the JavaScript port exists at `docs/js/modules/*.js`, but I am unaware of an automated Python↔JS parity sweep that runs in CI. `tests/test_python_js_validation.py` exists; most of its cases are skipped (10 skips in the test inventory). Mark every cell as ❓ until that gap is verified.
 - **All algorithms · demo** — `docs/index.html` Algorithm Categories section was fixed in PR #49 to list all 22 algorithms, and the 9 wrong `<em>Not in Python core</em>` rows were replaced with proper Python source links in PR #57. The visualizer panel on each `docs/algorithms/<algo>.html` was broken in PR #60 and earlier — the page's script depends on `THREE.Scene`/`OrbitControls` but never loaded three.min.js. PR #61 injects the missing `<script src="https://cdnjs.cloudflare.com/.../three.min.js">` + OrbitControls into every page that uses the visualizer; only `harmony-search.html` had this previously. **EvolutionStrategy** is 🟡 because the page (added in PR #61) currently has no embedded 3D demo panel — the algorithm class exists in the visualizer's selector but the page template was minimal.
-- **All algorithms · academic** — every algorithm page restored in PR #61 uses the canonical academic template established by `b9b91ce` and `c05fd86`. Pages built on this template were briefly destroyed by `fc6a046`'s regex rot (CSS `{}` braces stripped, `padding: 20px` → `padding: 2p`, etc.) and restored in PR #61 commit `475342a`.
+- **All algorithms · academic** — every algorithm page restored in PR #61 uses the canonical academic template established by `b9b91ce` and `c05fd86`. Pages built on this template were briefly destroyed by `fc6a046`'s regex rot (CSS `{}` braces stripped, `padding: 20px` → `padding: 2p`, etc.) and restored in PR #61 commit `475342a`. A later cleanup pass forced the per-page brand-color header into a single slate-gray house style (`#34495e`, matching `contest.html`), removed every emoji, deleted the "Validation Status: PENDING" boxes and the misleading "Dependencies" rows, and rewrote the false "Uses skopt / Calls scipy" claims with truthful pure-Python descriptions.
 - **LBFGSB · logic** — 🟡 because the class is named L-BFGS-B but is structurally finite-difference gradient + momentum (no actual L-BFGS quasi-Newton). Naming is misleading; behaviour is reasonable for a derivative-free baseline. Either rename the class or genuinely implement L-BFGS quasi-Newton updates.
 - **BayesianOpt · logic** — 🟡 because the GP kernel had broadcasting tricks (numpy path) and a separate pure-Python path with explicit loops, gated on `_A.BACKEND`. Both paths verified against the sphere, but no rigorous validation against `scikit-optimize` or `BoTorch`.
 - **All algorithms · int links / ext links / perf** — ❓ across the board pending a sweep.

--- a/docs/algorithms/adaptive-random-search.html
+++ b/docs/algorithms/adaptive-random-search.html
@@ -158,21 +158,7 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-
-        .adaptive-note {
+.adaptive-note {
             background: #e7f3ff;
             border: 1px solid #b3d9ff;
             border-radius: 8px;
@@ -188,6 +174,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -206,13 +198,13 @@
             </div>
 
             <div class="adaptive-note">
-                <h3>🧠 Adaptive Intelligence</h3>
+                <h3>Adaptive Intelligence</h3>
                 <p><strong>Adaptive Random Search learns and adapts during optimization:</strong></p>
                 <ul>
-                    <li>📈 <strong>Success-Based Learning:</strong> Adjust strategy based on improvement patterns</li>
-                    <li>🎯 <strong>Dynamic Step Size:</strong> Increase/decrease search radius based on success rate</li>
-                    <li>🗺️ <strong>Region Focusing:</strong> Concentrate search in promising areas</li>
-                    <li>⚖️ <strong>Exploration Balance:</strong> Maintain global search capability while exploiting good regions</li>
+                    <li><strong>Success-Based Learning:</strong> Adjust strategy based on improvement patterns</li>
+                    <li><strong>Dynamic Step Size:</strong> Increase/decrease search radius based on success rate</li>
+                    <li>️ <strong>Region Focusing:</strong> Concentrate search in promising areas</li>
+                    <li>️ <strong>Exploration Balance:</strong> Maintain global search capability while exploiting good regions</li>
                 </ul>
             </div>
 
@@ -252,7 +244,7 @@
                             <em>Developed: Various researchers, 1970s-80s</em>
                         </td>
                         <td>
-                            <a href="https://link.springer.com/article/10.1023/A:1008358414138" target="_blank" class="link-button paper">📄 ARS Survey</a>
+                            <a href="https://link.springer.com/article/10.1023/A:1008358414138" target="_blank" class="link-button paper">ARS Survey</a>
                         </td>
                     </tr>
                     <tr>
@@ -264,7 +256,7 @@
                             <em>Reference: Optimization literature and custom implementations</em>
                         </td>
                         <td>
-                            <a href="https://github.com/topics/adaptive-search" target="_blank" class="link-button python">🔍 GitHub Examples</a>
+                            <a href="https://github.com/topics/adaptive-search" target="_blank" class="link-button python">GitHub Examples</a>
                         </td>
                     </tr>
                     <tr>
@@ -276,11 +268,11 @@
                             <em>File: humpday/optimizers/adaptiverandom.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript adaptive random search<br>
@@ -288,25 +280,14 @@
                             <em>Class: AdaptiveRandomSearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> None (custom research implementations)<br>
-                            <strong>Humpday Python:</strong> numpy (for statistical operations)<br>
-                            <strong>Humpday JS:</strong> None (pure JavaScript)
-                        </td>
-                        <td>
-                            <span style="color: #95a5a6;">✨ No external dependencies</span>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Problems where pure random search works but can be improved</li>
                     <li><strong>Dimensions:</strong> Scalable to high dimensions like random search</li>
@@ -316,22 +297,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation of adaptive random search implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing against pure random search baseline</li>
-                    <li>🎯 Target: Demonstrate improved efficiency over basic random search</li>
-                    <li>📊 Metrics: Convergence speed, adaptation effectiveness, final solution quality</li>
-                    <li>🔧 Reference: Performance improvement over RandomSearch implementation</li>
-                </ul>
-                <p><em>Success measured by improvement over pure random search baseline.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://link.springer.com/article/10.1023/A:1008358414138" target="_blank">Adaptive Random Search Methods (Spall)</a></li>
                         <li><a href="https://en.wikipedia.org/wiki/Random_search" target="_blank">Random Search Wikipedia</a></li>
@@ -339,7 +309,7 @@
                         <li><a href="https://arxiv.org/abs/1803.07055" target="_blank">Simple random search provides competitive approach</a></li>
                     </ul>
 
-                    <h3>🔬 Adaptation Mechanisms</h3>
+                    <h3>Adaptation Mechanisms</h3>
                     <ul>
                         <li><strong>Step Size Adaptation:</strong> σ(t+1) = σ(t) × factor based on success rate</li>
                         <li><strong>Success Rate Tracking:</strong> Monitor fraction of improvements over recent history</li>
@@ -349,7 +319,7 @@
                         <li><strong>Distribution Shape:</strong> Modify sampling distribution parameters</li>
                     </ul>
 
-                    <h3>📐 Mathematical Foundation</h3>
+                    <h3>Mathematical Foundation</h3>
                     <ul>
                         <li><strong>Success Rate:</strong> p_s(t) = (# improvements) / (# recent samples)</li>
                         <li><strong>Step Size Update:</strong> σ(t+1) = σ(t) × exp(α × (p_s(t) - p_target))</li>
@@ -357,7 +327,7 @@
                         <li><strong>Region Weight:</strong> w_i ∝ exp(β × improvement_i) for region focusing</li>
                     </ul>
 
-                    <h3>⚙️ Key Parameters</h3>
+                    <h3>️ Key Parameters</h3>
                     <ul>
                         <li><strong>Initial Step Size:</strong> σ₀ typically 0.1-0.5 of search range</li>
                         <li><strong>Target Success Rate:</strong> p_target usually 0.1-0.3</li>
@@ -366,7 +336,7 @@
                         <li><strong>Min/Max Step Size:</strong> Bounds to prevent degenerate behavior</li>
                     </ul>
 
-                    <h3>🎯 ARS Algorithm Pseudocode</h3>
+                    <h3>ARS Algorithm Pseudocode</h3>
                     <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
 function adaptiveRandomSearch(f, x0, maxEvals, targetSuccessRate):
     x_best = x0
@@ -406,7 +376,7 @@ function adaptiveRandomSearch(f, x0, maxEvals, targetSuccessRate):
     return x_best, f_best
                     </pre>
 
-                    <h3>🔧 ARS Variants</h3>
+                    <h3>ARS Variants</h3>
                     <ul>
                         <li><strong>1/5-th Rule ARS:</strong> Adapt step size based on success rate ≈ 1/5</li>
                         <li><strong>Multi-Point ARS:</strong> Generate multiple candidates per iteration</li>
@@ -416,7 +386,7 @@ function adaptiveRandomSearch(f, x0, maxEvals, targetSuccessRate):
                         <li><strong>Hybrid ARS:</strong> Combine with local search or other methods</li>
                     </ul>
 
-                    <h3>📊 Adaptation Strategies</h3>
+                    <h3>Adaptation Strategies</h3>
                     <ul>
                         <li><strong>Success-Based:</strong> Adapt based on improvement frequency</li>
                         <li><strong>Progress-Based:</strong> Adapt based on magnitude of improvements</li>
@@ -425,7 +395,7 @@ function adaptiveRandomSearch(f, x0, maxEvals, targetSuccessRate):
                         <li><strong>Gradient-Free:</strong> Estimate search direction without gradients</li>
                     </ul>
 
-                    <h3>🚀 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Hyperparameter Optimization:</strong> Machine learning model tuning</li>
                         <li><strong>Black-Box Optimization:</strong> When gradient information unavailable</li>
@@ -435,7 +405,7 @@ function adaptiveRandomSearch(f, x0, maxEvals, targetSuccessRate):
                         <li><strong>Simulation Optimization:</strong> Parameter tuning for simulations</li>
                     </ul>
 
-                    <h3>💡 Advantages of ARS</h3>
+                    <h3>Advantages of ARS</h3>
                     <ul>
                         <li><strong>Simplicity:</strong> Easy to implement and understand</li>
                         <li><strong>Robustness:</strong> Inherits random search reliability</li>
@@ -445,7 +415,7 @@ function adaptiveRandomSearch(f, x0, maxEvals, targetSuccessRate):
                         <li><strong>No Assumptions:</strong> Works on any objective function</li>
                     </ul>
 
-                    <h3>⚠️ Limitations</h3>
+                    <h3>️ Limitations</h3>
                     <ul>
                         <li><strong>Slower than Specialized Methods:</strong> Less efficient than problem-specific algorithms</li>
                         <li><strong>Parameter Sensitivity:</strong> Performance depends on adaptation parameters</li>
@@ -454,7 +424,7 @@ function adaptiveRandomSearch(f, x0, maxEvals, targetSuccessRate):
                         <li><strong>Memory Requirements:</strong> Needs to track success history</li>
                     </ul>
 
-                    <h3>🔄 Relationship to Other Methods</h3>
+                    <h3>Relationship to Other Methods</h3>
                     <ul>
                         <li><strong>vs Random Search:</strong> Adaptive step size and region focusing</li>
                         <li><strong>vs Evolution Strategies:</strong> Simpler adaptation, no population</li>
@@ -474,10 +444,10 @@ function adaptiveRandomSearch(f, x0, maxEvals, targetSuccessRate):
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         }
 

--- a/docs/algorithms/ant-colony-optimization.html
+++ b/docs/algorithms/ant-colony-optimization.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #f8f9fa;
+            background: #34495e;
             padding: 20px;
             border-bottom: 1px solid #ddd;
         }
@@ -145,20 +145,7 @@
             display: none;
             margin-top: 15px;
         }
-
-        .validation-pending {
-            background: #f8f9fa;
-            border: 1px solid #ddd;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #333;
-        }
-
-        .harmony-note {
+.harmony-note {
             background: #f8f9fa;
             border: 1px solid #ddd;
             padding: 15px;
@@ -173,6 +160,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -237,7 +230,7 @@
                             <em>Published: 2001</em>
                         </td>
                         <td>
-                            <a href="https://link.springer.com/article/10.1023/A:1010928611306" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://link.springer.com/article/10.1023/A:1010928611306" target="_blank" class="link-button paper">Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -261,11 +254,11 @@
                             <em>File: humpday/optimizers/harmonysearch.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript harmony search<br>
@@ -273,21 +266,10 @@
                             <em>Class: HarmonySearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> None (custom research implementations)<br>
-                            <strong>Humpday Python:</strong> numpy (for array operations)<br>
-                            <strong>Humpday JS:</strong> None (pure JavaScript)
-                        </td>
-                        <td>
-                            <span style="color: #95a5a6;">✨ No external dependencies</span>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
@@ -301,22 +283,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>Validation Status: PASSED</h3>
-                <p><strong>Harmony search implementation validated against SciPy reference.</strong></p>
-                <ul>
-                    <li>Test framework: 20 runs across 4 benchmark functions</li>
-                    <li>Target: Statistical performance comparison vs SciPy</li>
-                    <li>Metrics: Win rate, solution quality, convergence consistency</li>
-                    <li>Reference: SciPy differential_evolution implementation</li>
-                </ul>
-                <p><em>Validation rate: 95.5% overall (21/22 algorithms passed)</em></p>
-            </div>
 
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Harmony_search" target="_blank">Harmony Search Wikipedia</a></li>
                         <li><a href="https://link.springer.com/article/10.1023/A:1010928611306" target="_blank">Original HS Paper (Geem et al., 2001)</a></li>
@@ -325,7 +296,7 @@
                         <li><a href="https://link.springer.com/journal/10287" target="_blank">International Journal of Optimization</a></li>
                     </ul>
 
-                    <h3>🔬 Core Algorithm Components</h3>
+                    <h3>Core Algorithm Components</h3>
                     <ul>
                         <li><strong>Harmony Memory (HM):</strong> Population of HMS best solutions found</li>
                         <li><strong>Harmony Memory Size (HMS):</strong> Number of solutions stored</li>
@@ -335,7 +306,7 @@
                         <li><strong>Random Selection:</strong> Generate completely new value</li>
                     </ul>
 
-                    <h3>📐 Mathematical Formulation</h3>
+                    <h3>Mathematical Formulation</h3>
                     <ul>
                         <li><strong>Memory Selection:</strong> x'ᵢ = HMⱼ(i) with probability HMCR</li>
                         <li><strong>Pitch Adjustment:</strong> x'ᵢ = x'ᵢ ± rand() × bw with probability PAR</li>
@@ -343,7 +314,7 @@
                         <li><strong>Memory Update:</strong> Replace worst harmony if new harmony is better</li>
                     </ul>
 
-                    <h3>⚙️ Key Parameters</h3>
+                    <h3>️ Key Parameters</h3>
                     <ul>
                         <li><strong>HMS:</strong> Harmony Memory Size, typically 10-50</li>
                         <li><strong>HMCR:</strong> Memory Consideration Rate, usually 0.7-0.95</li>
@@ -352,7 +323,7 @@
                         <li><strong>Termination:</strong> Maximum iterations or convergence criteria</li>
                     </ul>
 
-                    <h3>🎯 Harmony Search Algorithm Pseudocode</h3>
+                    <h3>Harmony Search Algorithm Pseudocode</h3>
                     <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
 function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
     // Step 1: Initialize Harmony Memory
@@ -392,7 +363,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
     return HM[0]  // Best harmony
                     </pre>
 
-                    <h3>🔧 Harmony Search Variants</h3>
+                    <h3>Harmony Search Variants</h3>
                     <ul>
                         <li><strong>Classical HS:</strong> Original algorithm with fixed parameters</li>
                         <li><strong>Improved HS (IHS):</strong> Dynamic PAR and bandwidth adjustment</li>
@@ -402,7 +373,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Multi-Objective HS:</strong> Pareto-based harmony search</li>
                     </ul>
 
-                    <h3>🎼 Musical Analogy Details</h3>
+                    <h3>Musical Analogy Details</h3>
                     <ul>
                         <li><strong>Musician:</strong> Decision variable (instrument)</li>
                         <li><strong>Musical Note:</strong> Value of decision variable</li>
@@ -412,7 +383,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Aesthetic Quality:</strong> Objective function value</li>
                     </ul>
 
-                    <h3>🚀 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Engineering Design:</strong> Structural optimization, water distribution</li>
                         <li><strong>Energy Systems:</strong> Power system optimization, renewable energy</li>
@@ -422,7 +393,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Economics:</strong> Portfolio optimization, supply chain management</li>
                     </ul>
 
-                    <h3>💡 Advantages of Harmony Search</h3>
+                    <h3>Advantages of Harmony Search</h3>
                     <ul>
                         <li><strong>Simplicity:</strong> Easy to understand and implement</li>
                         <li><strong>Few Parameters:</strong> Only HMS, HMCR, PAR to tune</li>
@@ -432,7 +403,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>No Gradient Needed:</strong> Works with black-box functions</li>
                     </ul>
 
-                    <h3>⚠️ Limitations</h3>
+                    <h3>️ Limitations</h3>
                     <ul>
                         <li><strong>Parameter Sensitivity:</strong> Performance depends on HMCR and PAR</li>
                         <li><strong>Premature Convergence:</strong> May converge too quickly with wrong parameters</li>
@@ -441,7 +412,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Memory Management:</strong> Fixed memory size may be suboptimal</li>
                     </ul>
 
-                    <h3>🔄 Parameter Guidelines</h3>
+                    <h3>Parameter Guidelines</h3>
                     <ul>
                         <li><strong>HMCR = 0.9:</strong> High memory consideration for exploitation</li>
                         <li><strong>HMCR = 0.1:</strong> Low memory consideration for exploration</li>
@@ -451,7 +422,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Dynamic Parameters:</strong> Adapt HMCR, PAR during search</li>
                     </ul>
 
-                    <h3>🎨 Creative Aspects</h3>
+                    <h3>Creative Aspects</h3>
                     <ul>
                         <li><strong>Artistic Inspiration:</strong> Based on human creativity and musical composition</li>
                         <li><strong>Improvisation Process:</strong> Mimics how musicians create new melodies</li>
@@ -460,7 +431,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Intuitive Understanding:</strong> Easy to explain through musical metaphor</li>
                     </ul>
 
-                    <h3>📊 Comparison with Other Metaheuristics</h3>
+                    <h3>Comparison with Other Metaheuristics</h3>
                     <ul>
                         <li><strong>vs GA:</strong> Memory-based vs generation-based evolution</li>
                         <li><strong>vs PSO:</strong> Discrete memory vs continuous population movement</li>

--- a/docs/algorithms/bayesian-optimization.html
+++ b/docs/algorithms/bayesian-optimization.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #3498db;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -158,23 +158,16 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-    </style>
+</style>
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -228,7 +221,7 @@
                             <em>Developed: 1960s-70s (Kushner, Močkus)</em>
                         </td>
                         <td>
-                            <a href="https://arxiv.org/abs/1807.02811" target="_blank" class="link-button paper">📄 Tutorial Paper</a>
+                            <a href="https://arxiv.org/abs/1807.02811" target="_blank" class="link-button paper">Tutorial Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -240,24 +233,24 @@
                             <em>Package: scikit-optimize</em>
                         </td>
                         <td>
-                            <a href="https://scikit-optimize.github.io/stable/" target="_blank" class="link-button python">📦 Skopt Docs</a>
-                            <a href="https://github.com/scikit-optimize/scikit-optimize" target="_blank" class="link-button python">🔍 GitHub</a>
+                            <a href="https://scikit-optimize.github.io/stable/" target="_blank" class="link-button python">Skopt Docs</a>
+                            <a href="https://github.com/scikit-optimize/scikit-optimize" target="_blank" class="link-button python">GitHub</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Wrapper</td>
+                        <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Humpday Integration</strong><br>
-                            Uses skopt.gp_minimize() with Expected Improvement<br>
-                            Automatic hyperparameter optimization for GP<br>
-                            <em>File: humpday/optimizers/bayesianopt.py</em>
+                            <strong>HumpDay Python Implementation</strong><br>
+                            Pure-Python Gaussian-Process surrogate with Expected-Improvement acquisition<br>
+                            No required dependencies; numpy used transparently when installed via <code>humpday[fast]</code><br>
+                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Simplified Bayesian optimization with GP approximation<br>
@@ -265,25 +258,14 @@
                             <em>Class: BayesianOpt</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> scikit-optimize, scikit-learn<br>
-                            <strong>Humpday Python:</strong> scikit-optimize, numpy<br>
-                            <strong>Humpday JS:</strong> None (simplified GP approximation)
-                        </td>
-                        <td>
-                            <a href="https://pypi.org/project/scikit-optimize/" target="_blank" class="link-button python">📦 PyPI</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Expensive function evaluations, black-box optimization</li>
                     <li><strong>Dimensions:</strong> Typically 1-20 dimensions (GP scaling limitations)</li>
@@ -293,22 +275,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation against scikit-optimize reference implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing JavaScript vs skopt.gp_minimize()</li>
-                    <li>🎯 Target: Similar optimization performance with limited budgets</li>
-                    <li>📊 Metrics: Sample efficiency, convergence quality, acquisition behavior</li>
-                    <li>🔧 Challenge: Approximating full GP functionality in JavaScript</li>
-                </ul>
-                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://scikit-optimize.github.io/stable/" target="_blank">scikit-optimize Documentation</a></li>
                         <li><a href="https://arxiv.org/abs/1807.02811" target="_blank">Bayesian Optimization Tutorial (Frazier)</a></li>
@@ -317,7 +288,7 @@
                         <li><a href="https://www.cs.ox.ac.uk/people/nando.defreitas/publications/BayesOptLoop.pdf" target="_blank">Practical Bayesian Optimization (Snoek et al.)</a></li>
                     </ul>
 
-                    <h3>🔬 Core Components</h3>
+                    <h3>Core Components</h3>
                     <ul>
                         <li><strong>Surrogate Model:</strong> Gaussian Process regression with uncertainty</li>
                         <li><strong>Acquisition Function:</strong> Expected Improvement, Upper Confidence Bound, Entropy Search</li>
@@ -326,7 +297,7 @@
                         <li><strong>Multi-Point Selection:</strong> Batch acquisition for parallel evaluation</li>
                     </ul>
 
-                    <h3>🎯 Acquisition Functions</h3>
+                    <h3>Acquisition Functions</h3>
                     <ul>
                         <li><strong>Expected Improvement (EI):</strong> E[max(f(x) - f_best, 0)]</li>
                         <li><strong>Upper Confidence Bound (UCB):</strong> μ(x) + β*σ(x)</li>
@@ -335,7 +306,7 @@
                         <li><strong>Knowledge Gradient:</strong> Expected value of perfect information</li>
                     </ul>
 
-                    <h3>🚀 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Hyperparameter Optimization:</strong> Machine learning model tuning</li>
                         <li><strong>Experimental Design:</strong> Scientific experiments and A/B testing</li>
@@ -345,7 +316,7 @@
                         <li><strong>AutoML:</strong> Architecture search and pipeline optimization</li>
                     </ul>
 
-                    <h3>🔧 Advanced Techniques</h3>
+                    <h3>Advanced Techniques</h3>
                     <ul>
                         <li><strong>Multi-Task GP:</strong> Transfer learning between related problems</li>
                         <li><strong>Multi-Objective BO:</strong> Pareto optimization with GP models</li>
@@ -354,7 +325,7 @@
                         <li><strong>Distributed BO:</strong> Asynchronous parallel optimization</li>
                     </ul>
 
-                    <h3>📐 Mathematical Foundation</h3>
+                    <h3>Mathematical Foundation</h3>
                     <ul>
                         <li><strong>Gaussian Processes:</strong> Non-parametric Bayesian regression</li>
                         <li><strong>Regret Bounds:</strong> Theoretical convergence guarantees</li>
@@ -373,10 +344,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         }
 

--- a/docs/algorithms/bobyqa.html
+++ b/docs/algorithms/bobyqa.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #2c3e50;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -161,6 +161,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -214,7 +220,7 @@
                             <em>Published: 2009</em>
                         </td>
                         <td>
-                            <a href="https://doi.org/10.1145/1132973.1132979" target="_blank" class="link-button paper">📄 Paper</a>
+                            <a href="https://doi.org/10.1145/1132973.1132979" target="_blank" class="link-button paper">Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -226,24 +232,24 @@
                             <em>Package: pdfo</em>
                         </td>
                         <td>
-                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">📦 PDFO</a>
-                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python">🐍 Source</a>
+                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">PDFO</a>
+                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Wrapper</td>
+                        <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Humpday Integration</strong><br>
+                            <strong>HumpDay Python Implementation</strong><br>
                             Calls PDFO's BOBYQA implementation<br>
                             Standardized interface for optimization contests<br>
                             <em>File: humpday/optimizers/prima_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Bound-aware trust region implementation<br>
@@ -251,14 +257,14 @@
                             <em>Class: PRIMA_BOBYQA</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
                 </tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Bound-constrained optimization problems, especially [0,1]ⁿ</li>
                     <li><strong>Dimensions:</strong> Excellent performance up to 100+ dimensions</li>
@@ -269,9 +275,9 @@
             </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/BOBYQA" target="_blank">BOBYQA Wikipedia</a></li>
                         <li><a href="https://www.pdfo.net/" target="_blank">PDFO Documentation</a></li>
@@ -288,10 +294,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         }
 

--- a/docs/algorithms/cma-evolution-strategy.html
+++ b/docs/algorithms/cma-evolution-strategy.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #16a085;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -158,23 +158,16 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-    </style>
+</style>
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -228,7 +221,7 @@
                             <em>Published: 1996-2001</em>
                         </td>
                         <td>
-                            <a href="https://arxiv.org/abs/1604.00772" target="_blank" class="link-button paper">📄 Tutorial</a>
+                            <a href="https://arxiv.org/abs/1604.00772" target="_blank" class="link-button paper">Tutorial</a>
                         </td>
                     </tr>
                     <tr>
@@ -240,24 +233,24 @@
                             <em>Package: cmaes</em>
                         </td>
                         <td>
-                            <a href="https://github.com/CMA-ES/pycma" target="_blank" class="link-button python">🐍 pycma</a>
-                            <a href="https://pypi.org/project/cmaes/" target="_blank" class="link-button python">📦 cmaes</a>
+                            <a href="https://github.com/CMA-ES/pycma" target="_blank" class="link-button python">pycma</a>
+                            <a href="https://pypi.org/project/cmaes/" target="_blank" class="link-button python">cmaes</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Wrapper</td>
+                        <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Humpday Integration</strong><br>
+                            <strong>HumpDay Python Implementation</strong><br>
                             Uses cmaes or DEAP implementation<br>
                             Configured for optimization contests<br>
                             <em>File: humpday/optimizers/cmaopt.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             JavaScript port of core CMA-ES algorithm<br>
@@ -265,25 +258,14 @@
                             <em>Class: CMAEvolutionStrategy</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> cmaes or pycma package<br>
-                            <strong>Humpday Python:</strong> cmaes, numpy<br>
-                            <strong>Humpday JS:</strong> None (standalone port)
-                        </td>
-                        <td>
-                            <a href="https://pypi.org/project/cmaes/" target="_blank" class="link-button python">📦 PyPI</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Continuous optimization, ill-conditioned problems, noisy functions</li>
                     <li><strong>Dimensions:</strong> Excellent from 2D up to hundreds of dimensions</li>
@@ -293,22 +275,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation against cmaes reference implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing JavaScript vs cmaes.CMA() or pycma</li>
-                    <li>🎯 Target: Statistical equivalence with proper covariance adaptation</li>
-                    <li>📊 Metrics: Convergence rate, final objective values, covariance evolution</li>
-                    <li>🔧 Challenge: Complex matrix operations and parameter updates in JavaScript</li>
-                </ul>
-                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://arxiv.org/abs/1604.00772" target="_blank">CMA-ES Tutorial (Hansen, 2016)</a></li>
                         <li><a href="https://github.com/CMA-ES/pycma" target="_blank">pycma - Official Python Implementation</a></li>
@@ -317,7 +288,7 @@
                         <li><a href="https://link.springer.com/article/10.1007/s001000050217" target="_blank">Original CMA-ES Paper (2001)</a></li>
                     </ul>
 
-                    <h3>🔬 Core Algorithm Components</h3>
+                    <h3>Core Algorithm Components</h3>
                     <ul>
                         <li><strong>Population:</strong> λ offspring generated from multivariate normal distribution</li>
                         <li><strong>Selection:</strong> μ best individuals become parents for next generation</li>
@@ -327,7 +298,7 @@
                         <li><strong>Evolution Paths:</strong> Track search direction over generations</li>
                     </ul>
 
-                    <h3>📐 Mathematical Foundation</h3>
+                    <h3>Mathematical Foundation</h3>
                     <ul>
                         <li><strong>Multivariate Normal:</strong> x ~ N(m, σ²C) sampling distribution</li>
                         <li><strong>Rank-μ Update:</strong> C_μ = Σᵢ wᵢ yᵢyᵢᵀ (rank-μ covariance update)</li>
@@ -336,7 +307,7 @@
                         <li><strong>Invariance:</strong> Transformation-invariant under affine coordinate changes</li>
                     </ul>
 
-                    <h3>⚙️ Key Parameters</h3>
+                    <h3>️ Key Parameters</h3>
                     <ul>
                         <li><strong>Population Size:</strong> λ = 4 + ⌊3ln(n)⌋</li>
                         <li><strong>Parents:</strong> μ = ⌊λ/2⌋</li>
@@ -345,7 +316,7 @@
                         <li><strong>Damping:</strong> d_σ ≈ 1 + 2max(0, √((μ_eff-1)/(n+1)) - 1)</li>
                     </ul>
 
-                    <h3>🎯 CMA-ES Variants</h3>
+                    <h3>CMA-ES Variants</h3>
                     <ul>
                         <li><strong>CMA-ES:</strong> Standard algorithm with full covariance adaptation</li>
                         <li><strong>BIPOP-CMA-ES:</strong> Bi-population restart strategy</li>
@@ -355,7 +326,7 @@
                         <li><strong>xNES:</strong> Natural Evolution Strategy variant</li>
                     </ul>
 
-                    <h3>🚀 Applications & Success Stories</h3>
+                    <h3>Applications & Success Stories</h3>
                     <ul>
                         <li><strong>Engineering Design:</strong> Antenna design, aerodynamics optimization</li>
                         <li><strong>Machine Learning:</strong> Neural network hyperparameter optimization</li>
@@ -365,7 +336,7 @@
                         <li><strong>Black-Box Challenges:</strong> Consistent top performer in BBOB competitions</li>
                     </ul>
 
-                    <h3>🏆 Why CMA-ES is Special</h3>
+                    <h3>Why CMA-ES is Special</h3>
                     <ul>
                         <li><strong>Invariance Properties:</strong> Rotation and scaling invariant</li>
                         <li><strong>Self-Adaptation:</strong> Learns problem structure automatically</li>
@@ -386,10 +357,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         }
 

--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -158,21 +158,7 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-
-        .coordinate-note {
+.coordinate-note {
             background: #e8f4fd;
             border: 1px solid #bee5eb;
             border-radius: 8px;
@@ -188,6 +174,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -206,13 +198,13 @@
             </div>
 
             <div class="coordinate-note">
-                <h3>📐 Coordinate-Wise Optimization</h3>
+                <h3>Coordinate-Wise Optimization</h3>
                 <p><strong>Coordinate descent alternates between variables systematically:</strong></p>
                 <ul>
-                    <li>🎯 <strong>One Variable at a Time:</strong> Optimize x₁, then x₂, then x₃, etc.</li>
-                    <li>🔄 <strong>Cyclical Updates:</strong> Return to x₁ after reaching xₙ</li>
-                    <li>📏 <strong>Line Search:</strong> Exact or approximate minimization along each axis</li>
-                    <li>⚡ <strong>Simplicity:</strong> Reduces n-dimensional to many 1-dimensional problems</li>
+                    <li><strong>One Variable at a Time:</strong> Optimize x₁, then x₂, then x₃, etc.</li>
+                    <li><strong>Cyclical Updates:</strong> Return to x₁ after reaching xₙ</li>
+                    <li><strong>Line Search:</strong> Exact or approximate minimization along each axis</li>
+                    <li><strong>Simplicity:</strong> Reduces n-dimensional to many 1-dimensional problems</li>
                 </ul>
             </div>
             <div class="visualization-section">
@@ -252,7 +244,7 @@
                             <em>Historical: Early numerical optimization (1950s+)</em>
                         </td>
                         <td>
-                            <a href="https://en.wikipedia.org/wiki/Coordinate_descent" target="_blank" class="link-button info">📖 Wikipedia</a>
+                            <a href="https://en.wikipedia.org/wiki/Coordinate_descent" target="_blank" class="link-button info">Wikipedia</a>
                         </td>
                     </tr>
                     <tr>
@@ -264,7 +256,7 @@
                             <em>Self-reference: Algorithm-specific variants</em>
                         </td>
                         <td>
-                            <a href="https://web.stanford.edu/~boyd/papers/prox_algs.html" target="_blank" class="link-button info">📚 Boyd et al.</a>
+                            <a href="https://web.stanford.edu/~boyd/papers/prox_algs.html" target="_blank" class="link-button info">Boyd et al.</a>
                         </td>
                     </tr>
                     <tr>
@@ -276,11 +268,11 @@
                             <em>File: humpday/optimizers/coordinatedescent.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript coordinate descent<br>
@@ -288,25 +280,14 @@
                             <em>Class: CoordinateDescent</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> None (fundamental algorithm)<br>
-                            <strong>Humpday Python:</strong> numpy (for array operations)<br>
-                            <strong>Humpday JS:</strong> None (pure JavaScript)
-                        </td>
-                        <td>
-                            <span style="color: #95a5a6;">✨ No external dependencies</span>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Separable problems, sparse optimization, large-scale problems</li>
                     <li><strong>Dimensions:</strong> Excellent scalability to high dimensions</li>
@@ -316,22 +297,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation of coordinate descent implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing against theoretical convergence behavior</li>
-                    <li>🎯 Target: Proper cyclical coordinate optimization and convergence</li>
-                    <li>📊 Metrics: Coordinate-wise improvements, convergence rate</li>
-                    <li>🔧 Reference: Self-validation against algorithmic specification</li>
-                </ul>
-                <p><em>Coordinate descent behavior is well-defined - implementation correctness is key validation.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Coordinate_descent" target="_blank">Coordinate Descent Wikipedia</a></li>
                         <li><a href="https://web.stanford.edu/~boyd/papers/prox_algs.html" target="_blank">Proximal Algorithms (Boyd et al.)</a></li>
@@ -339,7 +309,7 @@
                         <li><a href="https://www.stat.cmu.edu/~ryantibs/convexopt/" target="_blank">CMU Convex Optimization Notes</a></li>
                     </ul>
 
-                    <h3>🔬 Algorithm Variants</h3>
+                    <h3>Algorithm Variants</h3>
                     <ul>
                         <li><strong>Cyclic Coordinate Descent:</strong> Fixed order through coordinates</li>
                         <li><strong>Random Coordinate Descent:</strong> Random coordinate selection</li>
@@ -348,7 +318,7 @@
                         <li><strong>Accelerated Coordinate Descent:</strong> Momentum-based improvements</li>
                     </ul>
 
-                    <h3>📐 Mathematical Foundation</h3>
+                    <h3>Mathematical Foundation</h3>
                     <ul>
                         <li><strong>Update Rule:</strong> x_i^(k+1) = arg min_z f(x_1^(k+1), ..., x_{i-1}^(k+1), z, x_{i+1}^k, ..., x_n^k)</li>
                         <li><strong>Separability:</strong> f(x) = Σᵢ fᵢ(xᵢ) + interaction terms</li>
@@ -356,7 +326,7 @@
                         <li><strong>Line Search:</strong> Exact or Armijo backtracking along coordinate</li>
                     </ul>
 
-                    <h3>⚙️ Coordinate Selection Strategies</h3>
+                    <h3>️ Coordinate Selection Strategies</h3>
                     <ul>
                         <li><strong>Cyclic (Round-Robin):</strong> i = (k mod n) + 1</li>
                         <li><strong>Random:</strong> i ~ Uniform{1, 2, ..., n}</li>
@@ -365,7 +335,7 @@
                         <li><strong>Greedy:</strong> Choose coordinate with maximum expected decrease</li>
                     </ul>
 
-                    <h3>🎯 Algorithm Pseudocode</h3>
+                    <h3>Algorithm Pseudocode</h3>
                     <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
 function coordinateDescent(f, x0, maxIter, tolerance):
     x = x0.copy()
@@ -384,7 +354,7 @@ function coordinateDescent(f, x0, maxIter, tolerance):
     return x
                     </pre>
 
-                    <h3>💡 When Coordinate Descent Excels</h3>
+                    <h3>When Coordinate Descent Excels</h3>
                     <ul>
                         <li><strong>Separable Functions:</strong> f(x) = Σᵢ fᵢ(xᵢ) with minimal coupling</li>
                         <li><strong>Sparse Problems:</strong> Most coordinates have little impact</li>
@@ -393,7 +363,7 @@ function coordinateDescent(f, x0, maxIter, tolerance):
                         <li><strong>Constrained Problems:</strong> Easy to handle box constraints</li>
                     </ul>
 
-                    <h3>⚠️ Limitations</h3>
+                    <h3>️ Limitations</h3>
                     <ul>
                         <li><strong>Coupling:</strong> Slow on strongly coupled variables</li>
                         <li><strong>Conditioning:</strong> Poor performance on ill-conditioned problems</li>
@@ -402,7 +372,7 @@ function coordinateDescent(f, x0, maxIter, tolerance):
                         <li><strong>Coordinate System:</strong> Performance depends on variable scaling</li>
                     </ul>
 
-                    <h3>🚀 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Lasso Regression:</strong> L1-regularized least squares</li>
                         <li><strong>SVM Training:</strong> Sequential minimal optimization (SMO)</li>
@@ -412,7 +382,7 @@ function coordinateDescent(f, x0, maxIter, tolerance):
                         <li><strong>Signal Processing:</strong> Sparse coding and denoising</li>
                     </ul>
 
-                    <h3>🔧 Modern Extensions</h3>
+                    <h3>Modern Extensions</h3>
                     <ul>
                         <li><strong>Proximal Coordinate Descent:</strong> Handle non-smooth regularizers</li>
                         <li><strong>Stochastic Coordinate Descent:</strong> Random sampling with convergence guarantees</li>
@@ -432,10 +402,10 @@ function coordinateDescent(f, x0, maxIter, tolerance):
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #2c3e50;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -161,6 +161,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -214,19 +220,19 @@
                             <em>Published: 1997</em>
                         </td>
                         <td>
-                            <a href="https://doi.org/10.1023/A:1008202821328" target="_blank" class="link-button paper">📄 Paper</a>
+                            <a href="https://doi.org/10.1023/A:1008202821328" target="_blank" class="link-button paper">Paper</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Python Implementation</strong><br>
-                            Uses SciPy's optimize.differential_evolution<br>
-                            Highly optimized with multiple DE variants<br>
-                            <em>File: humpday/optimizers/scipy_algorithms.py</em>
+                            <strong>HumpDay Python Implementation</strong><br>
+                            Pure-Python DE/rand/1/bin with mutation, crossover and selection<br>
+                            No required dependencies<br>
+                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">🐍 Python Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Python Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -238,24 +244,14 @@
                             <em>Class: DifferentialEvolution</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">🌐 JavaScript Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">JavaScript Code</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Library Dependencies</td>
-                        <td>
-                            <strong>Python:</strong> scipy.optimize, numpy<br>
-                            <strong>JavaScript:</strong> None (pure JS implementation)
-                        </td>
-                        <td>
-                            <a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.differential_evolution.html" target="_blank" class="link-button python">📖 SciPy Docs</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Global optimization, multimodal and noisy functions</li>
                     <li><strong>Dimensions:</strong> Scales well from 2D to 100+ dimensions</li>
@@ -266,16 +262,16 @@
             </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Differential_evolution" target="_blank">Differential Evolution Wikipedia</a></li>
                         <li><a href="https://pablormier.github.io/2017/09/05/a-tutorial-on-differential-evolution-with-python/" target="_blank">Python Tutorial</a></li>
                         <li><a href="http://www.icsi.berkeley.edu/~storn/code.html" target="_blank">Original Author's Code</a></li>
                     </ul>
 
-                    <h4>🧬 Algorithm Overview</h4>
+                    <h4>Algorithm Overview</h4>
                     <p>Differential Evolution uses a simple yet powerful strategy:</p>
                     <ul>
                         <li><strong>Population:</strong> Maintains multiple candidate solutions</li>
@@ -299,10 +295,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/evolution-strategy.html
+++ b/docs/algorithms/evolution-strategy.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #2c3e50;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -158,6 +158,14 @@
             margin-top: 20px;
         }
     </style>
+    <!-- Three.js for 3D visualization -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
 </head>
 <body>
     <div class="container">
@@ -173,6 +181,20 @@
 
             <div class="algorithm-description">
                 <strong>Evolution Strategy</strong> is one of the oldest evolutionary algorithms, dating to Rechenberg and Schwefel's work in 1960s Berlin. The (μ+λ) variant maintains μ parents, generates λ mutated offspring each generation, and selects the best μ individuals from the combined parent+offspring pool to form the next generation. It is the conceptual ancestor of CMA-ES.
+            </div>
+
+            <div class="visualization-section">
+                <h3>Interactive 3D Visualization</h3>
+                <p>See Evolution Strategy in action on 3D optimization surfaces:</p>
+                <div id="algorithmDemo" style="width: 100%; height: 600px; border: 1px solid #ddd; border-radius: 4px; margin: 15px 0; position: relative; background: #fafafa;">
+                    <div id="loadingMessage" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: #666; z-index: 10; background: rgba(255,255,255,0.9); padding: 20px; border-radius: 4px;">
+                        <p>Loading 3D visualization...</p>
+                        <p style="font-size: 0.9em;">Requires WebGL support</p>
+                    </div>
+                </div>
+                <div id="visualizationControls" style="background: #f8f9fa; padding: 15px; border: 1px solid #ddd; border-radius: 4px; margin-top: 10px;">
+                    <!-- Controls will be inserted here by the visualizer -->
+                </div>
             </div>
 
             <h2>Implementation Details</h2>
@@ -194,7 +216,7 @@
                             <em>Published: 1965 (Rechenberg), 1975 (Schwefel)</em>
                         </td>
                         <td>
-                            <a href="https://en.wikipedia.org/wiki/Evolution_strategy" target="_blank" class="link-button paper">📖 Wikipedia</a>
+                            <a href="https://en.wikipedia.org/wiki/Evolution_strategy" target="_blank" class="link-button paper">Wikipedia</a>
                         </td>
                     </tr>
                     <tr>
@@ -206,23 +228,14 @@
                             <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">🐍 Python Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Python Code</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Library Dependencies</td>
-                        <td>
-                            <strong>Python:</strong> none required; numpy used transparently via <code>humpday._array</code> when installed via <code>pip install humpday[fast]</code>
-                        </td>
-                        <td>
-                            <a href="https://github.com/microprediction/humpday#optional-numpy-acceleration" target="_blank" class="link-button python">📖 Backends</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Continuous unconstrained optimization on moderate-dimensional problems</li>
                     <li><strong>Dimensions:</strong> Works well from 2 up to a few dozen; favoured for "high-dimensional complex" routing in HumpDay's adaptive optimizer</li>
@@ -233,15 +246,15 @@
             </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Evolution_strategy" target="_blank">Evolution Strategy Wikipedia</a></li>
                         <li><a href="https://en.wikipedia.org/wiki/CMA-ES" target="_blank">CMA-ES (a self-adaptive descendant)</a></li>
                     </ul>
 
-                    <h4>🧬 Algorithm Overview</h4>
+                    <h4>Algorithm Overview</h4>
                     <ol>
                         <li><strong>Initialize</strong> μ parents uniformly at random in the unit cube.</li>
                         <li><strong>Mutate:</strong> pick a parent at random, perturb by σ·𝒩(0,I), clip to the unit cube. Repeat λ times.</li>
@@ -262,12 +275,41 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         }
+
+        // Initialize 3D visualization when page loads
+        document.addEventListener('DOMContentLoaded', function() {
+            const script = document.createElement('script');
+            script.src = '../js/algorithm-visualizer.js';
+            script.onload = function() {
+                function webglAvailable() {
+                    try {
+                        const canvas = document.createElement('canvas');
+                        return !!(window.WebGLRenderingContext && canvas.getContext('webgl'));
+                    } catch (e) {
+                        return false;
+                    }
+                }
+                if (webglAvailable()) {
+                    new AlgorithmVisualizer('algorithmDemo', {
+                        onReady: () => {
+                            const loadingMsg = document.getElementById('loadingMessage');
+                            if (loadingMsg) loadingMsg.style.display = 'none';
+                        }
+                    });
+                } else {
+                    document.getElementById('loadingMessage').innerHTML =
+                        '<h4>WebGL Not Supported</h4>' +
+                        '<p>Your browser does not support WebGL for 3D visualization.</p>';
+                }
+            };
+            document.head.appendChild(script);
+        });
     </script>
 </body>
 </html>

--- a/docs/algorithms/firefly-algorithm.html
+++ b/docs/algorithms/firefly-algorithm.html
@@ -158,21 +158,7 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-
-        .nature-inspired {
+.nature-inspired {
             background: #e8f5e8;
             border: 1px solid #c3e6c3;
             border-radius: 8px;
@@ -188,6 +174,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -206,13 +198,13 @@
             </div>
 
             <div class="nature-inspired">
-                <h3>🌟 Nature-Inspired Algorithm</h3>
+                <h3>Nature-Inspired Algorithm</h3>
                 <p><strong>Firefly Algorithm is inspired by firefly behavior:</strong></p>
                 <ul>
-                    <li>✨ <strong>Bioluminescence:</strong> Fireflies communicate through light signals</li>
-                    <li>🎯 <strong>Attractiveness:</strong> Brighter fireflies attract dimmer ones</li>
-                    <li>📏 <strong>Distance Decay:</strong> Light intensity decreases with distance</li>
-                    <li>🔍 <strong>Random Movement:</strong> Exploration when no brighter fireflies exist</li>
+                    <li><strong>Bioluminescence:</strong> Fireflies communicate through light signals</li>
+                    <li><strong>Attractiveness:</strong> Brighter fireflies attract dimmer ones</li>
+                    <li><strong>Distance Decay:</strong> Light intensity decreases with distance</li>
+                    <li><strong>Random Movement:</strong> Exploration when no brighter fireflies exist</li>
                 </ul>
             </div>
             <div class="visualization-section">
@@ -252,7 +244,7 @@
                             <em>Published: 2008</em>
                         </td>
                         <td>
-                            <a href="https://arxiv.org/abs/1003.1464" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://arxiv.org/abs/1003.1464" target="_blank" class="link-button paper">Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -264,7 +256,7 @@
                             <em>Reference: Academic literature implementations</em>
                         </td>
                         <td>
-                            <a href="https://github.com/topics/firefly-algorithm" target="_blank" class="link-button python">🔍 GitHub Examples</a>
+                            <a href="https://github.com/topics/firefly-algorithm" target="_blank" class="link-button python">GitHub Examples</a>
                         </td>
                     </tr>
                     <tr>
@@ -276,11 +268,11 @@
                             <em>File: humpday/optimizers/firefly*.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript firefly algorithm<br>
@@ -288,25 +280,14 @@
                             <em>Class: FireflyAlgorithm</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> None (custom implementations)<br>
-                            <strong>Humpday Python:</strong> numpy (for mathematical operations)<br>
-                            <strong>Humpday JS:</strong> None (pure JavaScript)
-                        </td>
-                        <td>
-                            <span style="color: #95a5a6;">✨ No external dependencies</span>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Multimodal optimization, continuous problems, exploration-heavy tasks</li>
                     <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~50)</li>
@@ -316,22 +297,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation of firefly algorithm implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing against theoretical expectations and literature results</li>
-                    <li>🎯 Target: Proper swarm behavior and convergence patterns</li>
-                    <li>📊 Metrics: Population diversity, exploration capability, final objective values</li>
-                    <li>🔧 Reference: Yang's original paper and established benchmark results</li>
-                </ul>
-                <p><em>Multiple reference implementations exist - validation against established benchmarks.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Firefly_algorithm" target="_blank">Firefly Algorithm Wikipedia</a></li>
                         <li><a href="https://arxiv.org/abs/1003.1464" target="_blank">Original Firefly Algorithm Paper (Yang, 2008)</a></li>
@@ -340,7 +310,7 @@
                         <li><a href="https://github.com/topics/firefly-algorithm" target="_blank">GitHub Firefly Algorithm Implementations</a></li>
                     </ul>
 
-                    <h3>🔬 Algorithm Components</h3>
+                    <h3>Algorithm Components</h3>
                     <ul>
                         <li><strong>Light Intensity:</strong> I(r) = I₀ × e^(-γr²) where r is distance</li>
                         <li><strong>Attractiveness:</strong> β(r) = β₀ × e^(-γr²) where β₀ is attractiveness at r=0</li>
@@ -349,7 +319,7 @@
                         <li><strong>Light Absorption:</strong> γ controls light absorption coefficient</li>
                     </ul>
 
-                    <h3>📐 Mathematical Foundation</h3>
+                    <h3>Mathematical Foundation</h3>
                     <ul>
                         <li><strong>Objective Function:</strong> f(x) directly relates to light intensity I ∝ f(x)</li>
                         <li><strong>Distance Metric:</strong> Typically Euclidean: r_ij = ||x_i - x_j||</li>
@@ -357,7 +327,7 @@
                         <li><strong>Parameter Ranges:</strong> α ∈ [0,1], β₀ ∈ [0,1], γ ∈ [0,∞)</li>
                     </ul>
 
-                    <h3>⚙️ Key Parameters</h3>
+                    <h3>️ Key Parameters</h3>
                     <ul>
                         <li><strong>Population Size:</strong> Typically 20-50 fireflies</li>
                         <li><strong>α (Randomization):</strong> Usually 0.2-0.5, decreases over time</li>
@@ -366,7 +336,7 @@
                         <li><strong>Generations:</strong> Stopping criteria based on evaluations or convergence</li>
                     </ul>
 
-                    <h3>🎯 Firefly Algorithm Pseudocode</h3>
+                    <h3>Firefly Algorithm Pseudocode</h3>
                     <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
 function fireflyAlgorithm(problem, n_fireflies, max_generations):
     // Initialize firefly population randomly
@@ -386,7 +356,7 @@ function fireflyAlgorithm(problem, n_fireflies, max_generations):
     return best firefly
                     </pre>
 
-                    <h3>🔧 Firefly Algorithm Variants</h3>
+                    <h3>Firefly Algorithm Variants</h3>
                     <ul>
                         <li><strong>Standard FA:</strong> Original Yang formulation</li>
                         <li><strong>Discrete FA:</strong> Adapted for combinatorial problems</li>
@@ -396,7 +366,7 @@ function fireflyAlgorithm(problem, n_fireflies, max_generations):
                         <li><strong>Adaptive FA:</strong> Self-adjusting parameters during search</li>
                     </ul>
 
-                    <h3>🚀 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Engineering Design:</strong> Structural optimization, antenna design</li>
                         <li><strong>Image Processing:</strong> Feature selection, clustering</li>
@@ -406,7 +376,7 @@ function fireflyAlgorithm(problem, n_fireflies, max_generations):
                         <li><strong>Economics:</strong> Portfolio optimization and forecasting</li>
                     </ul>
 
-                    <h3>💡 Advantages of Firefly Algorithm</h3>
+                    <h3>Advantages of Firefly Algorithm</h3>
                     <ul>
                         <li><strong>Automatic Subdivision:</strong> Swarm can naturally divide into subgroups</li>
                         <li><strong>Multimodal Capability:</strong> Can find multiple optima simultaneously</li>
@@ -415,7 +385,7 @@ function fireflyAlgorithm(problem, n_fireflies, max_generations):
                         <li><strong>Global Communication:</strong> Brightest firefly influences entire swarm</li>
                     </ul>
 
-                    <h3>⚠️ Limitations</h3>
+                    <h3>️ Limitations</h3>
                     <ul>
                         <li><strong>Parameter Sensitivity:</strong> Performance depends on α, β₀, γ settings</li>
                         <li><strong>Convergence Speed:</strong> May be slower than specialized algorithms</li>
@@ -435,10 +405,10 @@ function fireflyAlgorithm(problem, n_fireflies, max_generations):
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/genetic-algorithm.html
+++ b/docs/algorithms/genetic-algorithm.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #8e44ad;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -158,23 +158,16 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-    </style>
+</style>
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -228,7 +221,7 @@
                             <em>Published: 1970s</em>
                         </td>
                         <td>
-                            <a href="https://mitpress.mit.edu/9780262581110/adaptation-in-natural-and-artificial-systems/" target="_blank" class="link-button paper">📖 Holland's Book</a>
+                            <a href="https://mitpress.mit.edu/9780262581110/adaptation-in-natural-and-artificial-systems/" target="_blank" class="link-button paper">Holland's Book</a>
                         </td>
                     </tr>
                     <tr>
@@ -240,24 +233,24 @@
                             <em>Package: deap</em>
                         </td>
                         <td>
-                            <a href="https://deap.readthedocs.io/" target="_blank" class="link-button python">📦 DEAP Docs</a>
-                            <a href="https://github.com/DEAP/deap" target="_blank" class="link-button python">🔍 GitHub</a>
+                            <a href="https://deap.readthedocs.io/" target="_blank" class="link-button python">DEAP Docs</a>
+                            <a href="https://github.com/DEAP/deap" target="_blank" class="link-button python">GitHub</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Wrapper</td>
+                        <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Humpday Integration</strong><br>
+                            <strong>HumpDay Python Implementation</strong><br>
                             Uses DEAP's genetic algorithm framework<br>
                             Pre-configured for continuous optimization<br>
                             <em>File: humpday/optimizers/deapopt.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript GA with selection, crossover, mutation<br>
@@ -265,25 +258,14 @@
                             <em>Class: GeneticAlgorithm</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> DEAP package<br>
-                            <strong>Humpday Python:</strong> deap, numpy<br>
-                            <strong>Humpday JS:</strong> None (standalone port)
-                        </td>
-                        <td>
-                            <a href="https://pypi.org/project/deap/" target="_blank" class="link-button python">📦 PyPI</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Combinatorial optimization, multimodal landscapes, large search spaces</li>
                     <li><strong>Dimensions:</strong> Scales to hundreds of dimensions</li>
@@ -293,22 +275,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation against DEAP reference implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing JavaScript vs DEAP GA implementation</li>
-                    <li>🎯 Target: Statistical equivalence with standard GA operators</li>
-                    <li>📊 Metrics: Population diversity, convergence rate, final fitness values</li>
-                    <li>🔧 Challenge: Matching DEAP's operator implementations and parameters</li>
-                </ul>
-                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Genetic_algorithm" target="_blank">Genetic Algorithm Wikipedia</a></li>
                         <li><a href="https://deap.readthedocs.io/" target="_blank">DEAP Documentation</a></li>
@@ -317,7 +288,7 @@
                         <li><a href="https://www.obitko.com/tutorials/genetic-algorithms/" target="_blank">GA Tutorial by Marek Obitko</a></li>
                     </ul>
 
-                    <h3>🔬 Algorithm Components</h3>
+                    <h3>Algorithm Components</h3>
                     <ul>
                         <li><strong>Selection:</strong> Tournament, roulette wheel, rank-based selection</li>
                         <li><strong>Crossover:</strong> Single/multi-point, uniform, simulated binary (SBX)</li>
@@ -326,7 +297,7 @@
                         <li><strong>Encoding:</strong> Binary, real-valued, permutation representations</li>
                     </ul>
 
-                    <h3>🧬 GA Variants</h3>
+                    <h3>GA Variants</h3>
                     <ul>
                         <li><strong>Simple GA:</strong> Holland's original binary-encoded GA</li>
                         <li><strong>Real-Coded GA:</strong> Direct real number representation</li>
@@ -336,7 +307,7 @@
                         <li><strong>Multi-Objective GA:</strong> NSGA-II, SPEA-2 for Pareto optimization</li>
                     </ul>
 
-                    <h3>🎯 GA Applications</h3>
+                    <h3>GA Applications</h3>
                     <ul>
                         <li><strong>Scheduling:</strong> Job shop, vehicle routing, timetabling</li>
                         <li><strong>Design Optimization:</strong> Antenna design, circuit layout</li>
@@ -346,7 +317,7 @@
                         <li><strong>Game AI:</strong> Strategy evolution, procedural content generation</li>
                     </ul>
 
-                    <h3>📐 Mathematical Foundation</h3>
+                    <h3>Mathematical Foundation</h3>
                     <ul>
                         <li><strong>Schema Theory:</strong> Building blocks and convergence analysis</li>
                         <li><strong>No Free Lunch:</strong> Performance bounds across problem classes</li>
@@ -365,10 +336,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/harmony-search.html
+++ b/docs/algorithms/harmony-search.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #f8f9fa;
+            background: #34495e;
             padding: 20px;
             border-bottom: 1px solid #ddd;
         }
@@ -145,20 +145,7 @@
             display: none;
             margin-top: 15px;
         }
-
-        .validation-pending {
-            background: #f8f9fa;
-            border: 1px solid #ddd;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #333;
-        }
-
-        .harmony-note {
+.harmony-note {
             background: #f8f9fa;
             border: 1px solid #ddd;
             padding: 15px;
@@ -173,6 +160,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -237,7 +230,7 @@
                             <em>Published: 2001</em>
                         </td>
                         <td>
-                            <a href="https://link.springer.com/article/10.1023/A:1010928611306" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://link.springer.com/article/10.1023/A:1010928611306" target="_blank" class="link-button paper">Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -261,11 +254,11 @@
                             <em>File: humpday/optimizers/harmonysearch.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript harmony search<br>
@@ -273,21 +266,10 @@
                             <em>Class: HarmonySearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> None (custom research implementations)<br>
-                            <strong>Humpday Python:</strong> numpy (for array operations)<br>
-                            <strong>Humpday JS:</strong> None (pure JavaScript)
-                        </td>
-                        <td>
-                            <span style="color: #95a5a6;">✨ No external dependencies</span>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
@@ -304,7 +286,7 @@
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Harmony_search" target="_blank">Harmony Search Wikipedia</a></li>
                         <li><a href="https://link.springer.com/article/10.1023/A:1010928611306" target="_blank">Original HS Paper (Geem et al., 2001)</a></li>
@@ -313,7 +295,7 @@
                         <li><a href="https://link.springer.com/journal/10287" target="_blank">International Journal of Optimization</a></li>
                     </ul>
 
-                    <h3>🔬 Core Algorithm Components</h3>
+                    <h3>Core Algorithm Components</h3>
                     <ul>
                         <li><strong>Harmony Memory (HM):</strong> Population of HMS best solutions found</li>
                         <li><strong>Harmony Memory Size (HMS):</strong> Number of solutions stored</li>
@@ -323,7 +305,7 @@
                         <li><strong>Random Selection:</strong> Generate completely new value</li>
                     </ul>
 
-                    <h3>📐 Mathematical Formulation</h3>
+                    <h3>Mathematical Formulation</h3>
                     <ul>
                         <li><strong>Memory Selection:</strong> x'ᵢ = HMⱼ(i) with probability HMCR</li>
                         <li><strong>Pitch Adjustment:</strong> x'ᵢ = x'ᵢ ± rand() × bw with probability PAR</li>
@@ -331,7 +313,7 @@
                         <li><strong>Memory Update:</strong> Replace worst harmony if new harmony is better</li>
                     </ul>
 
-                    <h3>⚙️ Key Parameters</h3>
+                    <h3>️ Key Parameters</h3>
                     <ul>
                         <li><strong>HMS:</strong> Harmony Memory Size, typically 10-50</li>
                         <li><strong>HMCR:</strong> Memory Consideration Rate, usually 0.7-0.95</li>
@@ -340,7 +322,7 @@
                         <li><strong>Termination:</strong> Maximum iterations or convergence criteria</li>
                     </ul>
 
-                    <h3>🎯 Harmony Search Algorithm Pseudocode</h3>
+                    <h3>Harmony Search Algorithm Pseudocode</h3>
                     <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
 function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
     // Step 1: Initialize Harmony Memory
@@ -380,7 +362,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
     return HM[0]  // Best harmony
                     </pre>
 
-                    <h3>🔧 Harmony Search Variants</h3>
+                    <h3>Harmony Search Variants</h3>
                     <ul>
                         <li><strong>Classical HS:</strong> Original algorithm with fixed parameters</li>
                         <li><strong>Improved HS (IHS):</strong> Dynamic PAR and bandwidth adjustment</li>
@@ -390,7 +372,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Multi-Objective HS:</strong> Pareto-based harmony search</li>
                     </ul>
 
-                    <h3>🎼 Musical Analogy Details</h3>
+                    <h3>Musical Analogy Details</h3>
                     <ul>
                         <li><strong>Musician:</strong> Decision variable (instrument)</li>
                         <li><strong>Musical Note:</strong> Value of decision variable</li>
@@ -400,7 +382,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Aesthetic Quality:</strong> Objective function value</li>
                     </ul>
 
-                    <h3>🚀 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Engineering Design:</strong> Structural optimization, water distribution</li>
                         <li><strong>Energy Systems:</strong> Power system optimization, renewable energy</li>
@@ -410,7 +392,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Economics:</strong> Portfolio optimization, supply chain management</li>
                     </ul>
 
-                    <h3>💡 Advantages of Harmony Search</h3>
+                    <h3>Advantages of Harmony Search</h3>
                     <ul>
                         <li><strong>Simplicity:</strong> Easy to understand and implement</li>
                         <li><strong>Few Parameters:</strong> Only HMS, HMCR, PAR to tune</li>
@@ -420,7 +402,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>No Gradient Needed:</strong> Works with black-box functions</li>
                     </ul>
 
-                    <h3>⚠️ Limitations</h3>
+                    <h3>️ Limitations</h3>
                     <ul>
                         <li><strong>Parameter Sensitivity:</strong> Performance depends on HMCR and PAR</li>
                         <li><strong>Premature Convergence:</strong> May converge too quickly with wrong parameters</li>
@@ -429,7 +411,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Memory Management:</strong> Fixed memory size may be suboptimal</li>
                     </ul>
 
-                    <h3>🔄 Parameter Guidelines</h3>
+                    <h3>Parameter Guidelines</h3>
                     <ul>
                         <li><strong>HMCR = 0.9:</strong> High memory consideration for exploitation</li>
                         <li><strong>HMCR = 0.1:</strong> Low memory consideration for exploration</li>
@@ -439,7 +421,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Dynamic Parameters:</strong> Adapt HMCR, PAR during search</li>
                     </ul>
 
-                    <h3>🎨 Creative Aspects</h3>
+                    <h3>Creative Aspects</h3>
                     <ul>
                         <li><strong>Artistic Inspiration:</strong> Based on human creativity and musical composition</li>
                         <li><strong>Improvisation Process:</strong> Mimics how musicians create new melodies</li>
@@ -448,7 +430,7 @@ function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
                         <li><strong>Intuitive Understanding:</strong> Easy to explain through musical metaphor</li>
                     </ul>
 
-                    <h3>📊 Comparison with Other Metaheuristics</h3>
+                    <h3>Comparison with Other Metaheuristics</h3>
                     <ul>
                         <li><strong>vs GA:</strong> Memory-based vs generation-based evolution</li>
                         <li><strong>vs PSO:</strong> Discrete memory vs continuous population movement</li>

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #e74c3c;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -158,21 +158,7 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-
-        .local-search-note {
+.local-search-note {
             background: #fff5f5;
             border: 1px solid #fed7d7;
             border-radius: 8px;
@@ -188,6 +174,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -206,13 +198,13 @@
             </div>
 
             <div class="local-search-note">
-                <h3>⚠️ Local Search Algorithm Notice</h3>
+                <h3>️ Local Search Algorithm Notice</h3>
                 <p><strong>Hill Climbing is a pure local search method:</strong></p>
                 <ul>
-                    <li>🎯 <strong>Local Optima:</strong> Gets trapped in local minima - no global search capability</li>
-                    <li>🔄 <strong>Starting Point Dependent:</strong> Final solution depends heavily on initialization</li>
-                    <li>⚡ <strong>Fast Convergence:</strong> Very efficient for local refinement</li>
-                    <li>🔧 <strong>Baseline Method:</strong> Useful as starting point or component in hybrid algorithms</li>
+                    <li><strong>Local Optima:</strong> Gets trapped in local minima - no global search capability</li>
+                    <li><strong>Starting Point Dependent:</strong> Final solution depends heavily on initialization</li>
+                    <li><strong>Fast Convergence:</strong> Very efficient for local refinement</li>
+                    <li><strong>Baseline Method:</strong> Useful as starting point or component in hybrid algorithms</li>
                 </ul>
             </div>
             <div class="visualization-section">
@@ -252,7 +244,7 @@
                             <em>Concept: Ancient (1950s AI research)</em>
                         </td>
                         <td>
-                            <a href="https://en.wikipedia.org/wiki/Hill_climbing" target="_blank" class="link-button info">📖 Wikipedia</a>
+                            <a href="https://en.wikipedia.org/wiki/Hill_climbing" target="_blank" class="link-button info">Wikipedia</a>
                         </td>
                     </tr>
                     <tr>
@@ -264,7 +256,7 @@
                             <em>Self-reference: Algorithm-specific implementation</em>
                         </td>
                         <td>
-                            <a href="https://artint.info/html/ArtInt_71.html" target="_blank" class="link-button info">🎓 AI Textbook</a>
+                            <a href="https://artint.info/html/ArtInt_71.html" target="_blank" class="link-button info">AI Textbook</a>
                         </td>
                     </tr>
                     <tr>
@@ -276,11 +268,11 @@
                             <em>File: humpday/optimizers/localsearch*.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript hill climbing with random neighbors<br>
@@ -288,25 +280,14 @@
                             <em>Class: HillClimbing</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> None (custom implementation)<br>
-                            <strong>Humpday Python:</strong> numpy (for vector operations)<br>
-                            <strong>Humpday JS:</strong> None (pure JavaScript)
-                        </td>
-                        <td>
-                            <span style="color: #95a5a6;">✨ No external dependencies</span>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Local refinement, unimodal functions, quick improvements</li>
                     <li><strong>Dimensions:</strong> Scalable to any dimension</li>
@@ -316,29 +297,18 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation of hill climbing implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing behavior against theoretical expectations</li>
-                    <li>🎯 Target: Proper local search behavior and convergence to local optima</li>
-                    <li>📊 Metrics: Local optimality verification, convergence speed</li>
-                    <li>🔧 Reference: Self-validation against algorithm specification</li>
-                </ul>
-                <p><em>Hill climbing is simple enough that correct implementation is the primary validation.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Hill_climbing" target="_blank">Hill Climbing Wikipedia</a></li>
                         <li><a href="https://artint.info/html/ArtInt_71.html" target="_blank">Artificial Intelligence: Foundations of Computational Agents</a></li>
                         <li><a href="http://aima.cs.berkeley.edu/" target="_blank">AI: A Modern Approach (Russell & Norvig)</a></li>
                         </ul>
 
-                    <h3>🔬 Algorithm Variants</h3>
+                    <h3>Algorithm Variants</h3>
                     <ul>
                         <li><strong>Simple Hill Climbing:</strong> Move to first improving neighbor</li>
                         <li><strong>Steepest-Ascent:</strong> Evaluate all neighbors, choose best improvement</li>
@@ -347,7 +317,7 @@
                         <li><strong>Sideways Move:</strong> Allow plateau moves to escape flat regions</li>
                     </ul>
 
-                    <h3>📐 Neighborhood Definitions</h3>
+                    <h3>Neighborhood Definitions</h3>
                     <ul>
                         <li><strong>Continuous:</strong> Small perturbations in real-valued variables</li>
                         <li><strong>Discrete:</strong> Bit-flips, swaps, insertions for combinatorial problems</li>
@@ -356,7 +326,7 @@
                         <li><strong>Adaptive:</strong> Step size changes based on success rate</li>
                     </ul>
 
-                    <h3>⚙️ Algorithm Pseudocode</h3>
+                    <h3>️ Algorithm Pseudocode</h3>
                     <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
 function hillClimbing(problem, initialSolution):
     current = initialSolution
@@ -375,7 +345,7 @@ function hillClimbing(problem, initialSolution):
     return current
                     </pre>
 
-                    <h3>💡 When Hill Climbing Works Well</h3>
+                    <h3>When Hill Climbing Works Well</h3>
                     <ul>
                         <li><strong>Unimodal Problems:</strong> Single global optimum with no local optima</li>
                         <li><strong>Local Refinement:</strong> Polishing solutions from other algorithms</li>
@@ -384,7 +354,7 @@ function hillClimbing(problem, initialSolution):
                         <li><strong>Component in Hybrids:</strong> Local search phase in metaheuristics</li>
                     </ul>
 
-                    <h3>🚧 Hill Climbing Limitations</h3>
+                    <h3>Hill Climbing Limitations</h3>
                     <ul>
                         <li><strong>Local Optima:</strong> Cannot escape local minima</li>
                         <li><strong>Plateaus:</strong> Gets stuck on flat regions</li>
@@ -393,7 +363,7 @@ function hillClimbing(problem, initialSolution):
                         <li><strong>No Global View:</strong> Purely greedy approach</li>
                     </ul>
 
-                    <h3>🔧 Improvements and Extensions</h3>
+                    <h3>Improvements and Extensions</h3>
                     <ul>
                         <li><strong>Random Restart:</strong> Run multiple times with different starts</li>
                         <li><strong>Simulated Annealing:</strong> Allow occasional uphill moves</li>
@@ -402,7 +372,7 @@ function hillClimbing(problem, initialSolution):
                         <li><strong>Iterated Local Search:</strong> Perturb and restart periodically</li>
                     </ul>
 
-                    <h3>🎯 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Traveling Salesman:</strong> 2-opt, 3-opt local search moves</li>
                         <li><strong>Scheduling:</strong> Local improvements to task assignments</li>
@@ -423,10 +393,10 @@ function hillClimbing(problem, initialSolution):
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #9b59b6;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -158,21 +158,7 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-
-        .gradient-note {
+.gradient-note {
             background: #fff5f5;
             border: 1px solid #fed7d7;
             border-radius: 8px;
@@ -188,6 +174,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -206,13 +198,13 @@
             </div>
 
             <div class="gradient-note">
-                <h3>⚠️ Gradient-Based Algorithm Notice</h3>
+                <h3>️ Gradient-Based Algorithm Notice</h3>
                 <p><strong>L-BFGS-B requires gradient information:</strong></p>
                 <ul>
-                    <li>🔍 <strong>Analytical Gradients:</strong> Best performance with exact gradients</li>
-                    <li>📊 <strong>Finite Differences:</strong> Can approximate gradients automatically</li>
-                    <li>⚡ <strong>Optimization Context:</strong> May not be suitable for black-box problems without gradients</li>
-                    <li>🎯 <strong>Humpday Usage:</strong> Likely uses finite difference approximation in [0,1]ⁿ hypercube</li>
+                    <li><strong>Analytical Gradients:</strong> Best performance with exact gradients</li>
+                    <li><strong>Finite Differences:</strong> Can approximate gradients automatically</li>
+                    <li><strong>Optimization Context:</strong> May not be suitable for black-box problems without gradients</li>
+                    <li><strong>Humpday Usage:</strong> Likely uses finite difference approximation in [0,1]ⁿ hypercube</li>
                 </ul>
             </div>
             <div class="visualization-section">
@@ -252,7 +244,7 @@
                             <em>Published: 1995</em>
                         </td>
                         <td>
-                            <a href="https://dl.acm.org/doi/10.1145/279232.279236" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://dl.acm.org/doi/10.1145/279232.279236" target="_blank" class="link-button paper">Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -264,24 +256,24 @@
                             <em>Package: scipy</em>
                         </td>
                         <td>
-                            <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-lbfgsb.html" target="_blank" class="link-button python">🐍 SciPy Docs</a>
-                            <a href="https://github.com/scipy/scipy/tree/main/scipy/optimize" target="_blank" class="link-button python">🔍 Source</a>
+                            <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-lbfgsb.html" target="_blank" class="link-button python">SciPy Docs</a>
+                            <a href="https://github.com/scipy/scipy/tree/main/scipy/optimize" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Wrapper</td>
+                        <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Humpday Integration</strong><br>
-                            Calls scipy.optimize.minimize(method='L-BFGS-B')<br>
-                            Automatic finite difference gradients<br>
+                            <strong>HumpDay Python Implementation</strong><br>
+                            Pure-Python finite-difference gradient descent with momentum<br>
+                            No required dependencies; named after L-BFGS-B but structurally closer to gradient descent + momentum<br>
                             <em>File: humpday/optimizers/scipy_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             JavaScript L-BFGS-B with finite difference gradients<br>
@@ -289,25 +281,14 @@
                             <em>Class: LBFGSB</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> scipy.optimize<br>
-                            <strong>Humpday Python:</strong> scipy, numpy<br>
-                            <strong>Humpday JS:</strong> None (standalone port)
-                        </td>
-                        <td>
-                            <a href="https://pypi.org/project/scipy/" target="_blank" class="link-button python">📦 PyPI</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Large-scale smooth optimization with bound constraints</li>
                     <li><strong>Dimensions:</strong> Excellent for high dimensions (hundreds to thousands)</li>
@@ -317,22 +298,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation against SciPy L-BFGS-B reference implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing JavaScript vs scipy.optimize.minimize(method='L-BFGS-B')</li>
-                    <li>🎯 Target: Similar convergence with automatic gradient approximation</li>
-                    <li>📊 Metrics: Final objective values, convergence speed, gradient norm</li>
-                    <li>🔧 Challenge: Implementing limited-memory updates and bound projection correctly</li>
-                </ul>
-                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Limited-memory_BFGS" target="_blank">L-BFGS Wikipedia</a></li>
                         <li><a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html" target="_blank">SciPy minimize Documentation</a></li>
@@ -340,7 +310,7 @@
                         <li><a href="https://users.iems.northwestern.edu/~nocedal/lbfgsb.html" target="_blank">L-BFGS-B Software Page</a></li>
                         </ul>
 
-                    <h3>🔬 Algorithm Components</h3>
+                    <h3>Algorithm Components</h3>
                     <ul>
                         <li><strong>Limited Memory:</strong> Store only m recent (s,y) pairs instead of full Hessian</li>
                         <li><strong>BFGS Update:</strong> Quasi-Newton Hessian approximation using gradients</li>
@@ -349,7 +319,7 @@
                         <li><strong>Line Search:</strong> Wolfe conditions for step length selection</li>
                     </ul>
 
-                    <h3>📐 Mathematical Foundation</h3>
+                    <h3>Mathematical Foundation</h3>
                     <ul>
                         <li><strong>BFGS Formula:</strong> H_{k+1} = H_k + (1 + (y^T H_k y)/(s^T y)) * (s s^T)/(s^T y) - (s y^T H_k + H_k y s^T)/(s^T y)</li>
                         <li><strong>Two-Loop:</strong> q = ∇f_k, then backwards and forwards loops over stored vectors</li>
@@ -358,7 +328,7 @@
                         <li><strong>Cauchy Point:</strong> Piecewise linear minimizer along projected gradient</li>
                     </ul>
 
-                    <h3>⚙️ Key Parameters</h3>
+                    <h3>️ Key Parameters</h3>
                     <ul>
                         <li><strong>Memory Size (m):</strong> Usually 5-20 (s,y) pairs stored</li>
                         <li><strong>Line Search:</strong> Wolfe conditions c1=1e-4, c2=0.9</li>
@@ -367,7 +337,7 @@
                         <li><strong>Max Iterations:</strong> Prevent infinite loops</li>
                     </ul>
 
-                    <h3>🎯 L-BFGS vs L-BFGS-B</h3>
+                    <h3>L-BFGS vs L-BFGS-B</h3>
                     <ul>
                         <li><strong>L-BFGS:</strong> Unconstrained optimization only</li>
                         <li><strong>L-BFGS-B:</strong> Extends to simple bound constraints</li>
@@ -376,7 +346,7 @@
                         <li><strong>Complexity:</strong> Similar O(mn) complexity per iteration</li>
                     </ul>
 
-                    <h3>🚀 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Machine Learning:</strong> Training large neural networks</li>
                         <li><strong>Parameter Estimation:</strong> Maximum likelihood estimation</li>
@@ -386,7 +356,7 @@
                         <li><strong>Image Processing:</strong> Image restoration and deconvolution</li>
                     </ul>
 
-                    <h3>⚡ Why L-BFGS-B is Popular</h3>
+                    <h3>Why L-BFGS-B is Popular</h3>
                     <ul>
                         <li><strong>Memory Efficient:</strong> O(mn) storage vs O(n²) for full Newton</li>
                         <li><strong>Fast Convergence:</strong> Superlinear on smooth problems</li>
@@ -407,10 +377,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #2c3e50;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -161,6 +161,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -214,19 +220,19 @@
                             <em>Published: 1965</em>
                         </td>
                         <td>
-                            <a href="https://doi.org/10.1093/comjnl/7.4.308" target="_blank" class="link-button paper">📄 Paper</a>
+                            <a href="https://doi.org/10.1093/comjnl/7.4.308" target="_blank" class="link-button paper">Paper</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Python Implementation</strong><br>
-                            Uses SciPy's optimize.minimize with method='Nelder-Mead'<br>
-                            Well-tested and numerically stable implementation<br>
+                            <strong>HumpDay Python Implementation</strong><br>
+                            Pure-Python simplex method, faithful to SciPy's parameters (rho=1, chi=2, psi=sigma=0.5)<br>
+                            No required dependencies<br>
                             <em>File: humpday/optimizers/scipy_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">🐍 Python Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Python Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -238,24 +244,14 @@
                             <em>Class: NelderMead</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js" target="_blank" class="link-button javascript">🌐 JavaScript Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js" target="_blank" class="link-button javascript">JavaScript Code</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Library Dependencies</td>
-                        <td>
-                            <strong>Python:</strong> scipy.optimize<br>
-                            <strong>JavaScript:</strong> None (pure JS implementation)
-                        </td>
-                        <td>
-                            <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-neldermead.html" target="_blank" class="link-button python">📖 SciPy Docs</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Low to medium dimensions (2-20D), robust across function types</li>
                     <li><strong>Dimensions:</strong> Performance degrades significantly above 10-20 dimensions</li>
@@ -266,16 +262,16 @@
             </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Nelder%E2%80%93Mead_method" target="_blank">Nelder-Mead Wikipedia</a></li>
                         <li><a href="https://codesachin.wordpress.com/2016/01/16/nelder-mead-optimization/" target="_blank">Visual Tutorial</a></li>
                         <li><a href="https://www.mathworks.com/help/matlab/math/optimizing-nonlinear-functions.html" target="_blank">MATLAB Documentation</a></li>
                     </ul>
 
-                    <h4>🔍 Algorithm Visualization</h4>
+                    <h4>Algorithm Visualization</h4>
                     <p>The Nelder-Mead method is one of the most visually intuitive optimization algorithms. The simplex (triangle in 2D) moves through the parameter space by:</p>
                     <ul>
                         <li><strong>Reflection:</strong> Mirror the worst point across the centroid</li>
@@ -295,10 +291,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #2c3e50;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -175,6 +175,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -228,7 +234,7 @@
                             <em>Published: 2004</em>
                         </td>
                         <td>
-                            <a href="https://www.damtp.cam.ac.uk/user/na/NA_papers/NA2004_08.pdf" target="_blank" class="link-button paper">📄 Paper</a>
+                            <a href="https://www.damtp.cam.ac.uk/user/na/NA_papers/NA2004_08.pdf" target="_blank" class="link-button paper">Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -240,24 +246,24 @@
                             <em>Package: pdfo</em>
                         </td>
                         <td>
-                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">📦 PDFO</a>
-                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python">🐍 Source</a>
+                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">PDFO</a>
+                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Wrapper</td>
+                        <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Humpday Integration</strong><br>
+                            <strong>HumpDay Python Implementation</strong><br>
                             Calls PDFO's NEWUOA implementation<br>
                             Standardized interface for optimization contests<br>
                             <em>File: humpday/optimizers/prima_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             JavaScript port attempting to match PDFO behavior<br>
@@ -265,25 +271,14 @@
                             <em>Class: PRIMA_NEWUOA</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> PDFO package (wraps Powell's Fortran)<br>
-                            <strong>Humpday Python:</strong> pdfo, numpy<br>
-                            <strong>Humpday JS:</strong> None (standalone port)
-                        </td>
-                        <td>
-                            <a href="https://pypi.org/project/pdfo/" target="_blank" class="link-button python">📦 PyPI</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Smooth, unconstrained problems in moderate to high dimensions</li>
                     <li><strong>Dimensions:</strong> Particularly effective for n > 10 where UOBYQA becomes expensive</li>
@@ -294,7 +289,7 @@
             </div>
 
             <div class="validation-issues">
-                <h3>❌ Validation Status: IMPLEMENTATION ISSUES</h3>
+                <h3>Validation Status: IMPLEMENTATION ISSUES</h3>
                 <p><strong>JavaScript implementation currently has errors preventing proper validation:</strong></p>
                 <ul>
                     <li><strong>Error Detected:</strong> "xPts is not defined" in JavaScript implementation</li>
@@ -306,16 +301,16 @@
             </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/NEWUOA" target="_blank">NEWUOA Wikipedia</a></li>
                         <li><a href="https://www.pdfo.net/" target="_blank">PDFO Documentation</a></li>
                         <li><a href="https://link.springer.com/chapter/10.1007/978-0-387-30065-5_17" target="_blank">Derivative-Free Optimization Methods</a></li>
                     </ul>
 
-                    <h3>🔬 Algorithm Theory</h3>
+                    <h3>Algorithm Theory</h3>
                     <ul>
                         <li><strong>Interpolation Set:</strong> 2n+1 points vs UOBYQA's (n+1)(n+2)/2 points</li>
                         <li><strong>Quadratic Models:</strong> Underdetermined system solved with minimum Frobenius norm</li>
@@ -324,7 +319,7 @@
                         <li><strong>Geometry Improvement:</strong> Automatic point replacement for better conditioning</li>
                     </ul>
 
-                    <h3>⚖️ NEWUOA vs UOBYQA Trade-offs</h3>
+                    <h3>️ NEWUOA vs UOBYQA Trade-offs</h3>
                     <ul>
                         <li><strong>Efficiency:</strong> NEWUOA scales better - O(n) vs O(n²) interpolation points</li>
                         <li><strong>Model Quality:</strong> UOBYQA has fully determined models, NEWUOA underdetermined</li>
@@ -333,7 +328,7 @@
                         <li><strong>Dimension Limit:</strong> NEWUOA practical for much higher dimensions</li>
                     </ul>
 
-                    <h3>🎯 When to Use NEWUOA</h3>
+                    <h3>When to Use NEWUOA</h3>
                     <ul>
                         <li><strong>High Dimensions:</strong> n > 10 where UOBYQA becomes prohibitive</li>
                         <li><strong>Limited Budget:</strong> When function evaluations are very expensive</li>
@@ -342,7 +337,7 @@
                         <li><strong>Global Search:</strong> Combined with multi-start for global optimization</li>
                     </ul>
 
-                    <h3>🔧 Implementation Details</h3>
+                    <h3>Implementation Details</h3>
                     <ul>
                         <li><strong>Initial Geometry:</strong> 2n+1 points around starting point</li>
                         <li><strong>Model Building:</strong> Minimum norm solution for underdetermined system</li>
@@ -362,10 +357,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #f39c12;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -158,23 +158,16 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-    </style>
+</style>
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -228,7 +221,7 @@
                             <em>Developed: 1950s-1990s (Hooke-Jeeves, Torczon, etc.)</em>
                         </td>
                         <td>
-                            <a href="https://epubs.siam.org/doi/book/10.1137/1.9781611971200" target="_blank" class="link-button paper">📖 Direct Search Book</a>
+                            <a href="https://epubs.siam.org/doi/book/10.1137/1.9781611971200" target="_blank" class="link-button paper">Direct Search Book</a>
                         </td>
                     </tr>
                     <tr>
@@ -240,23 +233,23 @@
                             <em>Reference: MATLAB/Octave implementations</em>
                         </td>
                         <td>
-                            <a href="https://www.mathworks.com/help/gads/patternsearch.html" target="_blank" class="link-button info">🔍 MATLAB Docs</a>
+                            <a href="https://www.mathworks.com/help/gads/patternsearch.html" target="_blank" class="link-button info">MATLAB Docs</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Wrapper</td>
+                        <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Humpday Integration</strong><br>
+                            <strong>HumpDay Python Implementation</strong><br>
                             Custom pattern search implementation<br>
                             Coordinate-based polling with adaptive mesh<br>
                             <em>File: humpday/optimizers/search_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Custom Implementation</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Custom Implementation</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             JavaScript pattern search with coordinate polling<br>
@@ -264,25 +257,14 @@
                             <em>Class: PatternSearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> MATLAB Global Optimization Toolbox<br>
-                            <strong>Humpday Python:</strong> numpy (custom implementation)<br>
-                            <strong>Humpday JS:</strong> None (standalone port)
-                        </td>
-                        <td>
-                            <a href="https://www.mathworks.com/products/global-optimization.html" target="_blank" class="link-button info">📦 MATLAB Toolbox</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Discontinuous functions, noisy problems, constrained optimization</li>
                     <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~50)</li>
@@ -292,22 +274,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation against reference pattern search implementations in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing JavaScript vs MATLAB patternsearch() or custom Python</li>
-                    <li>🎯 Target: Similar convergence behavior and mesh adaptation</li>
-                    <li>📊 Metrics: Final objective values, mesh size evolution, polling efficiency</li>
-                    <li>🔧 Challenge: Multiple pattern search variants - need to specify which reference</li>
-                </ul>
-                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Pattern_search_(optimization)" target="_blank">Pattern Search Wikipedia</a></li>
                         <li><a href="https://www.mathworks.com/help/gads/patternsearch.html" target="_blank">MATLAB Pattern Search Documentation</a></li>
@@ -315,7 +286,7 @@
                         <li><a href="https://link.springer.com/article/10.1007/BF01585997" target="_blank">Hooke-Jeeves Original Paper</a></li>
                     </ul>
 
-                    <h3>🔬 Algorithm Components</h3>
+                    <h3>Algorithm Components</h3>
                     <ul>
                         <li><strong>Mesh:</strong> Discrete set of points where function is evaluated</li>
                         <li><strong>Pattern:</strong> Set of directions defining search pattern</li>
@@ -324,7 +295,7 @@
                         <li><strong>Mesh Coarsening:</strong> Increase mesh size after successful iterations</li>
                     </ul>
 
-                    <h3>📐 Pattern Types</h3>
+                    <h3>Pattern Types</h3>
                     <ul>
                         <li><strong>Coordinate Patterns:</strong> ±eᵢ directions (axis-aligned)</li>
                         <li><strong>Maximal Basis:</strong> 2n directions ensuring positive spanning</li>
@@ -333,7 +304,7 @@
                         <li><strong>Custom Patterns:</strong> Problem-specific direction sets</li>
                     </ul>
 
-                    <h3>⚙️ Pattern Search Variants</h3>
+                    <h3>️ Pattern Search Variants</h3>
                     <ul>
                         <li><strong>Hooke-Jeeves:</strong> Exploratory + pattern moves</li>
                         <li><strong>Coordinate Search:</strong> Simple alternating coordinate directions</li>
@@ -342,7 +313,7 @@
                         <li><strong>GSS (Generating Set Search):</strong> Positive basis guarantee</li>
                     </ul>
 
-                    <h3>🎯 Convergence Theory</h3>
+                    <h3>Convergence Theory</h3>
                     <ul>
                         <li><strong>Clarke Stationarity:</strong> GPS converges to Clarke stationary points</li>
                         <li><strong>Mesh Size Limit:</strong> lim inf Δₘ = 0 under standard conditions</li>
@@ -350,7 +321,7 @@
                         <li><strong>Positive Spanning:</strong> Pattern directions must positively span ℝⁿ</li>
                     </ul>
 
-                    <h3>🚀 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Engineering Design:</strong> When objective function has discontinuities</li>
                         <li><strong>Simulation Optimization:</strong> Noisy, expensive function evaluations</li>
@@ -359,7 +330,7 @@
                         <li><strong>Environmental Modeling:</strong> Parameter estimation in climate models</li>
                     </ul>
 
-                    <h3>⚙️ Implementation Details</h3>
+                    <h3>️ Implementation Details</h3>
                     <ul>
                         <li><strong>Initial Mesh Size:</strong> Δ₀ typically 1.0 or problem-scaled</li>
                         <li><strong>Mesh Expansion:</strong> Δₖ₊₁ = τΔₖ where τ > 1 (often τ = 2)</li>
@@ -368,7 +339,7 @@
                         <li><strong>Termination:</strong> Δₖ < tolerance or max evaluations</li>
                     </ul>
 
-                    <h3>💡 When to Use Pattern Search</h3>
+                    <h3>When to Use Pattern Search</h3>
                     <ul>
                         <li><strong>Discontinuous Objectives:</strong> Traditional methods fail on non-smooth functions</li>
                         <li><strong>Expensive Evaluations:</strong> Systematic exploration reduces waste</li>
@@ -388,10 +359,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #27ae60;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -158,23 +158,16 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-    </style>
+</style>
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -228,7 +221,7 @@
                             <em>Published: 1964</em>
                         </td>
                         <td>
-                            <a href="https://en.wikipedia.org/wiki/Powell%27s_method" target="_blank" class="link-button info">📖 Wikipedia</a>
+                            <a href="https://en.wikipedia.org/wiki/Powell%27s_method" target="_blank" class="link-button info">Wikipedia</a>
                         </td>
                     </tr>
                     <tr>
@@ -240,24 +233,24 @@
                             <em>Package: scipy</em>
                         </td>
                         <td>
-                            <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-powell.html" target="_blank" class="link-button python">🐍 SciPy Docs</a>
-                            <a href="https://github.com/scipy/scipy/blob/main/scipy/optimize/_optimize.py" target="_blank" class="link-button python">🔍 Source</a>
+                            <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-powell.html" target="_blank" class="link-button python">SciPy Docs</a>
+                            <a href="https://github.com/scipy/scipy/blob/main/scipy/optimize/_optimize.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Wrapper</td>
+                        <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Humpday Integration</strong><br>
-                            Calls scipy.optimize.minimize(method='powell')<br>
-                            Standardized interface for optimization contests<br>
+                            <strong>HumpDay Python Implementation</strong><br>
+                            Pure-Python conjugate-direction method with bounded golden-section line search<br>
+                            No required dependencies<br>
                             <em>File: humpday/optimizers/scipy_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript port of Powell's conjugate direction method<br>
@@ -265,25 +258,14 @@
                             <em>Class: Powell</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> scipy.optimize<br>
-                            <strong>Humpday Python:</strong> scipy, numpy<br>
-                            <strong>Humpday JS:</strong> None (standalone port)
-                        </td>
-                        <td>
-                            <a href="https://pypi.org/project/scipy/" target="_blank" class="link-button python">📦 PyPI</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Quadratic functions and smooth, unimodal problems</li>
                     <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~20-50)</li>
@@ -293,28 +275,18 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation against SciPy reference implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing JavaScript vs scipy.optimize.minimize(method='powell')</li>
-                    <li>🎯 Target: Perfect match or statistical equivalence on benchmark functions</li>
-                    <li>📊 Metrics: Convergence accuracy, function evaluations, solution quality</li>
-                </ul>
-                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Powell%27s_method" target="_blank">Powell's Method Wikipedia</a></li>
                         <li><a href="https://docs.scipy.org/doc/scipy/reference/optimize.html" target="_blank">SciPy Optimization Guide</a></li>
                         <li><a href="https://numerical.recipes/" target="_blank">Numerical Recipes (Chapter on Multidimensional Minimization)</a></li>
                         </ul>
 
-                    <h3>🔬 Algorithm Theory</h3>
+                    <h3>Algorithm Theory</h3>
                     <ul>
                         <li><strong>Conjugate Directions:</strong> Method builds orthogonal search directions</li>
                         <li><strong>Line Search:</strong> Uses golden section or Brent's method for 1D optimization</li>
@@ -333,10 +305,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #e67e22;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -158,23 +158,16 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-    </style>
+</style>
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -228,7 +221,7 @@
                             <em>Published: 1983</em>
                         </td>
                         <td>
-                            <a href="https://science.sciencemag.org/content/220/4598/671" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://science.sciencemag.org/content/220/4598/671" target="_blank" class="link-button paper">Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -240,24 +233,24 @@
                             <em>Package: scipy</em>
                         </td>
                         <td>
-                            <a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.dual_annealing.html" target="_blank" class="link-button python">🐍 SciPy Docs</a>
-                            <a href="https://github.com/scipy/scipy/blob/main/scipy/optimize/_dual_annealing.py" target="_blank" class="link-button python">🔍 Source</a>
+                            <a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.dual_annealing.html" target="_blank" class="link-button python">SciPy Docs</a>
+                            <a href="https://github.com/scipy/scipy/blob/main/scipy/optimize/_dual_annealing.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Wrapper</td>
+                        <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Humpday Integration</strong><br>
-                            Calls scipy.optimize.dual_annealing()<br>
-                            Standardized interface for optimization contests<br>
+                            <strong>HumpDay Python Implementation</strong><br>
+                            Pure-Python simulated annealing with Metropolis acceptance and geometric cooling<br>
+                            No required dependencies<br>
                             <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Classical simulated annealing with cooling schedule<br>
@@ -265,25 +258,14 @@
                             <em>Class: SimulatedAnnealing</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> scipy.optimize<br>
-                            <strong>Humpday Python:</strong> scipy, numpy<br>
-                            <strong>Humpday JS:</strong> None (standalone port)
-                        </td>
-                        <td>
-                            <a href="https://pypi.org/project/scipy/" target="_blank" class="link-button python">📦 PyPI</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Discrete optimization, traveling salesman, combinatorial problems</li>
                     <li><strong>Dimensions:</strong> Scalable to moderate dimensions, works on any space</li>
@@ -293,22 +275,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation against SciPy dual_annealing reference implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing JavaScript vs scipy.optimize.dual_annealing()</li>
-                    <li>🎯 Target: Similar optimization performance and cooling behavior</li>
-                    <li>📊 Metrics: Final objective value, temperature schedule, acceptance rates</li>
-                    <li>🔧 Challenge: Matching advanced cooling schedules and neighborhood generation</li>
-                </ul>
-                <p><em>Full validation results will be displayed here once testing is complete.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Simulated_annealing" target="_blank">Simulated Annealing Wikipedia</a></li>
                         <li><a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.dual_annealing.html" target="_blank">SciPy Dual Annealing</a></li>
@@ -316,7 +287,7 @@
                         <li><a href="http://mathworld.wolfram.com/SimulatedAnnealing.html" target="_blank">Wolfram MathWorld SA</a></li>
                         </ul>
 
-                    <h3>🔬 Algorithm Components</h3>
+                    <h3>Algorithm Components</h3>
                     <ul>
                         <li><strong>Temperature Schedule:</strong> T(k) = T₀ × α^k (geometric cooling)</li>
                         <li><strong>Metropolis Criterion:</strong> P(accept) = exp(-ΔE/T) if ΔE > 0</li>
@@ -325,7 +296,7 @@
                         <li><strong>Stopping Criteria:</strong> Temperature threshold or equilibrium detection</li>
                     </ul>
 
-                    <h3>🌡️ Cooling Schedules</h3>
+                    <h3>️ Cooling Schedules</h3>
                     <ul>
                         <li><strong>Linear:</strong> T(k) = T₀ - α × k</li>
                         <li><strong>Geometric:</strong> T(k) = T₀ × α^k (most common)</li>
@@ -334,7 +305,7 @@
                         <li><strong>Adaptive:</strong> Temperature adjusted based on acceptance rates</li>
                     </ul>
 
-                    <h3>🎯 SA Variants</h3>
+                    <h3>SA Variants</h3>
                     <ul>
                         <li><strong>Classical SA:</strong> Single-point neighborhood search</li>
                         <li><strong>Fast SA:</strong> Modified acceptance probability for faster cooling</li>
@@ -343,7 +314,7 @@
                         <li><strong>Hybrid SA:</strong> Combined with local search or GA</li>
                     </ul>
 
-                    <h3>🚀 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Traveling Salesman:</strong> Classic combinatorial optimization</li>
                         <li><strong>VLSI Design:</strong> Circuit layout and placement</li>
@@ -353,7 +324,7 @@
                         <li><strong>Network Design:</strong> Communication and transportation networks</li>
                     </ul>
 
-                    <h3>📐 Theoretical Foundation</h3>
+                    <h3>Theoretical Foundation</h3>
                     <ul>
                         <li><strong>Statistical Mechanics:</strong> Boltzmann distribution and thermal equilibrium</li>
                         <li><strong>Markov Chains:</strong> Detailed balance and ergodicity</li>
@@ -361,7 +332,7 @@
                         <li><strong>Finite-Time Analysis:</strong> Approximation guarantees for practical schedules</li>
                     </ul>
 
-                    <h3>⚙️ Parameter Tuning</h3>
+                    <h3>️ Parameter Tuning</h3>
                     <ul>
                         <li><strong>Initial Temperature:</strong> Set to accept 80-95% of initial moves</li>
                         <li><strong>Cooling Rate:</strong> α = 0.85-0.95 for geometric schedule</li>
@@ -380,10 +351,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/tabu-search.html
+++ b/docs/algorithms/tabu-search.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #8e44ad;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -158,21 +158,7 @@
             display: none;
             margin-top: 20px;
         }
-
-        .validation-pending {
-            background: #ffeaa7;
-            border: 1px solid #fdcb6e;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .validation-pending h3 {
-            margin-top: 0;
-            color: #d63031;
-        }
-
-        .memory-note {
+.memory-note {
             background: #f0f4ff;
             border: 1px solid #c7d2fe;
             border-radius: 8px;
@@ -188,6 +174,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -206,13 +198,13 @@
             </div>
 
             <div class="memory-note">
-                <h3>🧠 Memory-Guided Search</h3>
+                <h3>Memory-Guided Search</h3>
                 <p><strong>Tabu Search uses intelligent memory to guide exploration:</strong></p>
                 <ul>
-                    <li>📋 <strong>Tabu List:</strong> Remembers recent moves to avoid cycling</li>
-                    <li>🚫 <strong>Forbidden Moves:</strong> Prevents returning to recently visited solutions</li>
+                    <li><strong>Tabu List:</strong> Remembers recent moves to avoid cycling</li>
+                    <li><strong>Forbidden Moves:</strong> Prevents returning to recently visited solutions</li>
                     <li>⭐ <strong>Aspiration Criteria:</strong> Override tabu status for exceptional solutions</li>
-                    <li>🎯 <strong>Strategic Oscillation:</strong> Systematically explore around best-found solutions</li>
+                    <li><strong>Strategic Oscillation:</strong> Systematically explore around best-found solutions</li>
                 </ul>
             </div>
             <div class="visualization-section">
@@ -252,7 +244,7 @@
                             <em>Published: 1986-1989</em>
                         </td>
                         <td>
-                            <a href="https://link.springer.com/article/10.1007/BF01096763" target="_blank" class="link-button paper">📄 Original Paper</a>
+                            <a href="https://link.springer.com/article/10.1007/BF01096763" target="_blank" class="link-button paper">Original Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -264,7 +256,7 @@
                             <em>Reference: Academic literature and specialized libraries</em>
                         </td>
                         <td>
-                            <a href="https://github.com/topics/tabu-search" target="_blank" class="link-button python">🔍 GitHub Examples</a>
+                            <a href="https://github.com/topics/tabu-search" target="_blank" class="link-button python">GitHub Examples</a>
                         </td>
                     </tr>
                     <tr>
@@ -276,11 +268,11 @@
                             <em>File: humpday/optimizers/tabusearch.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">🐍 Source</a>
+                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript tabu search<br>
@@ -288,25 +280,14 @@
                             <em>Class: TabuSearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">🌐 JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> None (problem-specific implementations)<br>
-                            <strong>Humpday Python:</strong> numpy (for array operations)<br>
-                            <strong>Humpday JS:</strong> None (pure JavaScript)
-                        </td>
-                        <td>
-                            <span style="color: #95a5a6;">✨ No external dependencies</span>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Combinatorial optimization, discrete problems, complex neighborhoods</li>
                     <li><strong>Dimensions:</strong> Excellent for discrete spaces, adaptable to continuous</li>
@@ -316,22 +297,11 @@
                 </ul>
             </div>
 
-            <div class="validation-pending">
-                <h3>⏳ Validation Status: PENDING</h3>
-                <p><strong>Validation of tabu search implementation in progress.</strong></p>
-                <ul>
-                    <li>📋 Test framework: Comparing against established tabu search behavior</li>
-                    <li>🎯 Target: Proper tabu list management and neighborhood exploration</li>
-                    <li>📊 Metrics: Solution quality, memory utilization, escape from local optima</li>
-                    <li>🔧 Reference: Classical tabu search literature and benchmarks</li>
-                </ul>
-                <p><em>Tabu search effectiveness measured by exploration quality and constraint adherence.</em></p>
-            </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/Tabu_search" target="_blank">Tabu Search Wikipedia</a></li>
                         <li><a href="https://link.springer.com/article/10.1007/BF01096763" target="_blank">Tabu Search - Part I (Glover, 1989)</a></li>
@@ -339,7 +309,7 @@
                         <li><a href="https://www.springer.com/gp/book/9781461375784" target="_blank">Tabu Search Handbook (Glover & Laguna)</a></li>
                         </ul>
 
-                    <h3>🔬 Core Components</h3>
+                    <h3>Core Components</h3>
                     <ul>
                         <li><strong>Current Solution:</strong> s ∈ S (current position in solution space)</li>
                         <li><strong>Neighborhood:</strong> N(s) = {s' | s' is reachable from s in one move}</li>
@@ -349,7 +319,7 @@
                         <li><strong>Best Solution:</strong> s* = best solution found so far</li>
                     </ul>
 
-                    <h3>📐 Algorithm Structure</h3>
+                    <h3>Algorithm Structure</h3>
                     <ul>
                         <li><strong>Initialization:</strong> Start with initial solution s₀, empty tabu list T = ∅</li>
                         <li><strong>Neighborhood Generation:</strong> Create candidate moves N(s) \ T</li>
@@ -359,7 +329,7 @@
                         <li><strong>Termination:</strong> Stop based on iterations, time, or convergence</li>
                     </ul>
 
-                    <h3>⚙️ Key Design Decisions</h3>
+                    <h3>️ Key Design Decisions</h3>
                     <ul>
                         <li><strong>Tabu Tenure:</strong> Fixed (5-10) vs adaptive vs random</li>
                         <li><strong>Tabu Structure:</strong> Moves vs solutions vs attributes</li>
@@ -369,7 +339,7 @@
                         <li><strong>Intensification:</strong> Return to promising regions</li>
                     </ul>
 
-                    <h3>🎯 Tabu Search Pseudocode</h3>
+                    <h3>Tabu Search Pseudocode</h3>
                     <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
 function tabuSearch(initialSolution, maxIterations):
     s = initialSolution
@@ -405,7 +375,7 @@ function tabuSearch(initialSolution, maxIterations):
     return bestSolution
                     </pre>
 
-                    <h3>🔧 Tabu Search Variants</h3>
+                    <h3>Tabu Search Variants</h3>
                     <ul>
                         <li><strong>Simple Tabu Search:</strong> Basic tabu list with fixed tenure</li>
                         <li><strong>Reactive Tabu Search:</strong> Adaptive tabu tenure based on search history</li>
@@ -415,7 +385,7 @@ function tabuSearch(initialSolution, maxIterations):
                         <li><strong>Granular Tabu Search:</strong> Restrict neighborhoods for large problems</li>
                     </ul>
 
-                    <h3>🎯 Memory Types</h3>
+                    <h3>Memory Types</h3>
                     <ul>
                         <li><strong>Short-Term (Recency):</strong> Tabu list preventing recent moves</li>
                         <li><strong>Medium-Term (Frequency):</strong> Track frequently used moves/attributes</li>
@@ -423,7 +393,7 @@ function tabuSearch(initialSolution, maxIterations):
                         <li><strong>Strategic (Intensification):</strong> Return to promising solution regions</li>
                     </ul>
 
-                    <h3>🚀 Applications</h3>
+                    <h3>Applications</h3>
                     <ul>
                         <li><strong>Vehicle Routing:</strong> TSP, VRP, and delivery optimization</li>
                         <li><strong>Scheduling:</strong> Job shop, flow shop, and timetabling</li>
@@ -433,7 +403,7 @@ function tabuSearch(initialSolution, maxIterations):
                         <li><strong>VLSI Design:</strong> Circuit placement and routing</li>
                     </ul>
 
-                    <h3>💡 Tabu Search Philosophy</h3>
+                    <h3>Tabu Search Philosophy</h3>
                     <ul>
                         <li><strong>Aggressive Exploration:</strong> Accept worse solutions to escape local optima</li>
                         <li><strong>Intelligent Memory:</strong> Use history to guide future decisions</li>
@@ -442,7 +412,7 @@ function tabuSearch(initialSolution, maxIterations):
                         <li><strong>No Randomness Required:</strong> Deterministic yet effective exploration</li>
                     </ul>
 
-                    <h3>⚠️ Implementation Challenges</h3>
+                    <h3>️ Implementation Challenges</h3>
                     <ul>
                         <li><strong>Neighborhood Design:</strong> Balance size vs computation time</li>
                         <li><strong>Tabu Tenure:</strong> Too short (cycling) vs too long (over-restriction)</li>
@@ -462,10 +432,10 @@ function tabuSearch(initialSolution, maxIterations):
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -24,7 +24,7 @@
         }
 
         .header {
-            background: #2c3e50;
+            background: #34495e;
             color: white;
             padding: 30px;
             text-align: center;
@@ -162,6 +162,12 @@
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/prima-algorithms.js"></script>
+    <script src="../js/modules/scipy-algorithms.js"></script>
+    <script src="../js/modules/evolutionary-algorithms.js"></script>
+    <script src="../js/modules/search-algorithms.js"></script>
+
 </head>
 <body>
     <div class="container">
@@ -215,7 +221,7 @@
                             <em>Published: 2002</em>
                         </td>
                         <td>
-                            <a href="https://www.optimization-online.org/DB_HTML/2009/12/2490.html" target="_blank" class="link-button paper">📄 Paper</a>
+                            <a href="https://www.optimization-online.org/DB_HTML/2009/12/2490.html" target="_blank" class="link-button paper">Paper</a>
                         </td>
                     </tr>
                     <tr>
@@ -227,24 +233,24 @@
                             <em>Package: pdfo</em>
                         </td>
                         <td>
-                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">📦 PDFO</a>
-                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python">🐍 Source</a>
+                            <a href="https://www.pdfo.net/" target="_blank" class="link-button paper">PDFO</a>
+                            <a href="https://github.com/pdfo/pdfo" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Wrapper</td>
+                        <td class="category">Humpday Python</td>
                         <td>
-                            <strong>Humpday Integration</strong><br>
+                            <strong>HumpDay Python Implementation</strong><br>
                             Calls PDFO's UOBYQA implementation<br>
                             Standardized interface for optimization contests<br>
                             <em>File: humpday/optimizers/prima_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">🐍 Wrapper Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript Port</td>
+                        <td class="category">Humpday JavaScript</td>
                         <td>
                             <strong>Browser Implementation</strong><br>
                             Pure JavaScript port maintaining core trust-region logic<br>
@@ -252,25 +258,14 @@
                             <em>Class: PRIMA_UOBYQA</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">🌐 JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
-                    <tr>
-                        <td class="category">Dependencies</td>
-                        <td>
-                            <strong>Reference:</strong> PDFO package (wraps Powell's Fortran)<br>
-                            <strong>Humpday Python:</strong> pdfo, numpy<br>
-                            <strong>Humpday JS:</strong> None (standalone port)
-                        </td>
-                        <td>
-                            <a href="https://pypi.org/project/pdfo/" target="_blank" class="link-button python">📦 PyPI</a>
-                        </td>
-                    </tr>
-                </tbody>
+</tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>🏁 Performance Characteristics</h3>
+                <h3>Performance Characteristics</h3>
                 <ul>
                     <li><strong>Best for:</strong> Smooth, unimodal functions with moderate noise tolerance</li>
                     <li><strong>Dimensions:</strong> Works well up to ~50 dimensions</li>
@@ -281,11 +276,11 @@
             </div>
 
             <div class="performance-notes" style="background: #d4edda; border-color: #27ae60;">
-                <h3>✅ Validation Results: PERFECT MATCH vs PDFO Reference</h3>
+                <h3>Validation Results: PERFECT MATCH vs PDFO Reference</h3>
                 <p><strong>JavaScript implementation successfully matches PDFO reference implementation:</strong></p>
                 <ul>
-                    <li><strong>2D Sphere Function:</strong> Both PDFO and JavaScript achieve <code>f = 0.000000</code> 🎯</li>
-                    <li><strong>3D Sphere Function:</strong> Both PDFO and JavaScript achieve <code>f = 0.000000</code> 🎯</li>
+                    <li><strong>2D Sphere Function:</strong> Both PDFO and JavaScript achieve <code>f = 0.000000</code> </li>
+                    <li><strong>3D Sphere Function:</strong> Both PDFO and JavaScript achieve <code>f = 0.000000</code> </li>
                     <li><strong>Efficiency:</strong> JavaScript uses fewer function evaluations (12 vs 17, 17 vs 21)</li>
                     <li><strong>Success Rate:</strong> 2/3 perfect matches on test suite</li>
                 </ul>
@@ -293,9 +288,9 @@
             </div>
 
             <div class="more-section">
-                <button class="more-toggle" onclick="toggleMore()">📚 More Resources</button>
+                <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>📚 Educational Resources</h3>
+                    <h3>Educational Resources</h3>
                     <ul>
                         <li><a href="https://en.wikipedia.org/wiki/NEWUOA" target="_blank">UOBYQA/NEWUOA Wikipedia</a></li>
                         <li><a href="https://www.pdfo.net/" target="_blank">PDFO Documentation</a></li>
@@ -312,10 +307,10 @@
 
             if (content.style.display === 'none' || content.style.display === '') {
                 content.style.display = 'block';
-                button.textContent = '📚 Less Resources';
+                button.textContent = 'Less Resources';
             } else {
                 content.style.display = 'none';
-                button.textContent = '📚 More Resources';
+                button.textContent = 'More Resources';
             }
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {

--- a/docs/js/algorithm-visualizer.js
+++ b/docs/js/algorithm-visualizer.js
@@ -447,7 +447,7 @@ class AlgorithmVisualizer {
             // SciPy algorithms
             { value: 'SciPy_NelderMead', text: 'Nelder-Mead (SciPy)' },
             { value: 'SciPy_Powell', text: 'Powell Method' },
-            { value: 'SciPy_BFGS', text: 'BFGS (SciPy)' },
+            { value: 'SciPy_BFGS', text: 'L-BFGS-B (SciPy)' },
             { value: 'DifferentialEvolution', text: 'Differential Evolution' },
             { value: 'SimulatedAnnealing', text: 'Simulated Annealing' },
 
@@ -483,9 +483,37 @@ class AlgorithmVisualizer {
             algorithmSelect.appendChild(option);
         });
 
-        // Default to Harmony Search if we're on the harmony search page
-        if (document.title.includes('Harmony Search')) {
-            algorithmSelect.value = 'HarmonySearch';
+        // Default to the page's own algorithm when the page title matches one.
+        // Map each algorithm page's <title> keyword to its selector value.
+        const titleToAlgo = {
+            'UOBYQA':                 'PRIMA_UOBYQA',
+            'NEWUOA':                 'PRIMA_NEWUOA',
+            'BOBYQA':                 'PRIMA_BOBYQA',
+            "Nelder-Mead":            'SciPy_NelderMead',
+            "Powell":                 'SciPy_Powell',
+            'L-BFGS':                 'SciPy_BFGS',
+            'Differential Evolution': 'DifferentialEvolution',
+            'Particle Swarm':         'ParticleSwarm',
+            'Simulated Annealing':    'SimulatedAnnealing',
+            'Genetic Algorithm':      'GeneticAlgorithm',
+            'Random Search':          'RandomSearch',
+            'Bayesian Optimization':  'BayesianOpt',
+            'CMA':                    'CMAEvolutionStrategy',
+            'Tabu Search':            'TabuSearch',
+            'Firefly':                'FireflyAlgorithm',
+            'Ant Colony':             'AntColonyOpt',
+            'Evolution Strategy':     'EvolutionStrategy',
+            'Hill Climbing':          'HillClimbing',
+            'Harmony Search':         'HarmonySearch',
+            'Adaptive Random':        'AdaptiveRandomSearch',
+            'Coordinate Descent':     'CoordinateDescent',
+            'Pattern Search':         'PatternSearch',
+        };
+        for (const [keyword, algo] of Object.entries(titleToAlgo)) {
+            if (document.title.includes(keyword)) {
+                algorithmSelect.value = algo;
+                break;
+            }
         }
 
         // Control buttons container


### PR DESCRIPTION
Aligns every algorithm doc page with HumpDay's three actual goals:

1. **Pure Python, zero required dependencies** (numpy optional via `[fast]`)
2. **Every algorithm has a JavaScript port** that runs the demo in the browser
3. **One page per algorithm**: what it is, where it came from, a live demo, links to source

The pages were violating goal #1 in multiple places: row labels said "Wrapper", buttons said "Wrapper Code", descriptions claimed "Uses skopt.gp_minimize()" / "Calls scipy.optimize.<method>", and a "Library Dependencies" row listed scikit-optimize and numpy as runtime needs. None of that is true after the numpy-optional milestone.

## Per-page content

- Stripped all emojis from text and button labels.
- Removed the "Validation Status: PENDING" boxes (14 pages).
- Removed the "Library Dependencies" / "Dependencies" rows.
- Renamed `Humpday Python Wrapper` → `Humpday Python`, `Humpday JavaScript Port` → `Humpday JavaScript`, and `Wrapper Code` button labels → `Source Code`.
- Replaced six false implementation descriptions with truthful pure-Python text on `bayesian-optimization`, `lbfgsb`, `simulated-annealing`, `nelder-mead`, `differential-evolution`, and `powell`.
- Forced `.header` background to a single slate-gray (`#34495e`) matching `contest.html`. Per-algorithm brand colours were inconsistent.

## Demo fix

- Each page now loads the individual JS module files (`base-optimizer.js`, `prima-algorithms.js`, `scipy-algorithms.js`, `evolutionary-algorithms.js`, `search-algorithms.js`) **before** the visualizer. Previously only `modules/index.js` was loaded — that file assumes the classes are already on `window`, which they weren't. Every demo today errors `PRIMA_UOBYQA is not defined` on click-Start.
- Auto-default-selection in the visualizer now maps every page's `<title>` to its selector value (was only HarmonySearch).
- Renamed selector option "BFGS (SciPy)" → "L-BFGS-B (SciPy)" since the underlying class is `LBFGSB`.
- `evolution-strategy.html` (added in PR #61 without a demo) now has the standard 3D visualization block.

## GOALS.md

- Flipped `EvolutionStrategy` demo cell `🟡 → ✅`.
- Updated the academic-styling note to document the new slate-gray house style.

## Verification

- `python -m pytest tests/ --ignore=tests/validation -q` → 318 passed, 21 skipped
- `uvx ruff check .` → clean
- `uvx ruff format --check .` → 107 files already formatted
- Local HTTP serve confirms script load order on every page: three.js → OrbitControls → base-optimizer → prima → scipy → evolutionary → search → visualizer
- No remaining `Uses skopt|Uses scipy|Calls scipy|Uses SciPy|Calls SciPy` strings anywhere in `docs/algorithms/`