### PR TITLE
JS PRIMA: remove artificial iteration cap + tighten UOBYQA rhoend

### DIFF
--- a/docs/js/modules/prima-algorithms.js
+++ b/docs/js/modules/prima-algorithms.js
@@ -38,7 +38,11 @@ class PRIMA_UOBYQA extends Optimizer {
 
         // Trust region parameters EXACTLY matching PDFO's aggressive behavior
         let rho = 0.5;  // LARGER initial trust region radius like PDFO
-        const rhoend = 1e-3; // Relaxed final radius for better visualization
+        // Final trust-region radius. Was 1e-3 ("relaxed for visualization")
+        // which terminated UOBYQA at a coarse precision — well before the
+        // user's evaluation budget was exhausted on most problems.
+        // Matches NEWUOA and BOBYQA's 1e-8.
+        const rhoend = 1e-8;
         const eta1 = 0.01; // MORE AGGRESSIVE step acceptance (accept more steps)
         const eta2 = 0.25; // MORE AGGRESSIVE trust region expansion
         const gamma1 = 0.5; // Contraction factor
@@ -1101,7 +1105,14 @@ class PRIMA_BOBYQA extends Optimizer {
         let kopt = this._argmin(FVAL);
 
         let iteration = 0;
-        const maxIter = Math.min(100, Math.floor(this.nTrials / npt));
+        // Cap iteration count by budget directly rather than by
+        // floor(budget / npt) — the previous formula gave only
+        // floor(80/7) = 11 iterations on a 3-D problem with budget 80,
+        // so the trust-region loop terminated long before it should have.
+        // Each iteration uses ~1 evaluation, so the while-loop's own
+        // `this.evaluations < this.nTrials` check is sufficient; this
+        // cap just guards against pathological infinite loops.
+        const maxIter = this.nTrials;
 
         while (this.evaluations < this.nTrials && rho > rhoend && iteration < maxIter) {
             iteration += 1;


### PR DESCRIPTION
User-observed: PRIMA_BOBYQA on the slingshot demo stops at ~25 evals even with budget=80, before the algorithm could genuinely have converged.

Two tolerance fixes mirroring the Python alignment work from PR #88 (NelderMead) and PR #89 (Powell):

**1. PRIMA_BOBYQA maxIter cap.** Was `min(100, floor(nTrials / npt))`. With n=3, npt=7, budget=80 → 11 iterations max, far below the algorithm's actual convergence point. The formula assumed npt evals per iteration but in practice each uses ~1, so the cap was off by a factor of npt. Now `maxIter = nTrials`.

**2. PRIMA_UOBYQA rhoend.** Was `1e-3` with a comment 'Relaxed final radius for better visualization'. Terminates the trust region at coarse precision. Tightened to `1e-8` to match NEWUOA and BOBYQA.

## Smoke test (sphere, n=3)

| Budget | BOBYQA evals before | BOBYQA after | UOBYQA before | UOBYQA after |
|---|---|---|---|---|
| 20 | 18 | 20 | 17 | 20 |
| 40 | 18 | 34 | 17 | 17 (1e-19) |
| 80 | 18 | 34 | 17 | 17 (1e-23) |

BOBYQA now uses more of the budget; UOBYQA converges to machine precision instead of the old 1e-3 floor.

On the slingshot's chaotic block-physics landscape, rho won't shrink as quickly, so both algorithms will use significantly more of the budget — which is what the user wanted.

## Future task (#21 still open)

Two more 'Relaxed for visualization' tolerances in PRIMA_UOBYQA (`gNorm < 1e-4` step-skipping, `distance < 1e-3` geometry check) are step-selection conditions, not termination conditions — leaving alone for now. Worth revisiting if UOBYQA still misbehaves on the demos.