### PR TITLE
slingshot: narrower back tower so blocks fall off more easily

### DIFF
--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -323,8 +323,8 @@ const GROUP_B_LEFT = GAP_RIGHT;
 const GROUP_B_RIGHT = W - 30;
 const GROUP_B_PEDESTAL_H = 60;        // raised by this many px above ground
 const GROUP_B_TABLE_TOP = H - 80 - GROUP_B_PEDESTAL_H;
-const GROUP_B_COLS = 3;
-const GROUP_B_ROWS = 4;               // 12 blocks — same shape as Group A
+const GROUP_B_COLS = 2;               // narrower so blocks fall off more easily
+const GROUP_B_ROWS = 5;               // slimmer const GROUP_B_ROWS = 4;               // 12 blocks — same shape as Group A taller — 10 blocks total
 
 const TOTAL_BLOCKS = GROUP_A_COLS * GROUP_A_ROWS + GROUP_B_COLS * GROUP_B_ROWS;
 document.getElementById('block-count').textContent = TOTAL_BLOCKS;


### PR DESCRIPTION
User-spotted: 'make the second tower more narrow so that they fall more easily off it'. Group B was 3×4 = 12 blocks spread across most of the pedestal width — blocks in the centre had nowhere to fall.

Now 2 cols × 5 rows = 10 blocks. With a 2-block-wide stack on the same-width pedestal, every block has empty pedestal on at least one side, so a solid hit spills blocks off rather than crowding them in place.