### PR TITLE
DifferentialEvolution: align with scipy defaults (best1bin + dither + CR=0.7)

### DIFF
--- a/benchmarks/reference_alignment.json
+++ b/benchmarks/reference_alignment.json
@@ -64,31 +64,31 @@
       "algorithm": "DifferentialEvolution",
       "reference": "scipy differential_evolution",
       "problem": "sphere",
-      "humpday_median": 0.00027178102421698976,
+      "humpday_median": 1.2195613612335951e-05,
       "reference_median": 1.2692186333740483e-12,
-      "humpday_to_opt": 0.00027178102421698976,
+      "humpday_to_opt": 1.2195613612335951e-05,
       "reference_to_opt": 1.2692186333740483e-12,
-      "ratio_humpday_over_reference": 213963972.08885607
+      "ratio_humpday_over_reference": 9601192.497815171
     },
     {
       "algorithm": "DifferentialEvolution",
       "reference": "scipy differential_evolution",
       "problem": "rosenbrock",
-      "humpday_median": 0.35802570586317956,
+      "humpday_median": 0.010980246271619067,
       "reference_median": 1.3748802524684246e-10,
-      "humpday_to_opt": 0.35802570586317956,
+      "humpday_to_opt": 0.010980246271619067,
       "reference_to_opt": 1.3748802524684246e-10,
-      "ratio_humpday_over_reference": 2604031159.72635
+      "ratio_humpday_over_reference": 79862710.87387925
     },
     {
       "algorithm": "DifferentialEvolution",
       "reference": "scipy differential_evolution",
       "problem": "ackley",
-      "humpday_median": 0.18715697671839893,
+      "humpday_median": 0.10986175663369879,
       "reference_median": 0.02694823439503624,
-      "humpday_to_opt": 0.18715697671839893,
+      "humpday_to_opt": 0.10986175663369879,
       "reference_to_opt": 0.02694823439503624,
-      "ratio_humpday_over_reference": 6.945055248327013
+      "ratio_humpday_over_reference": 4.076770114999884
     },
     {
       "algorithm": "SimulatedAnnealing",
@@ -214,5 +214,5 @@
   "n_runs": 4,
   "n_trials": 200,
   "n_dim": 2,
-  "recorded_at": "2026-05-27T20:08:51Z"
+  "recorded_at": "2026-05-28T21:22:29Z"
 }

--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -22,35 +22,55 @@ class DifferentialEvolution(BaseOptimizer):
     """
 
     def optimize(self):
-        # DE needs at least 4 members (current + 3 others for mutation).
+        # Match scipy.optimize.differential_evolution defaults: `best1bin`
+        # mutation strategy (mutate around the population's best member,
+        # not a random one), dither-mutation F drawn per-generation in
+        # [0.5, 1.0], recombination probability 0.7.
+        #
+        # The previous implementation used the `rand1` strategy with a
+        # fixed F=0.8 and CR=0.9 — `rand1` is more exploratory but
+        # converges very slowly on smooth landscapes, which is exactly
+        # why this port was 1e8x off scipy's DE on the sphere benchmark.
+        # Reference: scipy/optimize/_differentialevolution.py.
         pop_size = max(10, min(20, self.n_trials // 5))
-        F = 0.8  # Scaling factor
-        CR = 0.9  # Crossover probability
+        CR = 0.7  # scipy default recombination probability.
 
-        # Initialize population as list-of-vectors.
         population = [_A.random_uniform(self.n_dim) for _ in range(pop_size)]
         fitness = [self.evaluate(ind) for ind in population]
 
         while self.evaluations < self.n_trials:
+            # Dither: pick F uniformly in [0.5, 1.0] per generation. This
+            # is scipy's default `mutation=(0.5, 1)` behaviour, which
+            # helps the population avoid stagnation by varying the
+            # mutation scale.
+            F = 0.5 + 0.5 * _A.random_scalar()
+
             for i in range(pop_size):
                 if self.evaluations >= self.n_trials:
                     break
 
-                # Pick three indices distinct from `i`.
-                candidates = [k for k in range(pop_size) if k != i]
-                if len(candidates) < 3:
-                    a, b, c = _A.random_choice(candidates, k=3, replace=True)
-                else:
-                    a, b, c = _A.random_choice(candidates, k=3, replace=False)
-                a, b, c = int(a), int(b), int(c)
+                # `best1bin`: base point is the current population best,
+                # not a random member. Find best index.
+                best_idx = min(range(pop_size), key=fitness.__getitem__)
 
-                # Mutation: v = x_a + F * (x_b - x_c), clipped to bounds.
+                # Two donors distinct from i and best_idx.
+                candidates = [k for k in range(pop_size) if k != i and k != best_idx]
+                if len(candidates) < 2:
+                    candidates = [k for k in range(pop_size) if k != i]
+                if len(candidates) < 2:
+                    b, c = _A.random_choice(candidates, k=2, replace=True)
+                else:
+                    b, c = _A.random_choice(candidates, k=2, replace=False)
+                b, c = int(b), int(c)
+
+                # Mutation: v = x_best + F * (x_b - x_c), clipped to bounds.
                 mutant = _A.clip(
-                    population[a] + F * (population[b] - population[c]), 0, 1
+                    population[best_idx] + F * (population[b] - population[c]),
+                    0,
+                    1,
                 )
 
-                # Binomial crossover. `j_guaranteed` ensures at least one
-                # coordinate of the mutant survives — standard DE.
+                # Binomial crossover with at least one guaranteed coord.
                 trial = population[i].copy()
                 j_guaranteed = _A.random_int(self.n_dim)
                 for j in range(self.n_dim):


### PR DESCRIPTION
User-picked alignment target. HumpDay's DE was **1e8× off** scipy on sphere and **1e9× off** on Rosenbrock — the biggest unaligned single-algorithm gap that wasn't already a known hard port.

## Root cause
`rand1` mutation strategy + fixed F=0.8 + CR=0.9. scipy uses `best1bin` (mutate around the population's current best), dithered F ∼ U[0.5, 1.0] per generation, and CR=0.7. The strategy difference is the big one — `best1bin` pulls the population toward the best-so-far each generation, accelerating convergence by orders of magnitude on smooth basins.

## Before / after

| Problem | Before | After | Improvement |
|---|---|---|---|
| sphere | 2.1e8× | **9.6e6×** | 22× tighter |
| rosenbrock | 2.6e9× | **7.9e7×** | 33× tighter |
| ackley | 7× | **4.1×** | 1.7× tighter |

## Caveats
Still ~7 orders off scipy on sphere (scipy reaches 1e-12; HumpDay reaches 1e-5). The remaining gap is likely scipy's better initial sampling (latinhypercube / sobol vs HumpDay's uniform random) plus other implementation details — worth a follow-up PR.

## Tests
- 340 core tests pass.
- Reference-alignment harness re-recorded — `benchmarks/reference_alignment.json` updated.
- Ruff clean.