### PR TITLE
Follow-ups to #143: README thumbnail + correct figcaption link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -207,7 +207,7 @@
             </video>
             <figcaption style="margin-top: 12px; color: var(--text-secondary); font-size: 0.95em;">
                 Differential Evolution finds a single break that clears all 9 balls on the
-                <a href="applications/index.html"><strong>Pool Break Optimizer</strong></a>
+                <a href="applications/pool.html"><strong>Pool Break Optimizer</strong></a>
                 — one of 13+ interactive applications in the gallery.
                 <a href="applications/index.html">Browse them all →</a>
             </figcaption>

--- a/docs/index.html
+++ b/docs/index.html
@@ -206,10 +206,10 @@
                 <a href="assets/video/the-perfect-break.mp4">Download the perfect break (MP4)</a>
             </video>
             <figcaption style="margin-top: 12px; color: var(--text-secondary); font-size: 0.95em;">
-                Differential Evolution finds a single break that clears all 9 balls on the
-                <a href="applications/pool.html"><strong>Pool Break Optimizer</strong></a>
-                — one of 13+ interactive applications in the gallery.
-                <a href="applications/index.html">Browse them all →</a>
+                Differential Evolution clears the rack in one break.
+                <a href="applications/pool.html"><strong>Try it</strong></a>
+                ·
+                <a href="applications/index.html">13+ more demos →</a>
             </figcaption>
         </figure>
 


### PR DESCRIPTION
Two small follow-ups to the perfect-break video showcase that
landed in #143.

## 1. README thumbnail

GitHub's README markdown doesn't auto-embed raw \`.mp4\` URLs —
on the repo page, #143's video URL renders as a bare blue link
rather than the inline player the docs site gets. Replace it
with a still frame from the same video used as a clickable
thumbnail that links to the applications gallery.

- New asset: \`docs/assets/images/the-perfect-break.png\`
  (~123 KB, 1400 × 600). Frame from ~14.2 s of the source video,
  captured via Playwright. Shows the cue ball alone on the
  cleared felt next to the side panel reading \"5000 breaks ·
  Fast mode · DifferentialEvolution\" — outcome + context in
  one image.
- README's \"See it work\" section now opens with the thumbnail
  linked to the apps page, then a one-line description, an
  inline \"Watch the 14-second video\" link for anyone who
  wants the recording, and the Browse-all-applications CTA.

The docs site itself (\`docs/index.html\`) still uses the
\`<video>\` element — only the README rendering needed the
image fallback.

## 2. Figcaption link points at the actual demo

The figcaption under the docs/index video said \"Differential
Evolution finds a single break that clears all 9 balls on the
**Pool Break Optimizer**\" but the link href pointed at the
gallery (\`applications/index.html\`) rather than the demo
itself (\`applications/pool.html\`). Click-through expected
the pool table and got the card grid. Fixed to point at
\`applications/pool.html\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)