### PR TITLE
Cap minimize() method-dispatch test at maxiter=20 (~100x speedup)

### DIFF
--- a/tests/test_scipy_interface_missing_coverage.py
+++ b/tests/test_scipy_interface_missing_coverage.py
@@ -101,9 +101,20 @@ class TestSciPyInterfaceMissingCoverage:
             "RandomSearch",
         ]
 
+        # This test only exercises the method-dispatch code path
+        # (asserts the result has an `x` attribute). It does NOT need
+        # the default 100-trial budget — at 100 trials, BayesianOpt
+        # alone fits a 2-D GP nine times and adds ~10 s to the test
+        # for no extra coverage. Cap at 20 trials so all nine methods
+        # complete in well under a second.
         for method in methods:
             try:
-                result = minimize(objective, bounds=[(0, 1), (0, 1)], method=method)
+                result = minimize(
+                    objective,
+                    bounds=[(0, 1), (0, 1)],
+                    method=method,
+                    options={"maxiter": 20},
+                )
                 assert hasattr(result, "x")
             except Exception:
                 # Some methods might have specific requirements


### PR DESCRIPTION
## Summary
`test_minimize_with_specific_methods` (`tests/test_scipy_interface_missing_coverage.py:84`) loops through 9 optimizers calling `minimize()` on a 2-D objective, then only asserts `hasattr(result, "x")` — it exercises the method-dispatch code path, not solver quality. But at the default budget of 100 trials, BayesianOpt fits a 2-D GP nine times and adds ~10 s of wall time on CI for no extra coverage.

This PR passes `options={"maxiter": 20}` to each `minimize()` call. All nine methods finish in well under a second.

## Measurement
**Local timing on this test:**
- Before: ~10 s (dominated by BayesianOpt GP fitting at 100 trials)
- After: **0.10 s** (1 passed in 0.10s wall)

≈ **100× speedup** for the same coverage. The test still touches every dispatch branch.

## Why this specific test
A grep across the test suite turned up several BayesianOpt references; almost all already cap their budget:

| File | n_trials | Status |
|---|---|---|
| `test_scipy_interface_missing_coverage.py:98` | 100 (default) | **fixed here** |
| `test_ported_algorithms.py:131` | 50 (`N_TRIALS_PURE`) | already small |
| `test_reference_alignment.py:73` | 50 (per-method override) | already small |
| `test_missing_lines_coverage.py:104` | 15 | already small |
| `tests/performance/*` | varies | intentionally slow |

So this was the single remaining hot spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)