### PR TITLE
Restore homepage 'Browse Applications' bookend (lost during PR #130 squash)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -178,9 +178,8 @@
         <div style="text-align: center; margin: 8px 0; padding: 4px;">
             <a href="contest.html" class="btn" style="margin: 0 10px; padding: 6px 12px;">Run Algorithm Contest</a>
             <a href="https://github.com/microprediction/humpday/tree/main/humpday" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;" target="_blank" rel="noopener">Python Source</a>
-            <a href="https://github.com/microprediction/humpday/tree/main/docs/js/modules" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;" target="_blank" rel="noopener">JavaScript Source</a>
-            <a href="test-modular.html" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;">Test All Algorithms</a>
             <a href="applications/index.html" class="btn" style="margin: 0 10px; padding: 6px 12px;">Browse Applications</a>
+            <a href="https://github.com/microprediction/humpday/tree/main/docs/js/modules" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;" target="_blank" rel="noopener">JavaScript Source</a>
         </div>
 
         <section class="section">

--- a/docs/index.html
+++ b/docs/index.html
@@ -180,6 +180,7 @@
             <a href="https://github.com/microprediction/humpday/tree/main/humpday" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;" target="_blank" rel="noopener">Python Source</a>
             <a href="https://github.com/microprediction/humpday/tree/main/docs/js/modules" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;" target="_blank" rel="noopener">JavaScript Source</a>
             <a href="test-modular.html" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;">Test All Algorithms</a>
+            <a href="applications/index.html" class="btn" style="margin: 0 10px; padding: 6px 12px;">Browse Applications</a>
         </div>
 
         <section class="section">


### PR DESCRIPTION
Cherry-picks the two homepage commits that lived on \`add-wind-farm-demo\`
(PR #130's branch) but didn't make it into the squash-merge into \`main\`:

| commit  | message                                                                       |
|---------|-------------------------------------------------------------------------------|
| 4b2c0d6 | homepage: add 'Browse Applications' bookend button                            |
| 1c20fe8 | homepage: drop 'Test All Algorithms', alternate blue/gray across four buttons |

PR #130 was squashed before these two commits were included, so the
homepage on main still shows the old three-button row (Run Algorithm
Contest · Python Source · JavaScript Source · Test All Algorithms).

After this PR the homepage will show the intended four-button row
with the Applications page bookended against the Contest button:

  Run Algorithm Contest (blue) ·
  Python Source (gray) ·
  Browse Applications (blue) ·
  JavaScript Source (gray)

Co-authored by Peter — these are his original commits, applied
verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)