### PR TITLE
SimulatedAnnealing: add coordinate-descent polish (445,000× tighter on sphere)

### DIFF
--- a/benchmarks/reference_alignment.json
+++ b/benchmarks/reference_alignment.json
@@ -94,31 +94,31 @@
       "algorithm": "SimulatedAnnealing",
       "reference": "scipy dual_annealing",
       "problem": "sphere",
-      "humpday_median": 0.0007767336791690447,
+      "humpday_median": 1.72422016733603e-09,
       "reference_median": 4.411598234373943e-17,
-      "humpday_to_opt": 0.0007767336791690447,
+      "humpday_to_opt": 1.72422016733603e-09,
       "reference_to_opt": 4.411598234373943e-17,
-      "ratio_humpday_over_reference": 743915132327.0634
+      "ratio_humpday_over_reference": 1651369.3847168686
     },
     {
       "algorithm": "SimulatedAnnealing",
       "reference": "scipy dual_annealing",
       "problem": "rosenbrock",
-      "humpday_median": 0.17184828496753604,
+      "humpday_median": 0.05425842335976107,
       "reference_median": 1.4540795942913728e-10,
-      "humpday_to_opt": 0.17184828496753604,
+      "humpday_to_opt": 0.05425842335976107,
       "reference_to_opt": 1.4540795942913728e-10,
-      "ratio_humpday_over_reference": 1181827348.4811265
+      "ratio_humpday_over_reference": 373143605.2687251
     },
     {
       "algorithm": "SimulatedAnnealing",
       "reference": "scipy dual_annealing",
       "problem": "ackley",
-      "humpday_median": 2.479721243102784,
+      "humpday_median": 0.0014125135098272956,
       "reference_median": 2.5799275570300044,
-      "humpday_to_opt": 2.479721243102784,
+      "humpday_to_opt": 0.0014125135098272956,
       "reference_to_opt": 2.5799275570300044,
-      "ratio_humpday_over_reference": 0.9611592528425189
+      "ratio_humpday_over_reference": 0.0005475012296292425
     },
     {
       "algorithm": "BayesianOpt",
@@ -214,5 +214,5 @@
   "n_runs": 4,
   "n_trials": 200,
   "n_dim": 2,
-  "recorded_at": "2026-05-28T21:22:29Z"
+  "recorded_at": "2026-05-28T21:31:01Z"
 }

--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -147,60 +147,95 @@ class ParticleSwarm(BaseOptimizer):
 
 
 class SimulatedAnnealing(BaseOptimizer):
-    """Simulated Annealing with multi-restart.
+    """Simulated Annealing with multi-restart + coordinate-descent polish.
 
-    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    Two-stage algorithm matching the spirit of scipy.optimize.dual_annealing:
+
+      1. Multi-restart Metropolis SA explores the parameter space
+         globally with a geometric cooling schedule.
+      2. A coordinate-descent polish from the best SA point refines
+         to high precision.
+
+    scipy's dual_annealing uses L-BFGS-B for stage 2; the closest
+    derivative-free equivalent is a coordinate descent with shrinking
+    step. Without the polish stage HumpDay's SA was 1e9-1e11× off scipy
+    on sphere and Rosenbrock; the global SA can't reach machine
+    precision because its proposals are noisy.
     """
 
     def optimize(self):
-        # Multi-restart approach.
-        num_restarts = max(3, self.n_trials // 30)
-        trials_per_restart = self.n_trials // num_restarts
+        # Reserve ~30% of the budget for the polish phase.
+        polish_budget = max(20, self.n_trials // 3)
+        sa_budget = self.n_trials - polish_budget
+
+        # --- Stage 1: multi-restart SA ---------------------------------
+        num_restarts = max(3, sa_budget // 30)
+        trials_per_restart = max(1, sa_budget // num_restarts)
 
         for restart in range(num_restarts):
-            if self.evaluations >= self.n_trials:
+            if self.evaluations >= sa_budget:
                 break
 
-            # Warm-start the first restart near the centre of the cube;
-            # subsequent restarts roll the dice anywhere.
             if restart == 0:
                 x = 0.5 + (_A.random_uniform(self.n_dim) - 0.5) * 0.4
             else:
                 x = _A.random_uniform(self.n_dim)
 
             fx = self.evaluate(x)
-            best_x, best_fx = x.copy(), fx
 
-            # Temperature schedule.
-            temp = max(1.0, best_fx * 2)
-            final_temp = 1e-8
+            # Fixed initial temperature, geometric cooling. Reaches
+            # final_temp by the end of the restart's iteration count.
+            initial_temp = 1.0
+            final_temp = 1e-6
+            cooling = (final_temp / initial_temp) ** (1.0 / max(1, trials_per_restart))
+            temp = initial_temp
 
             for _iteration in range(trials_per_restart):
-                if self.evaluations >= self.n_trials:
+                if self.evaluations >= sa_budget:
                     break
 
-                # Generate neighbor.
-                step_size = 0.3 * (temp / max(1.0, best_fx * 2))
+                # Neighbour proposal: step scales with current temp.
+                step_size = 0.4 * temp
                 new_x = _A.clip(
-                    x + (_A.random_uniform(self.n_dim) - 0.5) * 2 * step_size, 0, 1
+                    x + (_A.random_uniform(self.n_dim) - 0.5) * 2 * step_size,
+                    0,
+                    1,
                 )
-
                 new_fx = self.evaluate(new_x)
-
-                # Update best.
-                if new_fx < best_fx:
-                    best_x, best_fx = new_x.copy(), new_fx
 
                 # Metropolis criterion.
                 delta = new_fx - fx
-                if delta < 0 or (
-                    temp > final_temp and _A.random_scalar() < _A.exp(-delta / temp)
-                ):
+                if delta < 0 or _A.random_scalar() < _A.exp(-delta / max(temp, 1e-12)):
                     x, fx = new_x, new_fx
 
-                # Cool down.
-                temp *= 0.99
-                temp = max(temp, final_temp)
+                temp *= cooling
+
+        # --- Stage 2: coordinate-descent polish from best --------------
+        # Equivalent of scipy.dual_annealing's local-search refinement.
+        # Halves the step on each unimproved round; keeps stepping along
+        # each coordinate axis from the running best until the budget is
+        # exhausted or the step shrinks below machine precision.
+        center = self.best_x.copy()
+        center_fx = self.best_value
+        step = 0.05
+        while self.evaluations < self.n_trials and step > 1e-14:
+            improved = False
+            for j in range(self.n_dim):
+                for sign in (-1, 1):
+                    if self.evaluations >= self.n_trials:
+                        break
+                    trial = center.copy()
+                    trial[j] = max(0.0, min(1.0, trial[j] + sign * step))
+                    f_trial = self.evaluate(trial)
+                    if f_trial < center_fx:
+                        center = trial
+                        center_fx = f_trial
+                        improved = True
+                        break
+                if improved:
+                    break
+            if not improved:
+                step *= 0.5
 
         return self.best_value, self.best_x
 


### PR DESCRIPTION
Per user's 'keep improving the algorithms' direction. HumpDay's SA was 7e11× off scipy on sphere and 1e9× off on Rosenbrock — among the largest remaining unaligned gaps.

## Root cause
scipy.optimize.dual_annealing is a **two-stage** algorithm: global Tsallis annealing + local search (L-BFGS-B) for polish. That polish is why it reaches 1e-17 on sphere; pure Metropolis SA can't reach machine precision because its proposals are inherently noisy. HumpDay's SA was single-stage.

## Changes
- Reserve ~33% of budget for stage 2.
- Stage 1: cleaned up some fragile heuristics (best-fx-dependent initial temp + bizarre step-size formula). Fixed initial temp 1.0, geometric cooling reaches final_temp over the restart's iteration count, step ∝ temperature.
- Stage 2: **coordinate descent with shrinking step** from the SA's best. Halve step each unimproved round; keep stepping each coord axis from the running best until budget exhausted or step < 1e-14.

## Before / after

| Problem | Before | After | Improvement |
|---|---|---|---|
| sphere | 7.4×10¹¹ | **1.6×10⁶** | 445,000× tighter |
| rosenbrock | 1.2×10⁹ | 3.7×10⁸ | 3.2× tighter |
| ackley | 0.96× | **0.001×** | HumpDay now far better than scipy |

The ackley result flips — HumpDay's multi-restart SA + polish escapes multimodal local minima dramatically better than scipy's single-trajectory Tsallis with default settings.

## Tests
- 340 core tests pass.
- Ruff clean.