### PR TITLE
applications landing: drop the calibration bullet list

### DIFF
--- a/docs/applications/index.html
+++ b/docs/applications/index.html
@@ -282,18 +282,6 @@
     faces — sparse rewards, hard physical constraints, regime change,
     expensive evaluation.
   </p>
-  <p>
-    Each application here is calibrated against one of those failure
-    modes:
-  </p>
-  <ul style="color: var(--muted); line-height: 1.6;">
-    <li><strong>Bowling, Slingshot</strong> — vast flat-zero region with a sharp scoring peak. Tests how fast an algorithm finds first contact.</li>
-    <li><strong>CartPole</strong> — stochastic objective with plateau / cliff topology. Punishes algorithms that over-trust a single low evaluation.</li>
-    <li><strong>Welded Beam</strong> — narrow feasible region carved out by seven nonlinear constraints. Tests constraint-cliff descent.</li>
-    <li><strong>Algo Trading</strong> — non-stationary objective; in-sample optimum ≠ out-of-sample optimum. Exposes regime-overfitting.</li>
-    <li><strong>Airfoil</strong> — severely limited budget; can't afford to fill a population. Bayesian / surrogate methods should dominate.</li>
-  </ul>
-
   <div class="skill-callout">
     <h3>🌱 Save the Planet</h3>
     <p>Cut and paste this into Claude or Cursor:</p>


### PR DESCRIPTION
Per user — was too explanatory and didn't tell the visitor anything they couldn't see from the cards above. The intro 'Why this pattern' paragraph still frames the context; the bullet recap is redundant.