### PR TITLE
slingshot: extend spin (±0.6→±1.2) and force (100→130)

### DIFF
--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -124,7 +124,7 @@
           <input type="range" id="manual-angle" min="5" max="75" step="0.5" value="40">
 
           <label for="manual-force">Force <output id="manual-force-out">60</output></label>
-          <input type="range" id="manual-force" min="25" max="100" step="0.5" value="60">
+          <input type="range" id="manual-force" min="25" max="130" step="0.5" value="60">
 
           <label for="manual-spin">Spin <output id="manual-spin-out">0.00</output></label>
           <input type="range" id="manual-spin" min="-1.0" max="1.0" step="0.02" value="0">
@@ -336,7 +336,7 @@ document.getElementById('block-count').textContent = TOTAL_BLOCKS;
 
 // Parameter ranges — the optimiser sees [0, 1]^3 which we decode into:
 //   angle  : 5° to 75°  (above horizontal, aimed right)
-//   force  : 25 to 100  (impulse magnitude in Matter.js units —
+//   force  : 25 to 130  (impulse magnitude in Matter.js units —
 //            extended upward so a glancing blow off the front tower
 //            can ricochet onto the back pedestal)
 //   spin   : -1.0 to +1.0 rad/step (extended — more spin lets a glancing
@@ -344,7 +344,7 @@ document.getElementById('block-count').textContent = TOTAL_BLOCKS;
 function decode(u) {
   return [
     5 + 70 * u[0],
-    25 + 75 * u[1],
+    25 + 105 * u[1],
     -1.0 + 2.0 * u[2],
   ];
 }

--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -127,7 +127,7 @@
           <input type="range" id="manual-force" min="25" max="100" step="0.5" value="60">
 
           <label for="manual-spin">Spin <output id="manual-spin-out">0.00</output></label>
-          <input type="range" id="manual-spin" min="-0.6" max="0.6" step="0.02" value="0">
+          <input type="range" id="manual-spin" min="-1.0" max="1.0" step="0.02" value="0">
         </div>
         <button id="manual-btn" onclick="manualThrow()">▶ Throw (Human Raphson)</button>
       </div>
@@ -339,12 +339,13 @@ document.getElementById('block-count').textContent = TOTAL_BLOCKS;
 //   force  : 25 to 100  (impulse magnitude in Matter.js units —
 //            extended upward so a glancing blow off the front tower
 //            can ricochet onto the back pedestal)
-//   spin   : -0.6 to +0.6 rad/step
+//   spin   : -1.0 to +1.0 rad/step (extended — more spin lets a glancing
+//            blow ricochet harder onto the back tower)
 function decode(u) {
   return [
     5 + 70 * u[0],
     25 + 75 * u[1],
-    -0.6 + 1.2 * u[2],
+    -1.0 + 2.0 * u[2],
   ];
 }
 

--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -127,7 +127,7 @@
           <input type="range" id="manual-force" min="25" max="130" step="0.5" value="60">
 
           <label for="manual-spin">Spin <output id="manual-spin-out">0.00</output></label>
-          <input type="range" id="manual-spin" min="-1.0" max="1.0" step="0.02" value="0">
+          <input type="range" id="manual-spin" min="-1.2" max="1.2" step="0.02" value="0">
         </div>
         <button id="manual-btn" onclick="manualThrow()">▶ Throw (Human Raphson)</button>
       </div>
@@ -339,13 +339,13 @@ document.getElementById('block-count').textContent = TOTAL_BLOCKS;
 //   force  : 25 to 130  (impulse magnitude in Matter.js units —
 //            extended upward so a glancing blow off the front tower
 //            can ricochet onto the back pedestal)
-//   spin   : -1.0 to +1.0 rad/step (extended — more spin lets a glancing
+//   spin   : -1.2 to +1.2 rad/step (extended — more spin lets a glancing
 //            blow ricochet harder onto the back tower)
 function decode(u) {
   return [
     5 + 70 * u[0],
     25 + 105 * u[1],
-    -1.0 + 2.0 * u[2],
+    -1.2 + 2.4 * u[2],
   ];
 }
 


### PR DESCRIPTION
User: 'Let's allow a little more spin in the slingshot game' + 'allow a bit more power too' + 'Put spin range back up to -1.2 to 1.2'.

- Spin envelope: ±0.6 → ±1.2 rad/step
- Force envelope: 25-100 → 25-130

Both the optimiser's decode and the Human Raphson sliders are updated.