### PR TITLE
Site navigation: top nav bar everywhere + algorithms listing page

### DIFF
--- a/docs/algorithm-visualization-demo.html
+++ b/docs/algorithm-visualization-demo.html
@@ -7,6 +7,46 @@
     <title>3D Algorithm Visualization - HumpDay</title>
     <link rel="stylesheet" href="academic.css">
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         .visualization-container {
             width: 100%;
             height: 600px;
@@ -104,6 +144,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="index.html">Home</a>
+                <a href="contest.html">Contest</a>
+                <a href="algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="header">
         <h1>3D Algorithm Visualization Tool</h1>
         <p class="subtitle">Interactive optimization algorithm demonstration on 3D surfaces</p>

--- a/docs/algorithms.html
+++ b/docs/algorithms.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HumpDay — Algorithms</title>
+    <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
+        body {
+            font-family: 'Times New Roman', Times, serif;
+            margin: 0;
+            padding: 0;
+            background: #f8f9fa;
+            color: #2c3e50;
+            line-height: 1.6;
+        }
+        .container {
+            max-width: 1100px;
+            margin: 30px auto;
+            background: white;
+            padding: 40px 50px;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+        }
+        h1 {
+            margin: 0 0 8px;
+            font-weight: 400;
+            font-size: 2.2em;
+        }
+        .lede {
+            color: #555;
+            margin: 0 0 32px;
+            font-size: 1.05em;
+        }
+        h2 {
+            margin: 36px 0 12px;
+            padding-bottom: 6px;
+            border-bottom: 2px solid #ecf0f1;
+            font-weight: 600;
+            font-size: 1.35em;
+            color: #34495e;
+        }
+        h2 .count {
+            color: #888;
+            font-weight: 400;
+            font-size: 0.7em;
+        }
+        table.algo-list {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 0 0 12px;
+        }
+        table.algo-list td {
+            padding: 10px 12px;
+            border-bottom: 1px solid #ecf0f1;
+            vertical-align: top;
+        }
+        table.algo-list td.name {
+            width: 24%;
+            font-weight: 600;
+        }
+        table.algo-list td.name a {
+            color: #2c3e50;
+            text-decoration: none;
+        }
+        table.algo-list td.name a:hover {
+            text-decoration: underline;
+        }
+        table.algo-list td.desc {
+            width: 52%;
+            color: #555;
+        }
+        table.algo-list td.links {
+            width: 24%;
+            text-align: right;
+            white-space: nowrap;
+            font-size: 0.9em;
+        }
+        table.algo-list td.links a {
+            color: #2980b9;
+            text-decoration: none;
+            margin-left: 10px;
+        }
+        table.algo-list td.links a:hover {
+            text-decoration: underline;
+        }
+        .footnote {
+            margin-top: 40px;
+            color: #888;
+            font-size: 0.9em;
+        }
+    </style>
+</head>
+<body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="index.html">Home</a>
+                <a href="contest.html">Contest</a>
+                <a href="algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
+    <div class="container">
+        <h1>Algorithms</h1>
+        <p class="lede">
+            HumpDay ships 22 derivative-free optimizers grouped into six
+            families. Every algorithm sees only <code>f(x)</code> calls —
+            no analytical gradients, no Jacobians — and is a pure-Python
+            port with no required dependencies. Each row links to a
+            details page (with an in-browser 3D demo) plus the Python and
+            JavaScript source.
+        </p>
+
+        <h2>PRIMA trust-region <span class="count">· 3 algorithms</span></h2>
+        <p>Powell's quadratic-model trust-region methods, ported to pure Python from the PRIMA project.</p>
+        <table class="algo-list">
+            <tr>
+                <td class="name"><a href="algorithms/uobyqa.html">PRIMA_UOBYQA</a></td>
+                <td class="desc">Full quadratic interpolation model, no constraints. Best for small <em>n</em>.</td>
+                <td class="links">
+                    <a href="algorithms/uobyqa.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L32">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js#L18">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/newuoa.html">PRIMA_NEWUOA</a></td>
+                <td class="desc">Underdetermined quadratic model; scales better than UOBYQA in higher <em>n</em>.</td>
+                <td class="links">
+                    <a href="algorithms/newuoa.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L266">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js#L672">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/bobyqa.html">PRIMA_BOBYQA</a></td>
+                <td class="desc">Bound-constrained variant of NEWUOA.</td>
+                <td class="links">
+                    <a href="algorithms/bobyqa.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L544">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js#L1068">js</a>
+                </td>
+            </tr>
+        </table>
+
+        <h2>Classic numerical <span class="count">· 3 algorithms</span></h2>
+        <p>Textbook methods, here as derivative-free baselines.</p>
+        <table class="algo-list">
+            <tr>
+                <td class="name"><a href="algorithms/nelder-mead.html">NelderMead</a></td>
+                <td class="desc">Simplex method (reflection / expansion / contraction / shrink). SciPy-faithful parameter values.</td>
+                <td class="links">
+                    <a href="algorithms/nelder-mead.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L18">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js#L19">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/powell.html">Powell</a></td>
+                <td class="desc">Conjugate-direction line searches; bounded golden-section per direction.</td>
+                <td class="links">
+                    <a href="algorithms/powell.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L142">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js#L140">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/lbfgsb.html">LBFGSB</a></td>
+                <td class="desc">Finite-difference quasi-Newton baseline; named after L-BFGS-B but uses central differences (HumpDay has no gradients).</td>
+                <td class="links">
+                    <a href="algorithms/lbfgsb.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L327">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js#L223">js</a>
+                </td>
+            </tr>
+        </table>
+
+        <h2>Evolutionary &amp; swarm <span class="count">· 5 algorithms</span></h2>
+        <p>Population-based methods inspired by biological evolution and swarm behaviour.</p>
+        <table class="algo-list">
+            <tr>
+                <td class="name"><a href="algorithms/differential-evolution.html">DifferentialEvolution</a></td>
+                <td class="desc">DE/rand/1/bin — vector-difference mutation, binomial crossover, greedy selection.</td>
+                <td class="links">
+                    <a href="algorithms/differential-evolution.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L17">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L15">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/particle-swarm.html">ParticleSwarm</a></td>
+                <td class="desc">Swarm of particles with velocity updates pulled toward personal and global best.</td>
+                <td class="links">
+                    <a href="algorithms/particle-swarm.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L69">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L79">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/genetic-algorithm.html">GeneticAlgorithm</a></td>
+                <td class="desc">Crossover, mutation and tournament-style selection on a real-valued population.</td>
+                <td class="links">
+                    <a href="algorithms/genetic-algorithm.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L188">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L305">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/evolution-strategy.html">EvolutionStrategy</a></td>
+                <td class="desc">Classical (μ+λ) ES — Rechenberg/Schwefel; elitist selection from parents+offspring.</td>
+                <td class="links">
+                    <a href="algorithms/evolution-strategy.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L826">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L893">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/cma-evolution-strategy.html">CMAEvolutionStrategy</a></td>
+                <td class="desc">CMA-ES with covariance-matrix adaptation; current state of the art for moderate <em>n</em>.</td>
+                <td class="links">
+                    <a href="algorithms/cma-evolution-strategy.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L476">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L550">js</a>
+                </td>
+            </tr>
+        </table>
+
+        <h2>Surrogate / model-based <span class="count">· 1 algorithm</span></h2>
+        <p>Builds a probabilistic surrogate of <em>f</em> and chooses queries by an acquisition function.</p>
+        <table class="algo-list">
+            <tr>
+                <td class="name"><a href="algorithms/bayesian-optimization.html">BayesianOpt</a></td>
+                <td class="desc">Pure-Python Gaussian-Process surrogate + Expected-Improvement acquisition. Best when <em>f</em> is expensive.</td>
+                <td class="links">
+                    <a href="algorithms/bayesian-optimization.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L275">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L405">js</a>
+                </td>
+            </tr>
+        </table>
+
+        <h2>Metaheuristics <span class="count">· 5 algorithms</span></h2>
+        <p>Nature-inspired heuristics: temperature, memory, light, pheromones, harmony.</p>
+        <table class="algo-list">
+            <tr>
+                <td class="name"><a href="algorithms/simulated-annealing.html">SimulatedAnnealing</a></td>
+                <td class="desc">Metropolis acceptance with a cooling schedule; classic global optimization heuristic.</td>
+                <td class="links">
+                    <a href="algorithms/simulated-annealing.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L129">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L190">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/tabu-search.html">TabuSearch</a></td>
+                <td class="desc">Local search with a tabu list that bans recently-visited moves to escape basins.</td>
+                <td class="links">
+                    <a href="algorithms/tabu-search.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L627">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L637">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/firefly-algorithm.html">FireflyAlgorithm</a></td>
+                <td class="desc">Fireflies attracted toward brighter neighbours; brightness inversely tied to <em>f</em>.</td>
+                <td class="links">
+                    <a href="algorithms/firefly-algorithm.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L676">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L699">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/ant-colony-optimization.html">AntColonyOpt</a></td>
+                <td class="desc">Pheromone-trail bias on a discretised search grid.</td>
+                <td class="links">
+                    <a href="algorithms/ant-colony-optimization.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L721">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L756">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/harmony-search.html">HarmonySearch</a></td>
+                <td class="desc">Memory-based search that improvises new candidates from a harmony memory.</td>
+                <td class="links">
+                    <a href="algorithms/harmony-search.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L913">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L828">js</a>
+                </td>
+            </tr>
+        </table>
+
+        <h2>Local &amp; pattern search <span class="count">· 5 algorithms</span></h2>
+        <p>Simple greedy / structured search methods that probe neighbourhoods directly.</p>
+        <table class="algo-list">
+            <tr>
+                <td class="name"><a href="algorithms/hill-climbing.html">HillClimbing</a></td>
+                <td class="desc">Greedy local moves with occasional random restarts.</td>
+                <td class="links">
+                    <a href="algorithms/hill-climbing.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L883">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L200">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/random-search.html">RandomSearch</a></td>
+                <td class="desc">Uniformly random sampling in the unit cube — the honest baseline.</td>
+                <td class="links">
+                    <a href="algorithms/random-search.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L261">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L382">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/adaptive-random-search.html">AdaptiveRandomSearch</a></td>
+                <td class="desc">(1+1)-ES with a global multiplicatively-adapted step size (1/5-rule-ish).</td>
+                <td class="links">
+                    <a href="algorithms/adaptive-random-search.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L14">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L16">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/coordinate-descent.html">CoordinateDescent</a></td>
+                <td class="desc">Cycles through axes; takes the better of two probes along each.</td>
+                <td class="links">
+                    <a href="algorithms/coordinate-descent.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L53">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L69">js</a>
+                </td>
+            </tr>
+            <tr>
+                <td class="name"><a href="algorithms/pattern-search.html">PatternSearch</a></td>
+                <td class="desc">Polls ±step along each coordinate axis; grows on success, halves on stall, random-restarts when tiny.</td>
+                <td class="links">
+                    <a href="algorithms/pattern-search.html">doc</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L105">py</a>
+                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js#L129">js</a>
+                </td>
+            </tr>
+        </table>
+
+        <p class="footnote">
+            Don't know which to pick? Use
+            <a href="https://github.com/microprediction/humpday#minimize-no-thinking-required"><code>humpday.minimize(f, n_dim, n_trials)</code></a>
+            and a sensible default is chosen for you.
+        </p>
+    </div>
+</body>
+</html>

--- a/docs/algorithms/adaptive-random-search.html
+++ b/docs/algorithms/adaptive-random-search.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Adaptive Random Search - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -182,6 +222,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Adaptive Random Search (Custom)</h1>

--- a/docs/algorithms/ant-colony-optimization.html
+++ b/docs/algorithms/ant-colony-optimization.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Ant Colony Optimization (acopy) - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
             line-height: 1.6;
@@ -168,6 +208,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Ant Colony Optimization (acopy)</h1>

--- a/docs/algorithms/bayesian-optimization.html
+++ b/docs/algorithms/bayesian-optimization.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Bayesian Optimization - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -170,6 +210,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Bayesian Optimization (scikit-optimize)</h1>

--- a/docs/algorithms/bobyqa.html
+++ b/docs/algorithms/bobyqa.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>BOBYQA (Prima) - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -169,6 +209,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>BOBYQA (PDFO)</h1>

--- a/docs/algorithms/cma-evolution-strategy.html
+++ b/docs/algorithms/cma-evolution-strategy.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>CMA-ES - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -170,6 +210,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>CMA-ES (DEAP/cmaes)</h1>

--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Coordinate Descent - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -182,6 +222,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Coordinate Descent (Custom)</h1>

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Differential Evolution (SciPy) - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -169,6 +209,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Differential Evolution (SciPy)</h1>

--- a/docs/algorithms/evolution-strategy.html
+++ b/docs/algorithms/evolution-strategy.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Evolution Strategy (μ+λ) - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -168,6 +208,17 @@
     <script src="../js/modules/search-algorithms.js"></script>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Evolution Strategy (μ+λ)</h1>

--- a/docs/algorithms/firefly-algorithm.html
+++ b/docs/algorithms/firefly-algorithm.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Firefly Algorithm - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -182,6 +222,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Firefly Algorithm (Custom)</h1>

--- a/docs/algorithms/genetic-algorithm.html
+++ b/docs/algorithms/genetic-algorithm.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Genetic Algorithm - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -170,6 +210,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Genetic Algorithm (DEAP)</h1>

--- a/docs/algorithms/harmony-search.html
+++ b/docs/algorithms/harmony-search.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Harmony Search (pyHarmonySearch) - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
             line-height: 1.6;
@@ -168,6 +208,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Harmony Search (pyHarmonySearch)</h1>

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Hill Climbing - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -182,6 +222,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Hill Climbing (Local Search)</h1>

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>L-BFGS-B - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -182,6 +222,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>L-BFGS-B (SciPy)</h1>

--- a/docs/algorithms/nelder-mead-scipy.html
+++ b/docs/algorithms/nelder-mead-scipy.html
@@ -5,8 +5,60 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Nelder-Mead (SciPy) - HumpDay Optimization</title>
     <link rel="stylesheet" href="../academic.css">
+    <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+    </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <nav class="breadcrumb">
         <a href="../index.html">HumpDay</a> >
         <a href="../contest.html">Contest</a> >

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Nelder-Mead (SciPy) - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -169,6 +209,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Nelder-Mead (SciPy)</h1>

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>NEWUOA (Prima) - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -183,6 +223,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>NEWUOA (PDFO)</h1>

--- a/docs/algorithms/particle-swarm.html
+++ b/docs/algorithms/particle-swarm.html
@@ -10,6 +10,46 @@
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" crossorigin="anonymous"
         onload="renderMathInElement(document.body, {delimiters:[{left:'$$',right:'$$',display:true},{left:'$',right:'$',display:false}]});"></script>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Times New Roman', Times, serif;
             font-size: 16px;
@@ -181,6 +221,17 @@
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="paper-header">
         <h1 class="paper-title">Particle Swarm Optimization</h1>
         <p class="paper-subtitle">HumpDay Implementation Documentation</p>

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Pattern Search - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -170,6 +210,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Pattern Search (MATLAB/Custom)</h1>

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Powell's Method - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -170,6 +210,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Powell's Method (SciPy)</h1>

--- a/docs/algorithms/random-search.html
+++ b/docs/algorithms/random-search.html
@@ -10,6 +10,46 @@
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" crossorigin="anonymous"
         onload="renderMathInElement(document.body, {delimiters:[{left:'$$',right:'$$',display:true},{left:'$',right:'$',display:false}]});"></script>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Times New Roman', Times, serif;
             font-size: 16px;
@@ -169,6 +209,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="paper-header">
         <h1 class="paper-title">Random Search</h1>
         <p class="paper-subtitle">HumpDay Implementation Documentation</p>

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Simulated Annealing - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -170,6 +210,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Simulated Annealing (SciPy)</h1>

--- a/docs/algorithms/tabu-search.html
+++ b/docs/algorithms/tabu-search.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>Tabu Search - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -182,6 +222,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Tabu Search (Custom)</h1>

--- a/docs/algorithms/uobyqa-pdfo.html
+++ b/docs/algorithms/uobyqa-pdfo.html
@@ -5,8 +5,60 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>UOBYQA (PDFO) - HumpDay Optimization</title>
     <link rel="stylesheet" href="../academic.css">
+    <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+    </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <nav class="breadcrumb">
         <a href="../index.html">HumpDay</a> >
         <a href="../contest.html">Contest</a> >

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -6,6 +6,46 @@
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline';">
     <title>UOBYQA (Prima) - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -170,6 +210,17 @@
 
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>UOBYQA (PDFO)</h1>

--- a/docs/contest-modular.html
+++ b/docs/contest-modular.html
@@ -5,6 +5,46 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HumpDay Optimization Contest - Modular Implementation</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         body {
@@ -216,6 +256,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="index.html">Home</a>
+                <a href="contest.html">Contest</a>
+                <a href="algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <header>
         <div class="container">
             <h1>HumpDay Optimization Contest</h1>

--- a/docs/contest.html
+++ b/docs/contest.html
@@ -7,6 +7,46 @@
     <title>Algorithm Contest - HumpDay</title>
     <link rel="stylesheet" href="academic.css">
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         * { box-sizing: border-box; }
         body {
             font-family: 'Times New Roman', Times, serif;
@@ -539,6 +579,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="index.html">Home</a>
+                <a href="contest.html">Contest</a>
+                <a href="algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="header">
         <div class="container">
             <h1>Algorithm Contest</h1>

--- a/docs/debug-modules.html
+++ b/docs/debug-modules.html
@@ -2,8 +2,60 @@
 <html>
 <head>
     <title>Debug Module Loading</title>
+    <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+    </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="index.html">Home</a>
+                <a href="contest.html">Contest</a>
+                <a href="algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <h1>Module Loading Debug</h1>
     <div id="debug-output"></div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,46 @@
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" crossorigin="anonymous"
         onload="renderMathInElement(document.body, {delimiters:[{left:'$$',right:'$$',display:true},{left:'$',right:'$',display:false}]});"></script>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         :root {
             --bg: #ffffff; --text: #2c3e50; --muted: #7f8c8d; --accent: #3498db;
             --border: #bdc3c7; --code-bg: #f8f9fa; --header-bg: #34495e;
@@ -98,6 +138,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="index.html">Home</a>
+                <a href="contest.html">Contest</a>
+                <a href="algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="header">
         <div class="container">
             <h1>HumpDay</h1>

--- a/docs/stick_breaking_demo.html
+++ b/docs/stick_breaking_demo.html
@@ -5,6 +5,46 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stick Breaking Transform Visualization</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Times New Roman', Times, serif;
             margin: 20px;
@@ -217,6 +257,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="index.html">Home</a>
+                <a href="contest.html">Contest</a>
+                <a href="algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <h1>🥖 Stick Breaking Transform</h1>
         <p class="subtitle">Interactive Visualization: Cube [0,1]² → Simplex (3 weights)</p>

--- a/docs/test-modular.html
+++ b/docs/test-modular.html
@@ -5,6 +5,46 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HumpDay Modular Test - All 22 Algorithms</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body { font-family: Arial, sans-serif; margin: 20px; }
         .test-result { margin: 5px 0; padding: 5px; }
         .success { background-color: #d4edda; color: #155724; }
@@ -14,6 +54,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="index.html">Home</a>
+                <a href="contest.html">Contest</a>
+                <a href="algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <h1>HumpDay Modular Implementation Test</h1>
     <p>Testing all 22 algorithms in modular structure...</p>
 

--- a/docs/tools/algorithm-template.html
+++ b/docs/tools/algorithm-template.html
@@ -5,6 +5,46 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ALGORITHM_NAME}} - Implementation Details</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: 'Georgia', 'Times New Roman', serif;
             margin: 0;
@@ -135,6 +175,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>{{ALGORITHM_NAME}}</h1>

--- a/docs/tools/learn-powell.html
+++ b/docs/tools/learn-powell.html
@@ -7,6 +7,46 @@
     <script src="https://cdn.jsdelivr.net/pyodide/v0.26.4/full/pyodide.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/2.35.2/plotly.min.js"></script>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             margin: 0;
@@ -152,6 +192,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>🎯 Meet Powell: The Ridge Walker</h1>

--- a/docs/tools/linkedin_post_generator.html
+++ b/docs/tools/linkedin_post_generator.html
@@ -7,6 +7,46 @@
     <script src="https://cdn.pyodide.org/v0.25.0/full/pyodide.js"></script>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             max-width: 1200px;
@@ -141,6 +181,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <h1>🚀 HumpDay LinkedIn Post Generator</h1>
         <p class="subtitle">Create viral optimization content for LinkedIn influencers</p>

--- a/docs/tools/simple_contest.html
+++ b/docs/tools/simple_contest.html
@@ -5,6 +5,46 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HumpDay Optimization Benchmark</title>
     <style>
+        .site-nav {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            background: #34495e;
+            color: white;
+            padding: 12px 24px;
+            font-family: 'Times New Roman', Times, serif;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+        .site-nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .site-nav-brand {
+            color: white;
+            text-decoration: none;
+            font-weight: 700;
+            font-size: 1.25em;
+            letter-spacing: 0.02em;
+        }
+        .site-nav-links {
+            display: flex;
+            gap: 24px;
+        }
+        .site-nav-links a {
+            color: #ecf0f1;
+            text-decoration: none;
+            font-size: 1em;
+        }
+        .site-nav-links a:hover {
+            color: white;
+            text-decoration: underline;
+        }
+
         body {
             font-family: Georgia, serif;
             margin: 0;
@@ -132,6 +172,17 @@
     </style>
 </head>
 <body>
+    <nav class="site-nav" data-site-nav="v1">
+        <div class="site-nav-inner">
+            <a href="../index.html" class="site-nav-brand">HumpDay</a>
+            <div class="site-nav-links">
+                <a href="../index.html">Home</a>
+                <a href="../contest.html">Contest</a>
+                <a href="../algorithms.html">Algorithms</a>
+                <a href="https://github.com/microprediction/humpday" target="_blank" rel="noopener">GitHub</a>
+            </div>
+        </div>
+    </nav>
     <div class="container">
         <div class="header">
             <h1>Optimization Algorithm Benchmark</h1>


### PR DESCRIPTION
Closes the dead-end navigation problem the user flagged: from any
algorithm page (and any other docs page), there's now a sticky-top
nav with **Home · Contest · Algorithms · GitHub**, plus a new
algorithms-listing page that groups all 22 optimizers by family.

## What's new

**Top navigation bar** — injected into 35 docs pages:

```
[ HumpDay ]              Home   Contest   Algorithms   GitHub
```

The bar lives just after `<body>`, position:sticky so it stays
visible while scrolling. Relative paths are computed per page (so
`docs/index.html` links to `algorithms.html`, `docs/algorithms/uobyqa.html`
links to `../algorithms.html`, etc.). The injection script is
idempotent — pages with `data-site-nav="v1"` are skipped.

**New page: `docs/algorithms.html`** — the listing page. Groups all
22 derivative-free algorithms into six families:

- PRIMA trust-region (3)
- Classic numerical (3)
- Evolutionary & swarm (5)
- Surrogate / model-based (1)
- Metaheuristics (5)
- Local & pattern search (5)

Each row shows the name, a one-line description, and direct links
to the doc page, the Python source (with `#L<line>` anchor), and
the JS source. Footnote points users to `humpday.minimize()` if
they don't want to choose.

## Verification

- `python -m pytest tests/ -q` → 318 passed, 21 skipped
- `uvx ruff check .` → clean
- Playwright checked nav rendering at four depths (root,
  same-level new page, sub-directory algorithm page, contest page);
  all four show the nav visible with correct relative URLs.