### PR TITLE
Reference-alignment harness: seed-aligned starting points (fair measurement)

### DIFF
--- a/benchmarks/reference_alignment.json
+++ b/benchmarks/reference_alignment.json
@@ -4,181 +4,181 @@
       "algorithm": "NelderMead",
       "reference": "scipy.optimize Nelder-Mead",
       "problem": "sphere",
-      "humpday_median": 1.6341203019139632e-09,
-      "reference_median": 0.0,
-      "humpday_to_opt": 1.6341203019139632e-09,
-      "reference_to_opt": 0.0,
-      "ratio_humpday_over_reference": 1634121.301913963
+      "humpday_median": 1.1588190026546114e-09,
+      "reference_median": 1.8833302058169138e-17,
+      "humpday_to_opt": 1.1588190026546114e-09,
+      "reference_to_opt": 1.8833302058169138e-17,
+      "ratio_humpday_over_reference": 1137399.023288355
     },
     {
       "algorithm": "NelderMead",
       "reference": "scipy.optimize Nelder-Mead",
       "problem": "rosenbrock",
-      "humpday_median": 1.5495482457901537e-08,
-      "reference_median": 5.643443807724621e-17,
-      "humpday_to_opt": 1.5495482457901537e-08,
-      "reference_to_opt": 5.643443807724621e-17,
-      "ratio_humpday_over_reference": 14667718.979422849
+      "humpday_median": 1.3162962169764077e-08,
+      "reference_median": 8.25903837971131e-17,
+      "humpday_to_opt": 1.3162962169764077e-08,
+      "reference_to_opt": 8.25903837971131e-17,
+      "ratio_humpday_over_reference": 12158766.017850507
     },
     {
       "algorithm": "NelderMead",
       "reference": "scipy.optimize Nelder-Mead",
       "problem": "ackley",
-      "humpday_median": 2.5799333600413914,
-      "reference_median": 4.440892098500626e-16,
-      "humpday_to_opt": 2.5799333600413914,
-      "reference_to_opt": 4.440892098500626e-16,
-      "ratio_humpday_over_reference": 1786547079255070.8
+      "humpday_median": 2.5799302907699126,
+      "reference_median": 3.574451877257705,
+      "humpday_to_opt": 2.5799302907699126,
+      "reference_to_opt": 3.574451877257705,
+      "ratio_humpday_over_reference": 0.7217694850459752
     },
     {
       "algorithm": "Powell",
       "reference": "scipy.optimize Powell",
       "problem": "sphere",
-      "humpday_median": 0.0012912377081610313,
+      "humpday_median": 0.00043788544137658285,
       "reference_median": 0.0,
-      "humpday_to_opt": 0.0012912377081610313,
+      "humpday_to_opt": 0.00043788544137658285,
       "reference_to_opt": 0.0,
-      "ratio_humpday_over_reference": 1291237708162.0312
+      "ratio_humpday_over_reference": 437885441377.5828
     },
     {
       "algorithm": "Powell",
       "reference": "scipy.optimize Powell",
       "problem": "rosenbrock",
-      "humpday_median": 0.6643862300860943,
-      "reference_median": 0.11826537146031661,
-      "humpday_to_opt": 0.6643862300860943,
-      "reference_to_opt": 0.11826537146031661,
-      "ratio_humpday_over_reference": 5.617757944547795
+      "humpday_median": 0.8873833535367698,
+      "reference_median": 0.001854308637883508,
+      "humpday_to_opt": 0.8873833535367698,
+      "reference_to_opt": 0.001854308637883508,
+      "ratio_humpday_over_reference": 478.55213280413983
     },
     {
       "algorithm": "Powell",
       "reference": "scipy.optimize Powell",
       "problem": "ackley",
-      "humpday_median": 3.7249752160125067,
-      "reference_median": 4.440892098500626e-16,
-      "humpday_to_opt": 3.7249752160125067,
-      "reference_to_opt": 4.440892098500626e-16,
-      "ratio_humpday_over_reference": 2579463367363063.0
+      "humpday_median": 1.4491605293294012,
+      "reference_median": 1.3685808042396275e-10,
+      "humpday_to_opt": 1.4491605293294012,
+      "reference_to_opt": 1.3685808042396275e-10,
+      "ratio_humpday_over_reference": 10588705731.765736
     },
     {
       "algorithm": "DifferentialEvolution",
       "reference": "scipy differential_evolution",
       "problem": "sphere",
-      "humpday_median": 0.0010115499716377933,
-      "reference_median": 3.820915072576403e-17,
-      "humpday_to_opt": 0.0010115499716377933,
-      "reference_to_opt": 3.820915072576403e-17,
-      "ratio_humpday_over_reference": 974321957123.6349
+      "humpday_median": 0.00027178102421698976,
+      "reference_median": 1.2692186333740483e-12,
+      "humpday_to_opt": 0.00027178102421698976,
+      "reference_to_opt": 1.2692186333740483e-12,
+      "ratio_humpday_over_reference": 213963972.08885607
     },
     {
       "algorithm": "DifferentialEvolution",
       "reference": "scipy differential_evolution",
       "problem": "rosenbrock",
-      "humpday_median": 0.3081106797268396,
-      "reference_median": 1.4275309104432942e-10,
-      "humpday_to_opt": 0.3081106797268396,
-      "reference_to_opt": 1.4275309104432942e-10,
-      "ratio_humpday_over_reference": 2158331698.046839
+      "humpday_median": 0.35802570586317956,
+      "reference_median": 1.3748802524684246e-10,
+      "humpday_to_opt": 0.35802570586317956,
+      "reference_to_opt": 1.3748802524684246e-10,
+      "ratio_humpday_over_reference": 2604031159.72635
     },
     {
       "algorithm": "DifferentialEvolution",
       "reference": "scipy differential_evolution",
       "problem": "ackley",
-      "humpday_median": 0.8455019847738936,
+      "humpday_median": 0.18715697671839893,
       "reference_median": 0.02694823439503624,
-      "humpday_to_opt": 0.8455019847738936,
+      "humpday_to_opt": 0.18715697671839893,
       "reference_to_opt": 0.02694823439503624,
-      "ratio_humpday_over_reference": 31.375041955609582
+      "ratio_humpday_over_reference": 6.945055248327013
     },
     {
       "algorithm": "SimulatedAnnealing",
       "reference": "scipy dual_annealing",
       "problem": "sphere",
-      "humpday_median": 0.0028342659664470846,
-      "reference_median": 2.9715479007977773e-17,
-      "humpday_to_opt": 0.0028342659664470846,
-      "reference_to_opt": 2.9715479007977773e-17,
-      "ratio_humpday_over_reference": 2752474857597.169
+      "humpday_median": 0.0007767336791690447,
+      "reference_median": 4.411598234373943e-17,
+      "humpday_to_opt": 0.0007767336791690447,
+      "reference_to_opt": 4.411598234373943e-17,
+      "ratio_humpday_over_reference": 743915132327.0634
     },
     {
       "algorithm": "SimulatedAnnealing",
       "reference": "scipy dual_annealing",
       "problem": "rosenbrock",
-      "humpday_median": 0.6535658208190718,
-      "reference_median": 1.36493201059018e-10,
-      "humpday_to_opt": 0.6535658208190718,
-      "reference_to_opt": 1.36493201059018e-10,
-      "ratio_humpday_over_reference": 4788231410.18629
+      "humpday_median": 0.17184828496753604,
+      "reference_median": 1.4540795942913728e-10,
+      "humpday_to_opt": 0.17184828496753604,
+      "reference_to_opt": 1.4540795942913728e-10,
+      "ratio_humpday_over_reference": 1181827348.4811265
     },
     {
       "algorithm": "SimulatedAnnealing",
       "reference": "scipy dual_annealing",
       "problem": "ackley",
-      "humpday_median": 3.3736796299438834,
-      "reference_median": 6.762100612789368e-08,
-      "humpday_to_opt": 3.3736796299438834,
-      "reference_to_opt": 6.762100612789368e-08,
-      "ratio_humpday_over_reference": 49890999.457655825
+      "humpday_median": 2.479721243102784,
+      "reference_median": 2.5799275570300044,
+      "humpday_to_opt": 2.479721243102784,
+      "reference_to_opt": 2.5799275570300044,
+      "ratio_humpday_over_reference": 0.9611592528425189
     },
     {
       "algorithm": "BayesianOpt",
       "reference": "scikit-optimize gp_minimize",
       "problem": "sphere",
-      "humpday_median": 0.004327610594202658,
+      "humpday_median": 0.0031538393898554538,
       "reference_median": 1.0534398261206358e-07,
-      "humpday_to_opt": 0.004327610594202658,
+      "humpday_to_opt": 0.0031538393898554538,
       "reference_to_opt": 1.0534398261206358e-07,
-      "ratio_humpday_over_reference": 41080.75701921792
+      "ratio_humpday_over_reference": 29938.486107290977
     },
     {
       "algorithm": "BayesianOpt",
       "reference": "scikit-optimize gp_minimize",
       "problem": "rosenbrock",
-      "humpday_median": 0.3602247657367674,
-      "reference_median": 0.0734108772697186,
-      "humpday_to_opt": 0.3602247657367674,
-      "reference_to_opt": 0.0734108772697186,
-      "ratio_humpday_over_reference": 4.906967184348761
+      "humpday_median": 0.3976920945101371,
+      "reference_median": 0.162104593317791,
+      "humpday_to_opt": 0.3976920945101371,
+      "reference_to_opt": 0.162104593317791,
+      "ratio_humpday_over_reference": 2.4533055255904883
     },
     {
       "algorithm": "BayesianOpt",
       "reference": "scikit-optimize gp_minimize",
       "problem": "ackley",
-      "humpday_median": 2.687640936713944,
-      "reference_median": 0.03241895649897275,
-      "humpday_to_opt": 2.687640936713944,
-      "reference_to_opt": 0.03241895649897275,
-      "ratio_humpday_over_reference": 82.9033758936388
+      "humpday_median": 2.8363751866134312,
+      "reference_median": 0.045916800632884947,
+      "humpday_to_opt": 2.8363751866134312,
+      "reference_to_opt": 0.045916800632884947,
+      "ratio_humpday_over_reference": 61.77205614325837
     },
     {
       "algorithm": "CMAEvolutionStrategy",
       "reference": "cmaes (CyberAgent)",
       "problem": "sphere",
-      "humpday_median": 7.003275732023356e-08,
-      "reference_median": 1.446285840288091e-09,
-      "humpday_to_opt": 7.003275732023356e-08,
-      "reference_to_opt": 1.446285840288091e-09,
-      "ratio_humpday_over_reference": 48.422454225113114
+      "humpday_median": 1.0913455403979044e-09,
+      "reference_median": 3.011116142866099e-08,
+      "humpday_to_opt": 1.0913455403979044e-09,
+      "reference_to_opt": 3.011116142866099e-08,
+      "ratio_humpday_over_reference": 0.036243919276896394
     },
     {
       "algorithm": "CMAEvolutionStrategy",
       "reference": "cmaes (CyberAgent)",
       "problem": "rosenbrock",
-      "humpday_median": 0.03567244776388118,
-      "reference_median": 0.15937062696711954,
-      "humpday_to_opt": 0.03567244776388118,
-      "reference_to_opt": 0.15937062696711954,
-      "ratio_humpday_over_reference": 0.22383326490421407
+      "humpday_median": 0.19034526443310745,
+      "reference_median": 0.04449886463650368,
+      "humpday_to_opt": 0.19034526443310745,
+      "reference_to_opt": 0.04449886463650368,
+      "ratio_humpday_over_reference": 4.277530808661544
     },
     {
       "algorithm": "CMAEvolutionStrategy",
       "reference": "cmaes (CyberAgent)",
       "problem": "ackley",
-      "humpday_median": 0.0020849095776438453,
-      "reference_median": 0.0005954671628143338,
-      "humpday_to_opt": 0.0020849095776438453,
-      "reference_to_opt": 0.0005954671628143338,
-      "ratio_humpday_over_reference": 3.501300672546771
+      "humpday_median": 0.002443107399070943,
+      "reference_median": 0.004222755318054272,
+      "humpday_to_opt": 0.002443107399070943,
+      "reference_to_opt": 0.004222755318054272,
+      "ratio_humpday_over_reference": 0.5785576513576165
     },
     {
       "algorithm": "PRIMA_BOBYQA",
@@ -195,24 +195,24 @@
       "reference": "Py-BOBYQA",
       "problem": "rosenbrock",
       "humpday_median": 0.4053290580992501,
-      "reference_median": 1.609197295776915e-18,
+      "reference_median": 5.3653609788160214e-18,
       "humpday_to_opt": 0.4053290580992501,
-      "reference_to_opt": 1.609197295776915e-18,
-      "ratio_humpday_over_reference": 404677851594803.9
+      "reference_to_opt": 5.3653609788160214e-18,
+      "ratio_humpday_over_reference": 403165927364580.94
     },
     {
       "algorithm": "PRIMA_BOBYQA",
       "reference": "Py-BOBYQA",
       "problem": "ackley",
       "humpday_median": 4.440892098500626e-16,
-      "reference_median": 4.440892098500626e-16,
+      "reference_median": 1.735306729422348e-07,
       "humpday_to_opt": 4.440892098500626e-16,
-      "reference_to_opt": 4.440892098500626e-16,
-      "ratio_humpday_over_reference": 1.0
+      "reference_to_opt": 1.735306729422348e-07,
+      "ratio_humpday_over_reference": 8.321809493638996e-09
     }
   ],
   "n_runs": 4,
   "n_trials": 200,
   "n_dim": 2,
-  "recorded_at": "2026-05-27T18:29:03Z"
+  "recorded_at": "2026-05-27T19:06:52Z"
 }

--- a/tests/test_reference_alignment.py
+++ b/tests/test_reference_alignment.py
@@ -11,6 +11,17 @@ The goal is **alignment**: HumpDay's port should behave indistinguishably
 from the reference within floating-point reason. Today most algorithms
 deviate substantially — those gaps are what this test makes visible.
 
+Fairness of starting points
+---------------------------
+HumpDay's algorithms initialise from `0.3 + 0.4 * U[0, 1]^n` (a random
+interior point in the unit cube). To compare apples-to-apples we draw
+each trial's x0 from the **same distribution**, seeded by the trial
+index, and use it on both sides — `_array.seed(seed)` for HumpDay
+(plus the stdlib `random.seed`, which the evolutionary algorithms use)
+and an explicit `x0` for any local-search reference that takes one.
+Global-search references (DE, dual annealing, gp_minimize, cmaes) get
+the same integer seed via their own RNG parameter.
+
 The test always *passes* (it's a characterisation harness, not a gate).
 The point is the printed table and the persisted snapshot at
 `benchmarks/reference_alignment.json`. Run with stdout visible:
@@ -26,15 +37,34 @@ from __future__ import annotations
 import importlib
 import json
 import math
+import random
 import time
 from pathlib import Path
 
 import pytest
 
+import humpday._array as _humpday_array
 from humpday.optimizers.alloptimizers import PURE_OPTIMIZERS
 
 REPO_ROOT = Path(__file__).parent.parent
 N_RUNS = 4
+
+# Same distribution HumpDay's optimisers use internally. Draw `n_dim`
+# coordinates in [0.3, 0.7] via a seeded `random.Random` so a given
+# trial index produces a reproducible x0 across calls.
+X0_LO, X0_HI = 0.3, 0.7
+
+
+def _draw_x0(seed, n_dim):
+    rng = random.Random(seed)
+    return [X0_LO + (X0_HI - X0_LO) * rng.random() for _ in range(n_dim)]
+
+
+def _seed_humpday(seed):
+    """Seed every RNG HumpDay's algorithms might draw from."""
+    _humpday_array.seed(seed)
+    random.seed(seed)
+
 
 # Cap n_trials per reference. Some references (e.g. skopt's gp_minimize)
 # scale cubically with n_calls; running them at the full HumpDay budget
@@ -109,7 +139,8 @@ def _can_load_pdfo():
         return False
 
 
-def _run_humpday(algorithm: str, func, n_trials: int, n_dim: int):
+def _run_humpday(algorithm: str, func, n_trials: int, n_dim: int, seed: int):
+    _seed_humpday(seed)
     cls = PURE_OPTIMIZERS[algorithm]
     opt = cls(func, n_trials=n_trials, n_dim=n_dim)
     res = opt.optimize()
@@ -122,11 +153,13 @@ def _run_humpday(algorithm: str, func, n_trials: int, n_dim: int):
 
 # ---------- reference adapters ----------
 # Each adapter returns {best_value, evals} on the same problem the HumpDay
-# port saw. References themselves can use different conventions (some
-# count evals differently); we report what the reference reports.
+# port saw, started from a seed-determined x0 drawn from the same
+# distribution HumpDay uses. References themselves can use different
+# conventions (some count evals differently); we report what the
+# reference reports.
 
 
-def _ref_scipy_neldermead(func, n_trials, n_dim):
+def _ref_scipy_neldermead(func, n_trials, n_dim, seed):
     from scipy.optimize import minimize
 
     counter = {"n": 0}
@@ -135,17 +168,16 @@ def _ref_scipy_neldermead(func, n_trials, n_dim):
         counter["n"] += 1
         return func(list(x))
 
-    x0 = [0.5] * n_dim
     r = minimize(
         wrapped,
-        x0,
+        _draw_x0(seed, n_dim),
         method="Nelder-Mead",
         options={"maxfev": n_trials, "xatol": 1e-8, "fatol": 1e-8},
     )
     return {"best_value": float(r.fun), "evals": counter["n"]}
 
 
-def _ref_scipy_powell(func, n_trials, n_dim):
+def _ref_scipy_powell(func, n_trials, n_dim, seed):
     from scipy.optimize import minimize
 
     counter = {"n": 0}
@@ -154,17 +186,16 @@ def _ref_scipy_powell(func, n_trials, n_dim):
         counter["n"] += 1
         return func(list(x))
 
-    x0 = [0.5] * n_dim
     r = minimize(
         wrapped,
-        x0,
+        _draw_x0(seed, n_dim),
         method="Powell",
         options={"maxfev": n_trials, "xtol": 1e-8, "ftol": 1e-8},
     )
     return {"best_value": float(r.fun), "evals": counter["n"]}
 
 
-def _ref_scipy_de(func, n_trials, n_dim):
+def _ref_scipy_de(func, n_trials, n_dim, seed):
     from scipy.optimize import differential_evolution
 
     counter = {"n": 0}
@@ -180,12 +211,12 @@ def _ref_scipy_de(func, n_trials, n_dim):
         maxiter=max(1, n_trials // (10 * n_dim)),
         popsize=10,
         tol=1e-8,
-        seed=0,
+        seed=seed,
     )
     return {"best_value": float(r.fun), "evals": counter["n"]}
 
 
-def _ref_scipy_dual_annealing(func, n_trials, n_dim):
+def _ref_scipy_dual_annealing(func, n_trials, n_dim, seed):
     from scipy.optimize import dual_annealing
 
     counter = {"n": 0}
@@ -195,11 +226,11 @@ def _ref_scipy_dual_annealing(func, n_trials, n_dim):
         return func(list(x))
 
     bounds = [(0, 1)] * n_dim
-    r = dual_annealing(wrapped, bounds, maxiter=max(1, n_trials // 10), seed=0)
+    r = dual_annealing(wrapped, bounds, maxiter=max(1, n_trials // 10), seed=seed)
     return {"best_value": float(r.fun), "evals": counter["n"]}
 
 
-def _ref_skopt_gp(func, n_trials, n_dim):
+def _ref_skopt_gp(func, n_trials, n_dim, seed):
     from skopt import gp_minimize
 
     counter = {"n": 0}
@@ -213,13 +244,13 @@ def _ref_skopt_gp(func, n_trials, n_dim):
         wrapped,
         bounds,
         n_calls=n_trials,
-        random_state=0,
+        random_state=seed,
         n_initial_points=min(10, n_trials // 2),
     )
     return {"best_value": float(r.fun), "evals": counter["n"]}
 
 
-def _ref_cmaes(func, n_trials, n_dim):
+def _ref_cmaes(func, n_trials, n_dim, seed):
     """CyberAgent `cmaes` reference. The library's `ask/tell` API expects
     exactly `population_size` solutions per `tell` call — partial
     generations (e.g. due to budget exhaustion) cause it to raise. We
@@ -235,7 +266,10 @@ def _ref_cmaes(func, n_trials, n_dim):
         return func(list(x))
 
     es = CMA(
-        mean=np.full(n_dim, 0.5), sigma=0.2, bounds=np.array([[0, 1]] * n_dim), seed=0
+        mean=np.asarray(_draw_x0(seed, n_dim)),
+        sigma=0.2,
+        bounds=np.array([[0, 1]] * n_dim),
+        seed=seed,
     )
     best = float("inf")
     while counter["n"] + es.population_size <= n_trials:
@@ -250,7 +284,7 @@ def _ref_cmaes(func, n_trials, n_dim):
     return {"best_value": float(best), "evals": counter["n"]}
 
 
-def _ref_pybobyqa(func, n_trials, n_dim):
+def _ref_pybobyqa(func, n_trials, n_dim, seed):
     import numpy as np
     import pybobyqa
 
@@ -260,22 +294,21 @@ def _ref_pybobyqa(func, n_trials, n_dim):
         counter["n"] += 1
         return func(list(x))
 
-    x0 = np.full(n_dim, 0.5)
     bounds = (np.zeros(n_dim), np.ones(n_dim))
     r = pybobyqa.solve(
         wrapped,
-        x0,
+        np.asarray(_draw_x0(seed, n_dim)),
         bounds=bounds,
         maxfun=n_trials,
         seek_global_minimum=False,
-        rhobeg=0.3,
+        rhobeg=0.2,
         rhoend=1e-8,
         print_progress=False,
     )
     return {"best_value": float(r.f), "evals": counter["n"]}
 
 
-def _ref_pdfo_newuoa(func, n_trials, n_dim):
+def _ref_pdfo_newuoa(func, n_trials, n_dim, seed):
     import numpy as np
     from pdfo import newuoa
 
@@ -287,13 +320,13 @@ def _ref_pdfo_newuoa(func, n_trials, n_dim):
 
     r = newuoa(
         wrapped,
-        np.full(n_dim, 0.5),
-        options={"maxfev": n_trials, "rhobeg": 0.3, "rhoend": 1e-8},
+        np.asarray(_draw_x0(seed, n_dim)),
+        options={"maxfev": n_trials, "rhobeg": 0.2, "rhoend": 1e-8},
     )
     return {"best_value": float(r.fun), "evals": counter["n"]}
 
 
-def _ref_pdfo_uobyqa(func, n_trials, n_dim):
+def _ref_pdfo_uobyqa(func, n_trials, n_dim, seed):
     import numpy as np
     from pdfo import uobyqa
 
@@ -305,8 +338,8 @@ def _ref_pdfo_uobyqa(func, n_trials, n_dim):
 
     r = uobyqa(
         wrapped,
-        np.full(n_dim, 0.5),
-        options={"maxfev": n_trials, "rhobeg": 0.3, "rhoend": 1e-8},
+        np.asarray(_draw_x0(seed, n_dim)),
+        options={"maxfev": n_trials, "rhobeg": 0.2, "rhoend": 1e-8},
     )
     return {"best_value": float(r.fun), "evals": counter["n"]}
 
@@ -367,15 +400,19 @@ def test_reference_alignment():
             opt_value = problem["opt"]
 
             hd_vals = []
-            for _ in range(N_RUNS):
+            for trial in range(N_RUNS):
                 hd_vals.append(
-                    _run_humpday(algorithm, func, n_trials, n_dim)["best_value"]
+                    _run_humpday(algorithm, func, n_trials, n_dim, seed=trial)[
+                        "best_value"
+                    ]
                 )
 
             ref_vals = []
-            for _ in range(N_RUNS):
+            for trial in range(N_RUNS):
                 try:
-                    ref_vals.append(ref_fn(func, n_trials, n_dim)["best_value"])
+                    ref_vals.append(
+                        ref_fn(func, n_trials, n_dim, seed=trial)["best_value"]
+                    )
                 except Exception as e:
                     print(f"    reference error on {problem_id}: {e}")
                     ref_vals.append(float("inf"))


### PR DESCRIPTION
## The bug

Every reference adapter in PR #85's harness started at `x0 = [0.5] * n_dim` — which is **precisely the optimum** for sphere and Ackley. So scipy converged to machine precision trivially while HumpDay started at a random interior point and had to actually optimize. The reported "1.8e15× gaps" were artefacts of the harness, not algorithmic divergence.

## The fix

Both implementations now share the same seed per trial. HumpDay's RNGs (`_array.seed` for the numpy or pure backend, plus stdlib `random.seed` for `evolutionary_algorithms.py`) are seeded with `trial_index`, and every reference adapter gets the same `seed` — used either to set its own RNG parameter (DE, dual_annealing, gp_minimize, cmaes) or to draw `x0` from `0.3 + 0.4 · U[0,1]^n` (the same distribution HumpDay uses internally) for local-search references (NelderMead, Powell, Py-BOBYQA, PDFO).

## Before / after, key cells

**Ackley** — most of the "huge gaps" were the reference getting the optimum as x0:

| Algorithm vs ref          | Before     | After   | Verdict |
|---|---|---|---|
| NelderMead vs scipy       | 1.8e15×    | 0.72×   | HumpDay actually slightly **better** |
| Powell vs scipy           | 2.6e15×    | 1.1e10× | Real algorithmic divergence remains |
| SimulatedAnnealing vs scipy | 5e7×    | 0.96×   | Essentially equal |
| PRIMA_BOBYQA vs Py-BOBYQA | 1.00×      | 0.00×   | HumpDay better |

**Rosenbrock** — most gaps unchanged because Rosenbrock's optimum is at (0.75, 0.75), not (0.5, 0.5), so the old harness wasn't biased there:

| Algorithm vs ref          | Before     | After   | Verdict |
|---|---|---|---|
| PRIMA_BOBYQA vs Py-BOBYQA | 4e14×      | 4e14×   | Real — survives the fix unchanged |
| Powell vs scipy           | 5.6×       | 479×    | Surfaces a real divergence the old harness hid |
| CMA vs cmaes              | 0.22×      | 4.28×   | More fair comparison now |

## What this enables

A clear priority list of **real** algorithmic gaps to close, in order:

1. **PRIMA_BOBYQA on Rosenbrock — 4e14×** — survives the bias fix. Py-BOBYQA's trust-region machinery is genuinely superior.
2. **Powell on Ackley — 1e10×** — HumpDay's golden-section line search can't escape the multimodal saddle; scipy's bracketing search can.
3. **Sphere convergence across the board** — every HumpDay algorithm consistently terminates around `1e-3` to `1e-4` while references hit machine precision. Probably a shared early-stop tolerance.

## Caveats

- The pre-existing PRIMA/PDFO `numpy<2` ABI failure on `tests/algorithms/test_prima_algorithms.py::test_prima_vs_real_prima` still fails the same way on this branch — not introduced here.
- Ruff clean.
- The harness still runs in ~55s.

After this merges I'll start closing the gaps one at a time, with this test as the regression gate.