### PR TITLE
Add pre-commit config so lint/format gates fire locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# Pre-commit hooks: keep local lint/format in sync with what CI runs.
+#
+# One-time setup:
+#     pipx install pre-commit          # (or: pip install --user pre-commit)
+#     pre-commit install
+#
+# After that, `git commit` runs the hooks below on the staged files
+# and aborts if anything's off. To run manually against the whole repo:
+#     pre-commit run --all-files
+#
+# Versions intentionally pinned. Bump with `pre-commit autoupdate`
+# when CI's ruff version changes.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.14
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # Catch the small stuff CI doesn't care about but reviewers shouldn't
+  # have to either — trailing whitespace, missing final newlines,
+  # accidentally-committed merge conflict markers.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-toml


### PR DESCRIPTION
CI runs both \`ruff check\` and \`ruff format --check\`, but it's easy to forget the second one locally — bit me on PR #74 (an unformatted \`print()\` landed and CI caught it).

This PR adds a pre-commit config that runs the same gates locally before the commit lands.

## Config

\`\`\`yaml
repos:
  - repo: astral-sh/ruff-pre-commit v0.15.14
    hooks:
      - ruff (lint, with --fix)
      - ruff-format

  - repo: pre-commit/pre-commit-hooks v5.0.0
    hooks:
      - trailing-whitespace
      - end-of-file-fixer
      - check-merge-conflict
      - check-yaml
      - check-toml
\`\`\`

## How to enable (one-time)

\`\`\`bash
pipx install pre-commit          # or pip install --user pre-commit
pre-commit install
\`\`\`

After that, \`git commit\` fails fast on violations and auto-fixes the small stuff. Manual full-repo run:

\`\`\`bash
pre-commit run --all-files
\`\`\`

## Versions

Pinned intentionally. Bump with \`pre-commit autoupdate\` whenever CI's ruff version changes.

No code, no tests affected — just one new file.