### PR TITLE
Trebuchet: slow the replay so the launch is actually visible

### DIFF
--- a/docs/applications/trebuchet.html
+++ b/docs/applications/trebuchet.html
@@ -704,8 +704,14 @@ function drawIdleScene() {
 // ============================================================================
 // Animations.
 // ============================================================================
-const REPLAY_MS_PER_FRAME = 16;
-const MONTAGE_MS_PER_FRAME = 8;
+// Replay playback rate. Was 16 ms/frame (62 fps real-time-ish) — too
+// fast for the eye to track the arm swing, sling whip, and projectile
+// release in the half-second the launch actually takes. Slowed to
+// 36 ms/frame (~28 fps) so you can SEE what's happening, then a brief
+// hold on the final frame so you can read the landing.
+const REPLAY_MS_PER_FRAME = 36;
+const MONTAGE_MS_PER_FRAME = 12;       // was 8
+const FINAL_FRAME_HOLD_MS = 700;       // linger on the last frame
 let animationToken = 0;
 
 function animateShot(frames, params, hudText, msPerFrame = REPLAY_MS_PER_FRAME) {
@@ -715,7 +721,16 @@ function animateShot(frames, params, hudText, msPerFrame = REPLAY_MS_PER_FRAME) 
     let i = 0;
     function tick() {
       if (myToken !== animationToken) return resolve();
-      if (i >= frames.length) return resolve();
+      if (i >= frames.length) {
+        // Hold the final frame so the landing is readable, but only
+        // when this is the slow replay (not the fast montage step).
+        if (msPerFrame >= REPLAY_MS_PER_FRAME) {
+          setTimeout(resolve, FINAL_FRAME_HOLD_MS);
+        } else {
+          resolve();
+        }
+        return;
+      }
       drawScene(frames[i], params, hudText);
       i += 1;
       setTimeout(tick, msPerFrame);


### PR DESCRIPTION
User noted the rock flies off screen before they can see what's
happening. The previous \`REPLAY_MS_PER_FRAME\` of 16 (~62 fps) was
so fast that the half-second-long launch — arm swing, sling
whip, release — played back faster than the eye can track.

Slowed the replay rate and added a brief hold on the final
frame so the landing is readable:

| | before | after |
|---|------:|------:|
| \`REPLAY_MS_PER_FRAME\` | 16 ms (~62 fps) | **36 ms (~28 fps, 2.25× slower)** |
| \`MONTAGE_MS_PER_FRAME\` | 8 ms | **12 ms** |
| \`FINAL_FRAME_HOLD_MS\` | — | **700 ms** (new) |

The 700 ms hold only fires when \`msPerFrame ≥ REPLAY_MS_PER_FRAME\`,
so the fast montage step doesn't pause between shots and the slow
single-shot replay does. Physics (\`SIM_DELTA\`, \`N_SIM_STEPS\`,
release threshold) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)