### PR TITLE
Drop Bayesian Optimization from high-D demos (>5-D)

### DIFF
--- a/docs/applications/brachistochrone.html
+++ b/docs/applications/brachistochrone.html
@@ -154,7 +154,7 @@
         </optgroup>
         <optgroup label="Other">
           <option value="SimulatedAnnealing">Simulated Annealing</option>
-          <option value="BayesianOpt">Bayesian Optimization</option>
+          <!-- BayesianOpt omitted: scales poorly past ~5-D; this is 8-D. -->
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
           <option value="TabuSearch">Tabu Search</option>

--- a/docs/applications/wind-farm.html
+++ b/docs/applications/wind-farm.html
@@ -162,7 +162,7 @@
         </optgroup>
         <optgroup label="Other">
           <option value="SimulatedAnnealing">Simulated Annealing</option>
-          <option value="BayesianOpt">Bayesian Optimization</option>
+          <!-- BayesianOpt omitted: scales poorly past ~5-D; this is 16-D. -->
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
           <option value="TabuSearch">Tabu Search</option>


### PR DESCRIPTION
BO's GP surrogate doesn't scale meaningfully past ~5-D — on these
problems it just adds latency without producing better solutions
than DE / CMA-ES / PSO. Removed the option from:

| demo               | dim | branch / status                     |
|--------------------|-----|-------------------------------------|
| `brachistochrone`  | 8   | this PR                             |
| `wind-farm`        | 16  | this PR                             |
| `rocket-landing`   | 12  | already done in #131 (still open)   |

The 4-D and 5-D demos (free-kick, welded-beam, cart-pole, bowling)
keep BO — it's defensible there.

Two-line diff per file: replaces the `<option value="BayesianOpt">`
line with an HTML comment documenting why it's gone, so future me
won't add it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)