### PR TITLE
mini-golf: make ball spin visible + impactful on ground roll

### DIFF
--- a/docs/applications/mini-golf.html
+++ b/docs/applications/mini-golf.html
@@ -98,8 +98,8 @@
           <label for="manual-angle">Angle <output id="manual-angle-out">25°</output></label>
           <input type="range" id="manual-angle" min="5" max="70" step="0.5" value="25">
 
-          <label for="manual-power">Power <output id="manual-power-out">35</output></label>
-          <input type="range" id="manual-power" min="10" max="60" step="0.5" value="35">
+          <label for="manual-power">Power <output id="manual-power-out">80</output></label>
+          <input type="range" id="manual-power" min="15" max="160" step="1" value="80">
 
           <label for="manual-spin">Spin <output id="manual-spin-out">0.00</output></label>
           <input type="range" id="manual-spin" min="-0.5" max="0.5" step="0.02" value="0">
@@ -235,12 +235,13 @@ const BALL_R = 9;
 
 // Parameter ranges.
 // angle: 5..70° (low putts to high chips)
-// power: 10..60 (impulse magnitude)
+// power: 15..160 (impulse magnitude — extended so a hard chip can
+//        actually reach the back of the course; 60 was too weak)
 // spin: -0.5..+0.5 (angular velocity affecting roll)
 function decode(u) {
   return [
     5 + 65 * u[0],
-    10 + 50 * u[1],
+    15 + 145 * u[1],
     -0.5 + 1.0 * u[2],
   ];
 }
@@ -296,7 +297,9 @@ function runShot(params, recordFrames = false) {
   const [angleDeg, power, spin] = params;
   const { engine, ball } = buildWorld();
   const rad = angleDeg * Math.PI / 180;
-  Body.setVelocity(ball, { x: power * Math.cos(rad) * 0.18, y: -power * Math.sin(rad) * 0.18 });
+  // Velocity multiplier 0.22 (was 0.18) gives a bit more travel per
+  // unit power so a mid-range stroke reaches the hole region.
+  Body.setVelocity(ball, { x: power * Math.cos(rad) * 0.22, y: -power * Math.sin(rad) * 0.22 });
   Body.setAngularVelocity(ball, spin);
 
   const frames = recordFrames ? [] : null;

--- a/docs/applications/mini-golf.html
+++ b/docs/applications/mini-golf.html
@@ -279,7 +279,9 @@ function buildWorld() {
   // Ball.
   const ball = Bodies.circle(TEE_X, TEE_Y, BALL_R, {
     density: 0.005,
-    friction: 0.05,
+    // friction 0.05 was too low — spin barely transferred to roll.
+    // 0.35 lets sidespin meaningfully change the post-bounce trajectory.
+    friction: 0.35,
     frictionAir: 0.02,        // air drag — keeps things from rolling forever
     restitution: 0.55,
     label: 'ball',
@@ -449,11 +451,25 @@ function drawBall(b) {
   ctx.beginPath();
   ctx.arc(0, 0, BALL_R, 0, Math.PI * 2);
   ctx.fill();
-  // Dimples — just a couple to suggest a golf ball.
+  // Bold red stripe across the ball — rotates with `b.a` so the spin is
+  // unambiguously visible. Without an asymmetric mark the ball just
+  // looked like a static gradient circle.
+  ctx.strokeStyle = '#cc1818';
+  ctx.lineWidth = 2.2;
+  ctx.beginPath();
+  ctx.moveTo(-BALL_R + 1, 0);
+  ctx.lineTo(BALL_R - 1, 0);
+  ctx.stroke();
+  // Smaller perpendicular tick (so it's clear which way is "up").
+  ctx.lineWidth = 1.4;
+  ctx.beginPath();
+  ctx.moveTo(0, -BALL_R + 2);
+  ctx.lineTo(0, -BALL_R + 5);
+  ctx.stroke();
+  // Dimples — a couple to keep the golf-ball feel.
   ctx.fillStyle = 'rgba(0,0,0,0.18)';
-  ctx.beginPath(); ctx.arc(-2, -2, 1.2, 0, Math.PI * 2); ctx.fill();
-  ctx.beginPath(); ctx.arc(3, -1, 1.2, 0, Math.PI * 2); ctx.fill();
-  ctx.beginPath(); ctx.arc(1, 3, 1.2, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(-4, -3, 1.0, 0, Math.PI * 2); ctx.fill();
+  ctx.beginPath(); ctx.arc(4, 3, 1.0, 0, Math.PI * 2); ctx.fill();
   ctx.restore();
 }
 


### PR DESCRIPTION
Per user: "the ball should visibly spin more off the ground".

Two issues fixed:

**Visual** — ball was drawn as a static gradient circle with a couple of dimples. No asymmetric mark, so even though Matter.js was rotating the body, the visual didn't show it. Added a bold red stripe across the ball + a small "up" tick, both inside the rotate(b.a) block. Spin is now unmistakable on screen.

**Physics** — ball.friction was 0.05 (very low). When the ball touched the ground, spin barely transferred to translation; post-bounce roll looked almost identical regardless of sidespin. Bumped to 0.35; sidespin now visibly changes post-bounce roll direction and distance.

Also includes the power-range fix from PR #100 (15-160 / multiplier 0.22) since that branch hadn't merged when this one was forked — it's the same change, cleanly cherry-picked.