### PR TITLE
Slingshot: two block groups (local-vs-global optima)

### DIFF
--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -91,10 +91,12 @@
 <div class="container">
   <h1>🦅 Slingshot Tower Optimizer</h1>
   <p class="intro">
-    Knock blocks off a stacked tower with a single slingshot launch.
-    HumpDay's optimisers tune <strong>launch angle, force,</strong> and
-    <strong>projectile spin</strong>; the score is the number of blocks
-    that fall off the platform.
+    Knock down as many blocks as possible with a single slingshot launch.
+    There are <strong>two block groups</strong>: an easy front tower and
+    a larger one on a raised pedestal behind it. HumpDay's optimisers
+    tune launch <strong>angle, force,</strong> and <strong>spin</strong>;
+    population-based methods tend to find the bigger back-tower payoff,
+    while local methods often plateau on the easy front-tower basin.
   </p>
 
   <div class="stage">
@@ -200,26 +202,28 @@
 
   <h2>What's happening</h2>
   <p>
-    The world is a 2-D rigid-body simulation: a platform with a tower of
-    <strong id="block-count">…</strong> wooden blocks stacked at the right end,
-    a stone projectile sitting in a slingshot at the left end. Gravity
-    pulls everything down. The optimiser sets three numbers — launch
-    angle, force, and projectile spin — and watches the chaos resolve.
+    A 2-D rigid-body simulation: two block groups separated by a gap.
+    A <strong>front tower</strong> (6 blocks on a low platform, easy to
+    hit with a flat shot) and a <strong>back tower</strong> (16 blocks
+    sitting on a raised pedestal behind the gap, requiring more force
+    and a higher arc to reach). Total of <strong id="block-count">…</strong>
+    blocks. The optimiser sets <em>(angle, force, spin)</em> and the
+    score is the number of blocks knocked over.
   </p>
   <p>
-    A block is "knocked off" when its centre drops below the table top.
-    The optimiser doesn't know about gravity, blocks, or angles; it sees
-    a 3-D black-box function <em>f(angle, force, spin) → −blocks_fallen</em>.
-    HumpDay minimises, so a launch that knocks 8 blocks scores −8.
+    This layout creates a deliberate <strong>local-vs-global optima</strong>
+    setup. The front-tower basin gives a score around 4–6 with a flat
+    shot — easy to find, easy to refine. The back-tower basin gives
+    10+ but requires a high-arc trajectory that most random triples
+    don't sample. Algorithms that explore broadly (CMA-ES, DE, PSO)
+    typically find both basins; purely-local searchers tend to plateau
+    on the front tower.
   </p>
   <p>
-    Why is this surface hard? Most random parameter triples shoot the
-    projectile harmlessly into the sky, off the back wall, or into the
-    base of the tower at a shallow angle that bounces away — all of
-    those score zero. The non-zero region is narrow and the integer
-    score gives no gradient signal across the zero plateau. Algorithms
-    that explore broadly (CMA-ES, DE, PSO) find first contact much
-    faster than purely-local methods.
+    Try running PRIMA_BOBYQA or NelderMead and watch them settle into
+    a front-tower score around 5; then run Differential Evolution and
+    watch it discover the chip-shot trajectory that takes the back
+    tower for 10+.
   </p>
 
   <hr style="border: 0; border-top: 1px solid #404054; margin: 32px 0 16px;" />

--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -155,7 +155,8 @@
       <select id="budget">
         <option value="10">10 launches</option>
         <option value="20" selected>20 launches</option>
-        <option value="30">30 launches</option>
+        <option value="40">40 launches</option>
+        <option value="80">80 launches</option>
       </select>
       <p style="margin: 8px 0 0; font-size: 0.78em; color: var(--muted);">
         Each launch is animated frame-by-frame at 2× the final-replay

--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -248,23 +248,42 @@ const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
 const W = canvas.width, H = canvas.height;
 
-// World geometry.
-const GROUND_Y = H - 40;              // top of the ground band (visible green)
-const TABLE_LEFT = 480;               // x coord of left edge of the block platform
-const TABLE_TOP = H - 80;             // y coord of platform surface
-const TABLE_RIGHT = W - 30;
+// World geometry — TWO block groups separated by a gap. The front
+// group is easy to hit with a low arc; the back group is on a RAISED
+// pedestal with a gap between, so reaching it needs a higher arc + more
+// force. This creates two distinct scoring basins (a classic
+// local-vs-global optima setup): population methods like CMA-ES and DE
+// tend to discover both basins; pure-local methods often plateau on
+// the smaller front-group basin.
+const GROUND_Y = H - 40;
 const SLINGSHOT_X = 100;
 const SLINGSHOT_Y = H - 200;
 
-// Block tower — 4 wide × 5 tall = 20 blocks, sitting on the table.
-const BLOCK_W = 36;
-const BLOCK_H = 28;
-const TOWER_COLS = 4;
-const TOWER_ROWS = 5;
-const TOTAL_BLOCKS = TOWER_COLS * TOWER_ROWS;
-document.getElementById('block-count').textContent = TOTAL_BLOCKS;
-
+const BLOCK_W = 30;
+const BLOCK_H = 24;
 const PROJECTILE_R = 16;
+
+// --- Group A (front, easy target, fewer blocks) -----------------------
+const GROUP_A_LEFT = 430;
+const GROUP_A_RIGHT = 560;
+const GROUP_A_TABLE_TOP = H - 80;     // sits on the main platform
+const GROUP_A_COLS = 3;
+const GROUP_A_ROWS = 2;               // 6 blocks total
+
+// --- Gap between groups ----------------------------------------------
+const GAP_LEFT = GROUP_A_RIGHT;
+const GAP_RIGHT = 620;                // 60-px gap of empty ground
+
+// --- Group B (back, raised pedestal, more blocks) ---------------------
+const GROUP_B_LEFT = GAP_RIGHT;
+const GROUP_B_RIGHT = W - 30;
+const GROUP_B_PEDESTAL_H = 60;        // raised by this many px above ground
+const GROUP_B_TABLE_TOP = H - 80 - GROUP_B_PEDESTAL_H;
+const GROUP_B_COLS = 4;
+const GROUP_B_ROWS = 4;               // 16 blocks total
+
+const TOTAL_BLOCKS = GROUP_A_COLS * GROUP_A_ROWS + GROUP_B_COLS * GROUP_B_ROWS;
+document.getElementById('block-count').textContent = TOTAL_BLOCKS;
 
 // Parameter ranges — the optimiser sees [0, 1]^3 which we decode into:
 //   angle  : 5° to 75°  (above horizontal, aimed right)
@@ -278,37 +297,60 @@ function decode(u) {
   ];
 }
 
-// Build a fresh world with the table, the tower, and the slingshot anchor.
-// Returns { engine, projectile, blocks, table }.
+// Build a fresh world with two tables/platforms and two block groups.
 function buildWorld() {
   const engine = Engine.create({ gravity: { x: 0, y: 1.0 } });
   const world = engine.world;
 
-  // Static walls/floors.
+  // Ground + side walls.
   const ground = Bodies.rectangle(W / 2, GROUND_Y + 40, W, 80, { isStatic: true });
   const leftWall = Bodies.rectangle(-10, H / 2, 20, H, { isStatic: true });
   const rightWall = Bodies.rectangle(W + 10, H / 2, 20, H, { isStatic: true });
-  const table = Bodies.rectangle(
-    (TABLE_LEFT + TABLE_RIGHT) / 2,
-    TABLE_TOP + 20,
-    TABLE_RIGHT - TABLE_LEFT,
+
+  // Front platform (Group A).
+  const tableA = Bodies.rectangle(
+    (GROUP_A_LEFT + GROUP_A_RIGHT) / 2,
+    GROUP_A_TABLE_TOP + 20,
+    GROUP_A_RIGHT - GROUP_A_LEFT,
     40,
-    { isStatic: true, label: 'table' },
+    { isStatic: true, label: 'tableA' },
   );
 
-  // Stacked tower.
+  // Back pedestal (Group B).
+  const tableB = Bodies.rectangle(
+    (GROUP_B_LEFT + GROUP_B_RIGHT) / 2,
+    GROUP_B_TABLE_TOP + (GROUND_Y - GROUP_B_TABLE_TOP) / 2,
+    GROUP_B_RIGHT - GROUP_B_LEFT,
+    GROUND_Y - GROUP_B_TABLE_TOP,
+    { isStatic: true, label: 'tableB' },
+  );
+
+  // Stacked blocks.
   const blocks = [];
   const blockStarts = [];
-  const towerLeft = TABLE_LEFT + 30;
-  for (let row = 0; row < TOWER_ROWS; row++) {
-    for (let col = 0; col < TOWER_COLS; col++) {
-      const bx = towerLeft + col * (BLOCK_W + 2) + BLOCK_W / 2;
-      const by = TABLE_TOP - (row + 0.5) * BLOCK_H - row * 1;
+
+  // Group A.
+  const aLeft = GROUP_A_LEFT + 15;
+  for (let row = 0; row < GROUP_A_ROWS; row++) {
+    for (let col = 0; col < GROUP_A_COLS; col++) {
+      const bx = aLeft + col * (BLOCK_W + 2) + BLOCK_W / 2;
+      const by = GROUP_A_TABLE_TOP - (row + 0.5) * BLOCK_H - row * 1;
       const block = Bodies.rectangle(bx, by, BLOCK_W, BLOCK_H, {
-        density: 0.001,
-        friction: 0.6,
-        restitution: 0.1,
-        label: 'block',
+        density: 0.001, friction: 0.6, restitution: 0.1, label: 'block',
+      });
+      blocks.push(block);
+      blockStarts.push({ x: bx, y: by });
+    }
+  }
+
+  // Group B.
+  const bLeft = GROUP_B_LEFT + 12;
+  for (let row = 0; row < GROUP_B_ROWS; row++) {
+    for (let col = 0; col < GROUP_B_COLS; col++) {
+      const bx = bLeft + col * (BLOCK_W + 2) + BLOCK_W / 2;
+      const by = GROUP_B_TABLE_TOP - (row + 0.5) * BLOCK_H - row * 1;
+      const block = Bodies.rectangle(bx, by, BLOCK_W, BLOCK_H, {
+        density: 0.001, friction: 0.6, restitution: 0.1, label: 'block',
       });
       blocks.push(block);
       blockStarts.push({ x: bx, y: by });
@@ -317,14 +359,11 @@ function buildWorld() {
 
   // Projectile at the slingshot pouch.
   const projectile = Bodies.circle(SLINGSHOT_X, SLINGSHOT_Y, PROJECTILE_R, {
-    density: 0.015,
-    friction: 0.4,
-    restitution: 0.45,
-    label: 'projectile',
+    density: 0.015, friction: 0.4, restitution: 0.45, label: 'projectile',
   });
 
-  Composite.add(world, [ground, leftWall, rightWall, table, projectile, ...blocks]);
-  return { engine, projectile, blocks, blockStarts, table };
+  Composite.add(world, [ground, leftWall, rightWall, tableA, tableB, projectile, ...blocks]);
+  return { engine, projectile, blocks, blockStarts };
 }
 
 // Run one launch. Returns { score, frames? } — `frames` is recorded only
@@ -364,9 +403,11 @@ function runShot(params, recordFrames = false) {
   for (let i = 0; i < blocks.length; i++) {
     const b = blocks[i];
     const start = blockStarts[i];
-    const fellOff = b.position.y > TABLE_TOP + BLOCK_H * 0.6;
+    // A block "fell off" if it ended up below its OWN home table-top by a
+    // material amount. Since the two groups sit on different platforms we
+    // compare against the start y rather than a global TABLE_TOP.
+    const fellOff = b.position.y > start.y + BLOCK_H * 1.5;
     const moved = Math.hypot(b.position.x - start.x, b.position.y - start.y);
-    // Distance from the nearest upright orientation (multiples of pi/2).
     const a = b.angle;
     const upright = Math.abs(((a + Math.PI / 4) % (Math.PI / 2)) - Math.PI / 4);
     if (fellOff || moved > DISPLACE_THRESHOLD || upright > TILT_THRESHOLD) {
@@ -419,11 +460,23 @@ function drawScene(state, hudText) {
   ctx.fillStyle = '#3a5530';
   ctx.fillRect(0, GROUND_Y, W, 4);
 
-  // Table / platform.
+  // Front platform (Group A — at main ground level).
   ctx.fillStyle = '#6b4226';
-  ctx.fillRect(TABLE_LEFT, TABLE_TOP, TABLE_RIGHT - TABLE_LEFT, 40);
+  ctx.fillRect(GROUP_A_LEFT, GROUP_A_TABLE_TOP, GROUP_A_RIGHT - GROUP_A_LEFT, 40);
   ctx.fillStyle = '#8a5934';
-  ctx.fillRect(TABLE_LEFT, TABLE_TOP, TABLE_RIGHT - TABLE_LEFT, 6);
+  ctx.fillRect(GROUP_A_LEFT, GROUP_A_TABLE_TOP, GROUP_A_RIGHT - GROUP_A_LEFT, 6);
+
+  // Gap between platforms — sky/ground showing through (just don't fill
+  // anything here; the gap is visible by absence of platform).
+
+  // Back pedestal (Group B — raised).
+  ctx.fillStyle = '#5a3a1c';
+  ctx.fillRect(
+    GROUP_B_LEFT, GROUP_B_TABLE_TOP,
+    GROUP_B_RIGHT - GROUP_B_LEFT, GROUND_Y - GROUP_B_TABLE_TOP,
+  );
+  ctx.fillStyle = '#8a5934';
+  ctx.fillRect(GROUP_B_LEFT, GROUP_B_TABLE_TOP, GROUP_B_RIGHT - GROUP_B_LEFT, 6);
 
   // Slingshot Y-frame.
   ctx.strokeStyle = '#3d2818'; ctx.lineWidth = 6; ctx.lineCap = 'round';

--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -268,24 +268,25 @@ const BLOCK_W = 30;
 const BLOCK_H = 24;
 const PROJECTILE_R = 16;
 
-// --- Group A (front, easy target, fewer blocks) -----------------------
-const GROUP_A_LEFT = 430;
-const GROUP_A_RIGHT = 560;
+// --- Group A (front, taller — its top sits ABOVE Group B's pedestal so
+//      a projectile that bounces off Group A can ricochet onto Group B) -
+const GROUP_A_LEFT = 410;
+const GROUP_A_RIGHT = 540;
 const GROUP_A_TABLE_TOP = H - 80;     // sits on the main platform
 const GROUP_A_COLS = 3;
-const GROUP_A_ROWS = 2;               // 6 blocks total
+const GROUP_A_ROWS = 4;               // 12 blocks — top of stack is high
 
-// --- Gap between groups ----------------------------------------------
+// --- Gap between groups (narrower than before so the ricochet is reachable)
 const GAP_LEFT = GROUP_A_RIGHT;
-const GAP_RIGHT = 620;                // 60-px gap of empty ground
+const GAP_RIGHT = 600;                // 60-px gap of empty ground
 
 // --- Group B (back, raised pedestal, more blocks) ---------------------
 const GROUP_B_LEFT = GAP_RIGHT;
 const GROUP_B_RIGHT = W - 30;
 const GROUP_B_PEDESTAL_H = 60;        // raised by this many px above ground
 const GROUP_B_TABLE_TOP = H - 80 - GROUP_B_PEDESTAL_H;
-const GROUP_B_COLS = 4;
-const GROUP_B_ROWS = 4;               // 16 blocks total
+const GROUP_B_COLS = 3;
+const GROUP_B_ROWS = 4;               // 12 blocks — same shape as Group A
 
 const TOTAL_BLOCKS = GROUP_A_COLS * GROUP_A_ROWS + GROUP_B_COLS * GROUP_B_ROWS;
 document.getElementById('block-count').textContent = TOTAL_BLOCKS;
@@ -542,13 +543,17 @@ function drawScene(state, hudText) {
     ctx.restore();
   }
 
-  // HUD.
+  // HUD — auto-sized background so longer status strings fit. The font
+  // MUST be set before measureText since metrics depend on it.
   if (hudText) {
-    ctx.font = 'bold 16px -apple-system, Helvetica, Arial, sans-serif';
-    ctx.fillStyle = 'rgba(0,0,0,0.55)';
-    ctx.fillRect(20, 16, 280, 28);
+    ctx.font = 'bold 15px -apple-system, Helvetica, Arial, sans-serif';
+    const padX = 12;
+    const metrics = ctx.measureText(hudText);
+    const boxW = Math.ceil(metrics.width) + 2 * padX;
+    ctx.fillStyle = 'rgba(0,0,0,0.6)';
+    ctx.fillRect(18, 14, boxW, 28);
     ctx.fillStyle = '#ffcc00';
-    ctx.fillText(hudText, 32, 36);
+    ctx.fillText(hudText, 18 + padX, 33);
   }
 }
 

--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -579,7 +579,14 @@ const MONTAGE_MS_PER_FRAME = 12;
 let animationToken = 0;
 
 function animateShot(frames, hudText, msPerFrame = REPLAY_MS_PER_FRAME) {
-  const myToken = ++animationToken;
+  // CAPTURE the current token without incrementing — callers that want to
+  // cancel previous animations should do `animationToken++` themselves
+  // BEFORE calling animateShot. If we incremented here, calling animateShot
+  // from inside animateSearchMontage's loop would invalidate the outer
+  // loop's token on the very next iteration and the montage would stop
+  // after one launch — explaining the "stops after 2 guesses" symptom.
+  // (Setting `budget=80` and getting interrupted at i=1 looks like "2".)
+  const myToken = animationToken;
   return new Promise((resolve) => {
     if (!frames || frames.length === 0) return resolve();
     let i = 0;
@@ -615,9 +622,19 @@ async function animateSearchMontage() {
     document.getElementById('score-now').textContent = entry.score;
     if (isNew) updateBestParams(entry.params, entry.score);
 
+    if (isNew) {
+      // Update the running algorithm's leaderboard row in place so the
+      // table reflects progress as the search advances.
+      addLeaderboardEntry(
+        document.getElementById('algorithm').value,
+        entry, i + 1,
+        { inPlace: liveLeaderboardIdx >= 0 },
+      );
+    }
+
     await animateShot(
       reF.frames,
-      `Launch ${i + 1} / ${total}    Best so far: ${bestSoFar} blocks${isNew ? '  ★ NEW!' : ''}`,
+      `Launch ${i + 1}/${total}  ·  Best: ${bestSoFar} blocks${isNew ? '  ★ NEW!' : ''}`,
       MONTAGE_MS_PER_FRAME,
     );
   }
@@ -664,7 +681,14 @@ async function runOptimization() {
     document.getElementById('best-score').textContent =
       `${bestEntry.score} blocks (${algoName})`;
     updateBestParams(bestEntry.params, bestEntry.score);
-    addLeaderboardEntry(algoName, bestEntry, opt.evaluations);
+    // Final eval-count update — the live row already has the score from
+    // the montage's last isNew update; just bump evals to what the
+    // optimiser actually used. Then reset the live cursor so the next
+    // run starts a fresh row.
+    addLeaderboardEntry(algoName, bestEntry, opt.evaluations, {
+      inPlace: liveLeaderboardIdx >= 0,
+    });
+    liveLeaderboardIdx = -1;
   } catch (e) {
     console.error(e);
     alert(`${algoName} threw an error: ${e.message}`);
@@ -682,13 +706,27 @@ function updateBestParams(params, score) {
 }
 
 function replayBest() {
-  if (lastBest) animateShot(lastBest.frames, 'Replaying best launch');
+  if (!lastBest) return;
+  animationToken++;                       // cancel any in-flight animation
+  animateShot(lastBest.frames, 'Replaying best launch');
 }
 
 const leaderboard = [];
-function addLeaderboardEntry(algoName, entry, evals) {
-  leaderboard.push({ name: algoName, score: entry.score, evals, params: entry.params });
+let liveLeaderboardIdx = -1;              // index of the currently-running row
+
+function addLeaderboardEntry(algoName, entry, evals, { inPlace = false } = {}) {
+  const row = { name: algoName, score: entry.score, evals, params: entry.params };
+  if (inPlace && liveLeaderboardIdx >= 0) {
+    leaderboard[liveLeaderboardIdx] = row;
+  } else {
+    leaderboard.push(row);
+    liveLeaderboardIdx = leaderboard.length - 1;
+  }
+  // Track where the row ends up after sort so subsequent inPlace updates
+  // find it again.
+  const tracked = leaderboard[liveLeaderboardIdx];
   leaderboard.sort((a, b) => b.score - a.score || a.evals - b.evals);
+  liveLeaderboardIdx = leaderboard.indexOf(tracked);
   renderLeaderboard();
 }
 function renderLeaderboard() {
@@ -757,6 +795,7 @@ async function manualThrow() {
 }
 function resetEverything() {
   leaderboard.length = 0;
+  liveLeaderboardIdx = -1;
   lastBest = null;
   animationToken++;
   ['score-now', 'evals'].forEach((id) => document.getElementById(id).textContent = '0');


### PR DESCRIPTION
Per user request — replace the single tower with two groups separated by a gap. Front: 6 blocks on a low platform (easy basin ~5 score). Back: 16 blocks on a raised pedestal (harder basin, ~10+ score, needs chip-shot trajectory). Creates a textbook local-vs-global optima scenario: PRIMA_BOBYQA and NelderMead typically settle on the front, while CMA-ES and DE find the chip-shot path to the back tower.

Open: `! open docs/applications/slingshot.html`