### PR TITLE
Source links: point Python & JS buttons to the actual class lines

### DIFF
--- a/docs/algorithms/adaptive-random-search.html
+++ b/docs/algorithms/adaptive-random-search.html
@@ -268,7 +268,7 @@
                             <em>File: humpday/optimizers/adaptiverandom.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L14" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -280,7 +280,7 @@
                             <em>Class: AdaptiveRandomSearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L16" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/ant-colony-optimization.html
+++ b/docs/algorithms/ant-colony-optimization.html
@@ -254,7 +254,7 @@
                             <em>File: humpday/optimizers/harmonysearch.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L721" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -266,7 +266,7 @@
                             <em>Class: HarmonySearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L756" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/bayesian-optimization.html
+++ b/docs/algorithms/bayesian-optimization.html
@@ -246,7 +246,7 @@
                             <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L275" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -258,7 +258,7 @@
                             <em>Class: BayesianOpt</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L405" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/bobyqa.html
+++ b/docs/algorithms/bobyqa.html
@@ -245,7 +245,7 @@
                             <em>File: humpday/optimizers/prima_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L544" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -257,7 +257,7 @@
                             <em>Class: PRIMA_BOBYQA</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js#L1068" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
                 </tbody>

--- a/docs/algorithms/cma-evolution-strategy.html
+++ b/docs/algorithms/cma-evolution-strategy.html
@@ -246,7 +246,7 @@
                             <em>File: humpday/optimizers/cmaopt.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L476" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -258,7 +258,7 @@
                             <em>Class: CMAEvolutionStrategy</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L550" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -268,7 +268,7 @@
                             <em>File: humpday/optimizers/coordinatedescent.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L53" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -280,7 +280,7 @@
                             <em>Class: CoordinateDescent</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L69" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -232,7 +232,7 @@
                             <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Python Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L17" target="_blank" class="link-button python">Python Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -244,7 +244,7 @@
                             <em>Class: DifferentialEvolution</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">JavaScript Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L15" target="_blank" class="link-button javascript">JavaScript Code</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/evolution-strategy.html
+++ b/docs/algorithms/evolution-strategy.html
@@ -225,13 +225,25 @@
                             <strong>Pure-Python Implementation</strong><br>
                             μ=10 parents, λ=min(30, n_trials/3) offspring<br>
                             Gaussian mutation with fixed step size σ=0.2, clipped to the unit cube<br>
+                            No required dependencies<br>
                             <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Python Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L826" target="_blank" class="link-button python">Python Code</a>
                         </td>
                     </tr>
-</tbody>
+                    <tr>
+                        <td class="category">Humpday JavaScript</td>
+                        <td>
+                            <strong>Browser Implementation</strong><br>
+                            Pure-JavaScript port of the (μ+λ)-ES for the in-browser demo<br>
+                            <em>Class: EvolutionStrategy</em>
+                        </td>
+                        <td>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L893" target="_blank" class="link-button javascript">JavaScript Code</a>
+                        </td>
+                    </tr>
+                </tbody>
             </table>
 
             <div class="performance-notes">

--- a/docs/algorithms/firefly-algorithm.html
+++ b/docs/algorithms/firefly-algorithm.html
@@ -268,7 +268,7 @@
                             <em>File: humpday/optimizers/firefly*.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L676" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -280,7 +280,7 @@
                             <em>Class: FireflyAlgorithm</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L699" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/genetic-algorithm.html
+++ b/docs/algorithms/genetic-algorithm.html
@@ -246,7 +246,7 @@
                             <em>File: humpday/optimizers/deapopt.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L188" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -258,7 +258,7 @@
                             <em>Class: GeneticAlgorithm</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L305" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/harmony-search.html
+++ b/docs/algorithms/harmony-search.html
@@ -254,7 +254,7 @@
                             <em>File: humpday/optimizers/harmonysearch.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L913" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -266,7 +266,7 @@
                             <em>Class: HarmonySearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L828" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -268,7 +268,7 @@
                             <em>File: humpday/optimizers/localsearch*.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L883" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -280,7 +280,7 @@
                             <em>Class: HillClimbing</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L200" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -269,7 +269,7 @@
                             <em>File: humpday/optimizers/scipy_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L327" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -281,7 +281,7 @@
                             <em>Class: LBFGSB</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js#L223" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/nelder-mead-scipy.html
+++ b/docs/algorithms/nelder-mead-scipy.html
@@ -91,8 +91,8 @@
             <h3>Implementation Details</h3>
             <p>Our HumpDay implementation includes:</p>
             <ul>
-                <li><strong>Python:</strong> <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L17" target="_blank">Pure Python implementation</a></li>
-                <li><strong>JavaScript:</strong> <a href="../js/optimizers.js" target="_blank">Browser-compatible version</a></li>
+                <li><strong>Python:</strong> <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L18" target="_blank">Pure-Python implementation</a></li>
+                <li><strong>JavaScript:</strong> <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js#L19" target="_blank">Browser port</a></li>
                 <li><strong>Validation:</strong> Cross-validated against <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-neldermead.html" target="_blank">SciPy reference</a></li>
                 <li><strong>Parameters:</strong> α=1.0, γ=2.0, β=0.5, σ=0.5 (standard values)</li>
             </ul>

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -232,7 +232,7 @@
                             <em>File: humpday/optimizers/scipy_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Python Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L18" target="_blank" class="link-button python">Python Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -244,7 +244,7 @@
                             <em>Class: NelderMead</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js" target="_blank" class="link-button javascript">JavaScript Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js#L19" target="_blank" class="link-button javascript">JavaScript Code</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -259,7 +259,7 @@
                             <em>File: humpday/optimizers/prima_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L266" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -271,7 +271,7 @@
                             <em>Class: PRIMA_NEWUOA</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js#L672" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -245,7 +245,7 @@
                             <em>File: humpday/optimizers/search_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Custom Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L105" target="_blank" class="link-button python">Custom Implementation</a>
                         </td>
                     </tr>
                     <tr>
@@ -257,7 +257,7 @@
                             <em>Class: PatternSearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L129" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -246,7 +246,7 @@
                             <em>File: humpday/optimizers/scipy_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L142" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -258,7 +258,7 @@
                             <em>Class: Powell</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js#L140" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/random-search.html
+++ b/docs/algorithms/random-search.html
@@ -220,7 +220,7 @@
             <tr>
                 <td><strong>Python Implementation</strong></td>
                 <td>HumpDay modular implementation in <span class="code-ref">evolutionary_algorithms.py</span></td>
-                <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L382">Source Code</a></td>
+                <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L261">Source Code</a></td>
             </tr>
             <tr>
                 <td><strong>JavaScript Implementation</strong></td>

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -246,7 +246,7 @@
                             <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L129" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -258,7 +258,7 @@
                             <em>Class: SimulatedAnnealing</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L190" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/tabu-search.html
+++ b/docs/algorithms/tabu-search.html
@@ -268,7 +268,7 @@
                             <em>File: humpday/optimizers/tabusearch.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L627" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -280,7 +280,7 @@
                             <em>Class: TabuSearch</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/optimizers.js" target="_blank" class="link-button javascript">JS Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L637" target="_blank" class="link-button javascript">JS Implementation</a>
                         </td>
                     </tr>
 </tbody>

--- a/docs/algorithms/uobyqa-pdfo.html
+++ b/docs/algorithms/uobyqa-pdfo.html
@@ -71,8 +71,8 @@
             <h3>Implementation Details</h3>
             <p>Our HumpDay implementation includes:</p>
             <ul>
-                <li><strong>Python:</strong> <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L16" target="_blank">Pure Python implementation</a></li>
-                <li><strong>JavaScript:</strong> <a href="../js/optimizers.js" target="_blank">Browser-compatible version</a></li>
+                <li><strong>Python:</strong> <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L32" target="_blank">Pure-Python implementation</a></li>
+                <li><strong>JavaScript:</strong> <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js#L18" target="_blank">Browser port</a></li>
                 <li><strong>Validation:</strong> Cross-validated against <a href="https://www.pdfo.net/" target="_blank">PDFO reference</a></li>
             </ul>
         </section>

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -246,7 +246,7 @@
                             <em>File: humpday/optimizers/prima_algorithms.py</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L32" target="_blank" class="link-button python">Source Code</a>
                         </td>
                     </tr>
                     <tr>
@@ -258,7 +258,7 @@
                             <em>Class: PRIMA_UOBYQA</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js#L18" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>


### PR DESCRIPTION
Every algorithm page's "Python Code" and "JavaScript Code" buttons now resolve to the specific class definition with a `#L<line>` anchor, instead of going to the repo root, the legacy monolithic `docs/js/optimizers.js`, or the file with no line anchor.

## What was wrong

- `bayesian-optimization.html` Python button → `https://github.com/microprediction/humpday` (repo root)
- 18+ JavaScript buttons → `docs/js/optimizers.js` (the 3,131-line monolithic file, not the modular structure)
- 7 pages → file-with-no-line (`scipy_algorithms.py`, no `#L`)
- `random-search.html` Python button → `evolutionary_algorithms.py#L382` (that's the JS line number — Python class is at L261)

## Mapping built from current grep

- **PRIMA trio**: `prima_algorithms.py:32 / 266 / 544` · `prima-algorithms.js:18 / 672 / 1068`
- **SciPy three**: `scipy_algorithms.py:18 / 142 / 327` · `scipy-algorithms.js:19 / 140 / 223`
- **Evolutionary 13**: `evolutionary_algorithms.py:…` + matching JS module
- **Search four**: `search_algorithms.py:14 / 53 / 105` + `search-algorithms.js:16 / 69 / 129` (HillClimbing JS lives in search-algorithms.js, the rest in evolutionary)

## Also in this PR

- Added the missing `Humpday JavaScript` table row to `evolution-strategy.html` (the page I added in PR #61 had no JS link).
- Fixed `nelder-mead-scipy.html` and `uobyqa-pdfo.html` which use a different `<li>`-based structure and still pointed to the legacy `docs/js/optimizers.js`.
- Fixed `random-search.html` Python line number.

Verified:
- `python -m pytest tests/ --ignore=tests/validation -q` → 318 passed, 21 skipped
- `uvx ruff check .` → clean
- Audit grep across `docs/algorithms/*.html`: every page has both Python and JS source links pointing to specific class lines in the current source tree.