### PR TITLE
Fix 3D visualizer coord mismatch: algorithm dots offset from surface dimples

### DIFF
--- a/docs/js/algorithm-visualizer.js
+++ b/docs/js/algorithm-visualizer.js
@@ -269,8 +269,16 @@ class AlgorithmVisualizer {
         const func = this.functions[this.currentFunction];
         const range = func.range;
 
-        // Normalize all surfaces to the same visual size (8x8 units)
-        const visualSize = 8;
+        // Normalize all surfaces to the same visual size (12x12 units).
+        // The same `visualSize` is reused in `addOptimumMarker` and
+        // `addToPath` for dot placement, so all three must match — and
+        // there must NOT be a separate `surface.scale.setScalar(...)`
+        // below, otherwise the dots fall short of where the surface
+        // dimple actually renders. (Previous bug: visualSize=8 here +
+        // surface.scale.setScalar(1.5) — surface rendered at 12, dots
+        // placed at 8, so e.g. Easom's optimum dot appeared 4 units
+        // closer to centre than the surface minimum it was tracking.)
+        const visualSize = 12;
         const geometry = new THREE.PlaneGeometry(visualSize, visualSize, this.resolution - 1, this.resolution - 1);
 
         const vertices = geometry.attributes.position.array;
@@ -333,9 +341,6 @@ class AlgorithmVisualizer {
         this.surface.receiveShadow = true;
         this.surface.castShadow = true;
 
-        // Make the surface bigger by default for better visibility
-        this.surface.scale.setScalar(1.5);
-
         this.scene.add(this.surface);
 
         // Add optimum marker
@@ -361,8 +366,9 @@ class AlgorithmVisualizer {
         });
         const marker = new THREE.Mesh(geometry, material);
 
-        // Map mathematical coordinates to visual coordinates
-        const visualSize = 8;
+        // Map mathematical coordinates to visual coordinates.
+        // visualSize must match the value used in createSurface().
+        const visualSize = 12;
         const sceneX = ((optimum.x - (range.max + range.min) / 2) / (range.max - range.min)) * visualSize;
         const sceneY = ((optimum.y - (range.max + range.min) / 2) / (range.max - range.min)) * visualSize;
 
@@ -881,8 +887,9 @@ class AlgorithmVisualizer {
         const func = this.functions[this.currentFunction];
         const range = func.range;
 
-        // Convert mathematical coordinates to visual coordinates
-        const visualSize = 8;
+        // Convert mathematical coordinates to visual coordinates.
+        // visualSize must match the value used in createSurface().
+        const visualSize = 12;
         const sceneX = ((position.x - (range.max + range.min) / 2) / (range.max - range.min)) * visualSize;
         const sceneY = ((position.y - (range.max + range.min) / 2) / (range.max - range.min)) * visualSize;
 


### PR DESCRIPTION
The bug shows up most clearly on Easom — the algorithm's red "current best" dot lands well away from the visible blue dimple even when the algorithm has the right `(π, π)` math position.

## Root cause

`createSurface()` builds a `PlaneGeometry(8, 8, …)`, then immediately applies:

```js
this.surface.scale.setScalar(1.5);
```

So the surface mesh renders at **12×12** in scene units.

But `addOptimumMarker()` and `addToPath()` each independently hard-code `const visualSize = 8;` and compute scene positions as:

```js
const sceneX = ((position.x − midRange) / spanRange) * visualSize;
```

i.e. with the **unscaled** size. So every dot is placed at `8/12 ≈ 67%` of the radial distance the surface dimple actually renders at.

This is invisible on functions whose optimum is at the origin (Sphere, Ackley, Rastrigin, Matyas, …) because `position.x = position.y = 0 → sceneX = 0` regardless of scale. It's obvious on functions whose optimum is far from origin: Easom `(π, π)`, Schwefel `(420.9, 420.9)`, Beale `(3, 0.5)`, Booth `(1, 3)`, Himmelblau `(3, 2)`.

## Fix

Drop the `surface.scale.setScalar(1.5)` and bump `visualSize` to 12 in all three places. Added a comment in `createSurface()` noting the invariant (all three sites must agree, and there must be no separate `setScalar` on the surface).

## Verification

Loaded `algorithms/uobyqa.html` in Playwright, switched the test-function dropdown to "Easom", and the green optimum marker now sits exactly on top of the blue dimple. (Before this fix, the green marker appeared ~33% closer to the centre of the surface than the dimple it was marking.)

No Python changes; tests are unaffected.