### PR TITLE
mini-golf: budget dropdown 10/20/50/100/200/500

### DIFF
--- a/docs/applications/mini-golf.html
+++ b/docs/applications/mini-golf.html
@@ -154,8 +154,10 @@
       <select id="budget">
         <option value="10">10 strokes</option>
         <option value="20" selected>20 strokes</option>
-        <option value="40">40 strokes</option>
-        <option value="80">80 strokes</option>
+        <option value="50">50 strokes</option>
+        <option value="100">100 strokes</option>
+        <option value="200">200 strokes</option>
+        <option value="500">500 strokes</option>
       </select>
       <p style="margin: 8px 0 0; font-size: 0.78em; color: var(--muted);">
         Each stroke is animated at 2× the final-replay speed.


### PR DESCRIPTION
Per user request — extends the choices upward so longer searches are available (default stays at 20). Previously 10/20/40/80.