### PR TITLE
Fix the actual reason every demo was broken: unclosed toggleMore()

### DIFF
--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -458,6 +458,8 @@ function coordinateDescent(f, x0, maxIter, tolerance):
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -351,6 +351,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/firefly-algorithm.html
+++ b/docs/algorithms/firefly-algorithm.html
@@ -461,6 +461,8 @@ function fireflyAlgorithm(problem, n_fireflies, max_generations):
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/genetic-algorithm.html
+++ b/docs/algorithms/genetic-algorithm.html
@@ -392,6 +392,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -449,6 +449,8 @@ function hillClimbing(problem, initialSolution):
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -198,18 +198,6 @@
             display: none;
             margin-top: 20px;
         }
-.gradient-note {
-            background: #fff5f5;
-            border: 1px solid #fed7d7;
-            border-radius: 8px;
-            padding: 15px;
-            margin: 20px 0;
-        }
-
-        .gradient-note h3 {
-            margin-top: 0;
-            color: #c53030;
-        }
     </style>
     <!-- Three.js for 3D visualization -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
@@ -235,8 +223,8 @@
     </nav>
     <div class="container">
         <div class="header">
-            <h1>L-BFGS-B (SciPy)</h1>
-            <p>Limited-memory BFGS with Box Constraints</p>
+            <h1>Finite-Difference Quasi-Newton</h1>
+            <p>(HumpDay's <code>LBFGSB</code> class — a derivative-free baseline)</p>
         </div>
 
         <div class="content">
@@ -245,18 +233,7 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>L-BFGS-B</strong> is a limited-memory quasi-Newton method for bound-constrained optimization. Developed by Byrd, Lu, Nocedal, and Zhu, it extends the popular L-BFGS algorithm to handle simple bounds on variables. The algorithm is widely used for large-scale optimization problems where gradient information is available or can be approximated.
-            </div>
-
-            <div class="gradient-note">
-                <h3>️ Gradient-Based Algorithm Notice</h3>
-                <p><strong>L-BFGS-B requires gradient information:</strong></p>
-                <ul>
-                    <li><strong>Analytical Gradients:</strong> Best performance with exact gradients</li>
-                    <li><strong>Finite Differences:</strong> Can approximate gradients automatically</li>
-                    <li><strong>Optimization Context:</strong> May not be suitable for black-box problems without gradients</li>
-                    <li><strong>Humpday Usage:</strong> Likely uses finite difference approximation in [0,1]ⁿ hypercube</li>
-                </ul>
+                HumpDay is a <strong>derivative-free</strong> library: every algorithm sees only <code>f(x)</code>, never an analytical gradient. This one estimates a descent direction by central finite differences from function calls, then moves along it with an adaptive step size and momentum. It is named <code>LBFGSB</code> in the codebase as a nod to the limited-memory BFGS family it sits closest to in spirit, but it is <em>not</em> a faithful Byrd–Lu–Nocedal–Zhu L-BFGS-B implementation — that algorithm needs true gradients, which HumpDay does not have. Think of this as a finite-difference gradient-descent baseline.
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -433,6 +410,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -347,6 +347,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -413,6 +413,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -415,6 +415,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -361,6 +361,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -407,6 +407,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/tabu-search.html
+++ b/docs/algorithms/tabu-search.html
@@ -488,6 +488,8 @@ function tabuSearch(initialSolution, maxIterations):
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -363,6 +363,8 @@
                 content.style.display = 'none';
                 button.textContent = 'More Resources';
             }
+        }
+
         // Initialize 3D visualization when page loads
         document.addEventListener('DOMContentLoaded', function() {
             // Load optimizers first, then visualizer


### PR DESCRIPTION
In 13 algorithm pages the inline <script> at the bottom of each page looks like:

    function toggleMore() {
        const content = ...;
        const button = ...;
        if (...) {
            ...
        } else {
            ...
        }
        // Initialize 3D visualization when page loads     <-- toggleMore() never closed!
        document.addEventListener('DOMContentLoaded', function() {
            ...
        });

The opening brace of toggleMore() is never matched. The browser reports 'Unexpected end of input' on the inline script, the DOMContentLoaded listener registered inside the broken scope never fires, so algorithm-visualizer.js never loads and the 3D demo's loading overlay stays up forever. Also explains why the More Resources button does nothing — toggleMore is never defined.

Inserted the missing closing brace before the
'// Initialize 3D visualization' comment in:
  coordinate-descent, differential-evolution, firefly-algorithm,
  genetic-algorithm, hill-climbing, lbfgsb, nelder-mead, newuoa,
  pattern-search, powell, simulated-annealing, tabu-search, uobyqa.

Also on lbfgsb.html: rewrote the algorithm description to stop pretending HumpDay ships textbook L-BFGS-B (which requires gradients HumpDay does not have); replaced the misleading 'Gradient-Based Algorithm Notice' callout box with a clear statement that HumpDay's LBFGSB class is a derivative-free finite-difference baseline that shares the name but not the internals. Also removed the dead .gradient-note CSS.

Verified locally via Playwright on uobyqa.html:
  - loadingMessage.style.display: 'none' (overlay hidden)
  - AlgorithmVisualizer defined: true
  - PRIMA_UOBYQA defined: true
  - Click 'More Resources' -> moreContent display flips to 'block', button text changes to 'Less Resources'
  - 0 page errors, 0 console errors