### PR TITLE
applications landing: add mini-golf card to the grid

### DIFF
--- a/docs/applications/index.html
+++ b/docs/applications/index.html
@@ -217,6 +217,23 @@
         <span class="play">Open →</span>
       </div>
     </a>
+
+    <a class="card live" href="mini-golf.html" style="text-decoration:none;">
+      <div class="emoji">⛳</div>
+      <span class="tag">Live</span>
+      <h3>Mini-Golf</h3>
+      <p class="desc">
+        Sink a single putt over a wall, around a balloon, onto a
+        sloped elevated green. 3-D parameter space (angle, force,
+        backspin) with a deliberately bimodal landscape: a false
+        front green traps local methods; population methods find the
+        chip-and-grip line to the back green.
+      </p>
+      <div class="meta">
+        <span>n=3 · score 0–100</span>
+        <span class="play">Open →</span>
+      </div>
+    </a>
   </div>
 
   <h2>Coming soon</h2>


### PR DESCRIPTION
User-spotted on https://humpday.microprediction.org/applications/index.html — mini-golf wasn't appearing. The page itself landed in PR #95/#101 but no card was added to the landing-page grid. Adding alongside slingshot with the same Live tag.