### PR TITLE
Powell: port scipy's Brent line search (closes 2/3 alignment cells)

### DIFF
--- a/benchmarks/reference_alignment.json
+++ b/benchmarks/reference_alignment.json
@@ -34,31 +34,31 @@
       "algorithm": "Powell",
       "reference": "scipy.optimize Powell",
       "problem": "sphere",
-      "humpday_median": 0.00043788544137658285,
+      "humpday_median": 0.0,
       "reference_median": 0.0,
-      "humpday_to_opt": 0.00043788544137658285,
+      "humpday_to_opt": 0.0,
       "reference_to_opt": 0.0,
-      "ratio_humpday_over_reference": 437885441377.5828
+      "ratio_humpday_over_reference": 1.0
     },
     {
       "algorithm": "Powell",
       "reference": "scipy.optimize Powell",
       "problem": "rosenbrock",
-      "humpday_median": 0.8873833535367698,
+      "humpday_median": 0.3078015365425487,
       "reference_median": 0.06758611872244405,
-      "humpday_to_opt": 0.8873833535367698,
+      "humpday_to_opt": 0.3078015365425487,
       "reference_to_opt": 0.06758611872244405,
-      "ratio_humpday_over_reference": 13.129668788660219
+      "ratio_humpday_over_reference": 4.554212349529848
     },
     {
       "algorithm": "Powell",
       "reference": "scipy.optimize Powell",
       "problem": "ackley",
-      "humpday_median": 1.4491605293294012,
+      "humpday_median": 6.015143938498113e-11,
       "reference_median": 1.4808820836265113e-10,
-      "humpday_to_opt": 1.4491605293294012,
+      "humpday_to_opt": 6.015143938498113e-11,
       "reference_to_opt": 1.4808820836265113e-10,
-      "ratio_humpday_over_reference": 9785726761.268095
+      "ratio_humpday_over_reference": 0.40619056614628973
     },
     {
       "algorithm": "DifferentialEvolution",
@@ -214,5 +214,5 @@
   "n_runs": 4,
   "n_trials": 200,
   "n_dim": 2,
-  "recorded_at": "2026-05-27T19:25:37Z"
+  "recorded_at": "2026-05-27T20:08:51Z"
 }

--- a/humpday/optimizers/scipy_algorithms.py
+++ b/humpday/optimizers/scipy_algorithms.py
@@ -226,13 +226,27 @@ class Powell(BaseOptimizer):
         return self.best_value, self.best_x
 
     def _linesearch_powell(self, p, xi, fval):
-        """Bounded golden-section line search along direction `xi` from
-        point `p`. Returns `(best_f, best_x, scaled_direction)`."""
+        """Bounded Brent-method line search along direction `xi` from
+        point `p`. Returns `(best_f, best_x, scaled_direction)`.
+
+        Ported from scipy.optimize._optimize.Brent.optimize and the
+        downhill-walk `bracket` routine that initialises it. Compared
+        to the previous bounded golden-section, Brent reaches superlinear
+        convergence on smooth landscapes by interleaving inverse
+        quadratic interpolation with golden-section fallbacks, and is
+        what gives scipy's Powell its sharpness on convex problems.
+
+        Adaptations:
+          - The bracket-grow step stops at the alpha bounds (so we stay
+            inside `[0, 1]^n`) instead of growing freely as scipy does.
+          - Every function evaluation is gated by the remaining budget.
+          - On budget exhaustion we return the best alpha seen so far,
+            which preserves the caller's invariant that the line search
+            never worsens `fval`.
+        """
 
         def myfunc(alpha):
             x_trial = _A.clip(p + alpha * xi, 0, 1)
-            if self.evaluations >= self.n_trials:
-                return float("inf")
             return self.evaluate(x_trial)
 
         # If direction is essentially zero, skip the search.
@@ -240,91 +254,189 @@ class Powell(BaseOptimizer):
             return fval, p, xi
 
         # Clamp alpha so p + alpha * xi stays in [0, 1]^n.
-        alpha_bounds = []
+        # Each non-zero `xi[i]` gives two alpha values where the
+        # corresponding coordinate hits 0 or 1; the intersection of all
+        # such intervals is [alpha_min, alpha_max].
+        alpha_lo = float("-inf")
+        alpha_hi = float("inf")
         for i in range(len(xi)):
             xi_i = float(xi[i])
-            if abs(xi_i) > 1e-12:
-                bound1 = -float(p[i]) / xi_i
-                bound2 = (1.0 - float(p[i])) / xi_i
-                alpha_bounds.extend([bound1, bound2])
+            if abs(xi_i) <= 1e-12:
+                continue
+            b1 = -float(p[i]) / xi_i
+            b2 = (1.0 - float(p[i])) / xi_i
+            lo, hi = (b1, b2) if b1 < b2 else (b2, b1)
+            if lo > alpha_lo:
+                alpha_lo = lo
+            if hi < alpha_hi:
+                alpha_hi = hi
 
-        if not alpha_bounds:
+        if alpha_hi <= alpha_lo:
+            return fval, p, xi
+        # Cap to a sensible range. The original bounded golden-section
+        # used [-1, 1] so the magnitude of `xi_new` stayed comparable to
+        # `xi`'s; keep that convention.
+        alpha_lo = max(alpha_lo, -1.0)
+        alpha_hi = min(alpha_hi, 1.0)
+        if alpha_hi <= alpha_lo:
             return fval, p, xi
 
-        alpha_min = max(min(alpha_bounds), -1.0)
-        alpha_max = min(max(alpha_bounds), 1.0)
+        # Track the best alpha seen across bracket + Brent so that on
+        # budget exhaustion we still return progress.
+        best_alpha = 0.0
+        best_f = fval
 
-        if alpha_max <= alpha_min:
-            return fval, p, xi
+        def evaluate(alpha):
+            """Run `myfunc(alpha)` with budget check, updating best_*."""
+            nonlocal best_alpha, best_f
+            if self.evaluations >= self.n_trials:
+                return None
+            f = myfunc(alpha)
+            if f < best_f:
+                best_alpha = alpha
+                best_f = f
+            return f
 
-        # Golden-section search.
-        golden_ratio = (3.0 - math.sqrt(5.0)) / 2.0
-        tol = 1e-6
-        max_evals = min(10, self.n_trials - self.evaluations)
+        # ---- Bracket the minimum (scipy.optimize.bracket adaptation) ----
+        # Start two points apart inside the bounded interval. Use a step
+        # one decimal of the interval width — tiny enough that a smooth
+        # function shows curvature, large enough not to look constant.
+        span = alpha_hi - alpha_lo
+        xa = 0.0 if alpha_lo < 0 < alpha_hi else alpha_lo
+        xb = xa + min(span * 0.1, 1e-1)
+        if xb >= alpha_hi:
+            xb = alpha_lo + 0.5 * (alpha_hi - alpha_lo)
 
-        if abs(alpha_min) < abs(alpha_max):
-            a, c = alpha_min, alpha_max
+        fa = evaluate(xa)
+        if fa is None:
+            return self._linesearch_result(p, xi, fval, best_alpha, best_f)
+        fb = evaluate(xb)
+        if fb is None:
+            return self._linesearch_result(p, xi, fval, best_alpha, best_f)
+
+        if fa < fb:
+            xa, xb = xb, xa
+            fa, fb = fb, fa
+
+        # Step in the downhill direction (golden-ratio expansion).
+        gold = 1.618033988749895
+        xc = xb + gold * (xb - xa)
+        if xc > alpha_hi:
+            xc = alpha_hi
+        if xc < alpha_lo:
+            xc = alpha_lo
+
+        fc = evaluate(xc)
+        if fc is None:
+            return self._linesearch_result(p, xi, fval, best_alpha, best_f)
+
+        # Grow the bracket until f starts increasing on the far side
+        # or we hit a bound. Capped at a small constant to keep the
+        # cost predictable.
+        for _ in range(20):
+            if fc >= fb:
+                break
+            # We have a downhill triple — keep walking.
+            new_xc = xc + gold * (xc - xb)
+            if new_xc > alpha_hi or new_xc < alpha_lo:
+                new_xc = alpha_hi if (xc - xb) > 0 else alpha_lo
+                if new_xc == xc:
+                    break
+            xa, xb = xb, xc
+            fa, fb = fb, fc
+            xc = new_xc
+            fc = evaluate(xc)
+            if fc is None:
+                return self._linesearch_result(p, xi, fval, best_alpha, best_f)
+
+        # If we couldn't bracket (e.g. flat or boundary-attached), bail
+        # out gracefully with whatever the best evaluation was.
+        if not ((xa < xb < xc) or (xc < xb < xa)) or not (fb <= fa and fb <= fc):
+            return self._linesearch_result(p, xi, fval, best_alpha, best_f)
+
+        # ---- Brent's method inside the bracket --------------------------
+        if xa > xc:
+            a_, b_ = xc, xa
         else:
-            a, c = alpha_max, alpha_min
+            a_, b_ = xa, xc
 
-        b = a + golden_ratio * (c - a)
+        x = w = v = xb
+        fx = fw = fv = fb
+        deltax = 0.0
+        rat = 0.0
+        cg = 0.3819660  # 1 - 1/phi (scipy's _cg)
+        brent_tol = 1.48e-8
+        mintol = 1.0e-11
 
-        if self.evaluations >= self.n_trials:
-            return fval, p, xi
-        fa = fval if abs(a) < 1e-10 else myfunc(a)
+        for _ in range(50):
+            tol1 = brent_tol * abs(x) + mintol
+            tol2 = 2.0 * tol1
+            xmid = 0.5 * (a_ + b_)
+            if abs(x - xmid) < (tol2 - 0.5 * (b_ - a_)):
+                break
 
-        if self.evaluations >= self.n_trials:
-            return fval, p, xi
-        fc = myfunc(c)
-
-        if self.evaluations >= self.n_trials:
-            return fval, p, xi
-        fb = myfunc(b)
-
-        best_alpha = a
-        best_f = fa
-        if fb < best_f:
-            best_alpha = b
-            best_f = fb
-        if fc < best_f:
-            best_alpha = c
-            best_f = fc
-
-        evaluations_used = 3
-        while (
-            evaluations_used < max_evals
-            and abs(c - a) > tol
-            and self.evaluations < self.n_trials
-        ):
-            if c - b > b - a:
-                # Larger interval is on the right.
-                x = b + golden_ratio * (c - b)
-                fx = myfunc(x)
-                evaluations_used += 1
-                if fx < fb:
-                    a, b = b, x
-                    fa, fb = fb, fx
-                    if fx < best_f:
-                        best_alpha = x
-                        best_f = fx
-                else:
-                    c = x
-                    fc = fx
+            if abs(deltax) <= tol1:
+                # Take a golden-section step.
+                deltax = (a_ - x) if x >= xmid else (b_ - x)
+                rat = cg * deltax
             else:
-                # Larger interval is on the left.
-                x = b - golden_ratio * (b - a)
-                fx = myfunc(x)
-                evaluations_used += 1
-                if fx < fb:
-                    c, b = b, x
-                    fc, fb = fb, fx
-                    if fx < best_f:
-                        best_alpha = x
-                        best_f = fx
+                # Try an inverse parabolic step.
+                tmp1 = (x - w) * (fx - fv)
+                tmp2 = (x - v) * (fx - fw)
+                p_ = (x - v) * tmp2 - (x - w) * tmp1
+                tmp2 = 2.0 * (tmp2 - tmp1)
+                if tmp2 > 0.0:
+                    p_ = -p_
+                tmp2 = abs(tmp2)
+                dx_temp = deltax
+                deltax = rat
+                if (
+                    (p_ > tmp2 * (a_ - x))
+                    and (p_ < tmp2 * (b_ - x))
+                    and (abs(p_) < abs(0.5 * tmp2 * dx_temp))
+                ):
+                    rat = p_ / tmp2
+                    u = x + rat
+                    if (u - a_) < tol2 or (b_ - u) < tol2:
+                        rat = tol1 if (xmid - x) >= 0 else -tol1
                 else:
-                    a = x
-                    fa = fx
+                    deltax = (a_ - x) if x >= xmid else (b_ - x)
+                    rat = cg * deltax
 
+            # Ensure the step is at least tol1.
+            if abs(rat) < tol1:
+                u = x + (tol1 if rat >= 0 else -tol1)
+            else:
+                u = x + rat
+
+            fu = evaluate(u)
+            if fu is None:
+                break
+
+            if fu > fx:
+                if u < x:
+                    a_ = u
+                else:
+                    b_ = u
+                if fu <= fw or w == x:
+                    v, fv = w, fw
+                    w, fw = u, fu
+                elif fu <= fv or v == x or v == w:
+                    v, fv = u, fu
+            else:
+                if u >= x:
+                    a_ = x
+                else:
+                    b_ = x
+                v, fv = w, fw
+                w, fw = x, fx
+                x, fx = u, fu
+
+        return self._linesearch_result(p, xi, fval, best_alpha, best_f)
+
+    def _linesearch_result(self, p, xi, fval, best_alpha, best_f):
+        """Translate the best (alpha, f) pair from the line search back
+        into the (f, x, direction) tuple Powell's outer loop expects."""
         if best_f < fval:
             x_new = _A.clip(p + best_alpha * xi, 0, 1)
             xi_new = best_alpha * xi


### PR DESCRIPTION
Second iteration of the post-#87 alignment work. **Closes Powell sphere to 1.00× (exact) and Powell Ackley to 0.41× (HumpDay better!) by porting scipy's Brent's method into the line search.**

## The problem

PR #88 closed NelderMead but left Powell with substantial gaps. Tracing showed they were *not* algorithmic divergence in the outer loop — Powell's line search was a bounded golden-section, whose **linear** convergence rate (interval reduction factor ≈ 0.618 per eval) just can't drive the residual down on smooth landscapes the way scipy's Brent's method can. Brent's method interleaves inverse parabolic interpolation with golden-section fallback for **superlinear** convergence.

## The change

Replace `humpday/optimizers/scipy_algorithms.py::Powell._linesearch_powell` with a faithful port of `scipy.optimize._optimize.Brent.optimize` plus the downhill-walk `bracket` routine. Source lines 2439-2617 and 2954-3110 of `scipy/optimize/_optimize.py` respectively.

Adaptations made to scipy's algorithm:

- **Bracket-grow capped at the alpha bounds.** scipy's `bracket` assumes unbounded 1-D minimisation; HumpDay's bounded line search must stay inside `[0, 1]^n`.
- **Every function evaluation budget-gated.** On budget exhaustion the routine returns the best alpha seen so far via a new helper `_linesearch_result`, preserving the caller's invariant that the line search never worsens `fval`.
- **50-iteration cap on the Brent loop** (matches scipy's default `maxiter=500` scaled to our typical 200-eval budget).

## Before / after

Powell alignment ratios (HumpDay median / scipy median, lower-is-closer-to-aligned):

| Problem | Before | After | Verdict |
|---|---|---|---|
| Sphere | 4.4e11× | **1.00× (exact 0)** | ALIGNED |
| Rosenbrock | 13× | 4.55× | Improved |
| **Ackley** | **9.8e9×** | **0.41×** | HumpDay **beats** scipy! |

The Ackley result is the most striking: golden-section's bounded-interval search was getting trapped in a local minimum at f≈1.45; Brent's downhill-bracket walk crosses local optima better and finds f≈6e-11.

The remaining 4.55× Rosenbrock gap is from the outer Powell loop's direction-set update (not the line search) — that's its own task.

## Doesn't break anything

- 340 passed, 10 skipped, 30 deselected.
- `test_scipy_convergence` still passes (it broke on a previous attempt to lift the line-search eval cap).
- The pre-existing PRIMA/PDFO numpy-2 ABI failure is unchanged.
- Ruff clean.

## Next iterations

After this merges the remaining big real gaps are:

1. **PRIMA_BOBYQA Rosenbrock — 4e14×** — port Py-BOBYQA trust region.
2. **Powell Rosenbrock — 4.55×** — port scipy's direction-set update.
3. **BayesianOpt sphere — 3e4×** — port skopt's GP/acquisition logic.