### PR TITLE
Fix every broken 3D demo + drop gradient-based framing from LBFGSB page

### DIFF
--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -407,6 +407,8 @@ function coordinateDescent(f, x0, maxIter, tolerance):
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -300,6 +300,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/firefly-algorithm.html
+++ b/docs/algorithms/firefly-algorithm.html
@@ -410,6 +410,8 @@ function fireflyAlgorithm(problem, n_fireflies, max_generations):
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/genetic-algorithm.html
+++ b/docs/algorithms/genetic-algorithm.html
@@ -341,6 +341,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -398,6 +398,8 @@ function hillClimbing(problem, initialSolution):
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -158,18 +158,6 @@
             display: none;
             margin-top: 20px;
         }
-.gradient-note {
-            background: #fff5f5;
-            border: 1px solid #fed7d7;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .gradient-note h3 {
-            margin-top: 0;
-            color: #c53030;
-        }
     </style>
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
@@ -184,8 +172,8 @@
 <body>
     <div class="container">
         <div class="header">
-            <h1>L-BFGS-B (SciPy)</h1>
-            <p>Limited-memory BFGS with Box Constraints</p>
+            <h1>Finite-Difference Quasi-Newton</h1>
+            <p>(HumpDay's <code>LBFGSB</code> class — a derivative-free baseline)</p>
         </div>
 
         <div class="content">
@@ -194,18 +182,7 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>L-BFGS-B</strong> is a limited-memory quasi-Newton method for bound-constrained optimization. Developed by Byrd, Lu, Nocedal, and Zhu, it extends the popular L-BFGS algorithm to handle simple bounds on variables. The algorithm is widely used for large-scale optimization problems where gradient information is available or can be approximated.
-            </div>
-
-            <div class="gradient-note">
-                <h3>️ Gradient-Based Algorithm Notice</h3>
-                <p><strong>L-BFGS-B requires gradient information:</strong></p>
-                <ul>
-                    <li><strong>Analytical Gradients:</strong> Best performance with exact gradients</li>
-                    <li><strong>Finite Differences:</strong> Can approximate gradients automatically</li>
-                    <li><strong>Optimization Context:</strong> May not be suitable for black-box problems without gradients</li>
-                    <li><strong>Humpday Usage:</strong> Likely uses finite difference approximation in [0,1]ⁿ hypercube</li>
-                </ul>
+                HumpDay is a <strong>derivative-free</strong> library: every algorithm sees only <code>f(x)</code>, never an analytical gradient. This one estimates a descent direction by central finite differences from function calls, then moves along it with an adaptive step size and momentum. It is named <code>LBFGSB</code> in the codebase as a nod to the limited-memory BFGS family it sits closest to in spirit, but it is <em>not</em> a faithful Byrd–Lu–Nocedal–Zhu L-BFGS-B implementation — that algorithm needs true gradients, which HumpDay does not have. Think of this as a finite-difference gradient-descent baseline.
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -382,6 +359,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -296,6 +296,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -362,6 +362,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -364,6 +364,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -310,6 +310,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -356,6 +356,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/tabu-search.html
+++ b/docs/algorithms/tabu-search.html
@@ -437,6 +437,8 @@ function tabuSearch(initialSolution, maxIterations):
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -312,6 +312,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer


### PR DESCRIPTION
This is the actual reason every algorithm-page demo has been broken
since forever, not what PR #63 fixed.

## The real bug

13 algorithm pages have an inline `<script>` at the bottom that looks like:

```js
function toggleMore() {
    const content = ...;
    const button = ...;
    if (...) {
        ...
    } else {
        ...
    }
    // Initialize 3D visualization when page loads     <-- toggleMore() never closed!
    document.addEventListener('DOMContentLoaded', function() {
        ...
    });
```

`toggleMore()`'s opening `{` is never matched. The browser reports
"Unexpected end of input" on the inline script. The
`DOMContentLoaded` listener registered inside the broken scope never
fires, so `algorithm-visualizer.js` never loads, so the
visualization's loading overlay stays up **forever**. This also
explains why the "More Resources" button does nothing on every
page — `toggleMore` is never defined.

PR #63 added Three.js + module scripts to the head, which was a
real fix for a separate problem (the visualizer eventually does
need `THREE.*` and `PRIMA_UOBYQA` etc.), but it couldn't take
effect because the loader was never running.

## The fix

Insert the missing closing brace before the
`// Initialize 3D visualization` comment in:

> coordinate-descent · differential-evolution · firefly-algorithm · genetic-algorithm · hill-climbing · lbfgsb · nelder-mead · newuoa · pattern-search · powell · simulated-annealing · tabu-search · uobyqa

The other algorithm pages (`adaptive-random-search`, `ant-colony-optimization`, `bayesian-optimization`, `bobyqa`, `cma-evolution-strategy`, `harmony-search`) didn't have the same broken pattern.

## Also: LBFGSB page rewrite

HumpDay is a derivative-free / black-box optimization library — every
algorithm sees only `f(x)`, never analytical gradients. The page was
describing textbook L-BFGS-B (which absolutely needs gradients) and
included a "Gradient-Based Algorithm Notice" callout listing
"Analytical Gradients" as a usage mode. None of that applies in
HumpDay's context.

Replaced with:

- Honest header: "Finite-Difference Quasi-Newton — HumpDay's
  `LBFGSB` class, a derivative-free baseline".
- Honest description: it estimates a descent direction via central
  finite differences from function calls, then takes a step with
  adaptive size + momentum. Named `LBFGSB` in the codebase as a nod
  to the family, but not a faithful L-BFGS-B implementation.
- Removed the misleading "Gradient-Based Algorithm Notice" div and
  the dead `.gradient-note` CSS.

## Verification

Loaded `docs/algorithms/uobyqa.html` in Playwright/Chromium:

```
loadingMessage.style.display: 'none'        ← overlay actually hides
AlgorithmVisualizer defined: true           ← script loads
PRIMA_UOBYQA defined: true                  ← module loads
click '.more-toggle' -> moreContent display 'block'  ← button works
0 page errors, 0 console errors
```

`python -m pytest tests/ -q` → 318 passed, 21 skipped
`uvx ruff check .` → clean