### PR TITLE
PRIMA_BOBYQA: guard initial-set evals against budget overshoot

### DIFF
--- a/humpday/optimizers/prima_algorithms.py
+++ b/humpday/optimizers/prima_algorithms.py
@@ -685,11 +685,16 @@ class PRIMA_BOBYQA(BaseOptimizer):
         FVAL = []
 
         XPT.append(_A.zeros(n))
+        if self.evaluations >= self.n_trials:
+            return XPT, FVAL
         FVAL.append(self.evaluate(xbase))
 
         # Coordinate directions, clipped to bound-feasible step sizes.
+        # Each evaluate() is budget-guarded so a restart triggered close
+        # to n_trials can't overshoot via the init-set (caught by the
+        # test_numpy_backend BOBYQA test — 206 vs 200 evals).
         for i in range(n):
-            if len(FVAL) >= npt:
+            if len(FVAL) >= npt or self.evaluations >= self.n_trials:
                 return XPT, FVAL
             step_pos = min(rho, float(xu[i]) - float(xbase[i]))
             if step_pos > 1e-10:
@@ -698,7 +703,7 @@ class PRIMA_BOBYQA(BaseOptimizer):
                 XPT.append(offset)
                 FVAL.append(self.evaluate(_A.clip(xbase + offset, 0, 1)))
 
-            if len(FVAL) >= npt:
+            if len(FVAL) >= npt or self.evaluations >= self.n_trials:
                 return XPT, FVAL
             step_neg = max(-rho, float(xl[i]) - float(xbase[i]))
             if step_neg < -1e-10:
@@ -708,7 +713,7 @@ class PRIMA_BOBYQA(BaseOptimizer):
                 FVAL.append(self.evaluate(_A.clip(xbase + offset, 0, 1)))
 
         # Optional diagonal-direction point, clipped to bounds.
-        if len(FVAL) < npt:
+        if len(FVAL) < npt and self.evaluations < self.n_trials:
             diagonal_step = [rho / math.sqrt(n)] * n
             for i in range(n):
                 xi_target = float(xbase[i]) + diagonal_step[i]


### PR DESCRIPTION
## Summary
Fixes CI failure on `test_numpy_backend[prima_algorithms-PRIMA_BOBYQA]`:
\`\`\`
AssertionError: PRIMA_BOBYQA did 206 evals, budget was 200
\`\`\`

`_initialize_bobyqa_points` calls `self.evaluate()` up to `npt = 2n+1` times without checking `self.evaluations` against `self.n_trials`. The main `optimize()` loop guards each TR-step evaluate, but a restart pass triggered close to the budget rebuilds the initial set on top — BOBYQA could finish with up to (npt - 1) extra evals.

The fix adds `self.evaluations < self.n_trials` guards before each evaluate in the init-set builder and at the diagonal-point block.

PRIMA_UOBYQA and PRIMA_NEWUOA already pass the same test — only BOBYQA's init path was unguarded.

## Verification
- `pytest tests/test_ported_algorithms.py::test_numpy_backend -x` → **22/22 pass** locally.
- Only `humpday/optimizers/prima_algorithms.py` changed, +8/-3 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)