### PR TITLE
JS optimizers: budget compliance + dead-code cleanup (#157, #158, #159, #156)

### DIFF
--- a/docs/js/modules/evolutionary-algorithms.js
+++ b/docs/js/modules/evolutionary-algorithms.js
@@ -176,9 +176,6 @@ class ParticleSwarm extends Optimizer {
                     particle.stagnationCount = 0;
                 }
             }
-
-            // Early termination for excellent solutions
-            if (this.bestValue < 1e-6) break; // Relaxed termination for visualization
         }
 
         return {
@@ -284,9 +281,6 @@ class SimulatedAnnealing extends Optimizer {
                 // Fast exponential cooling with floor
                 temperature *= 0.99;
                 temperature = Math.max(temperature, finalTemp);
-
-                // Early termination if we find a very good solution
-                if (bestFx < 1e-6) break;
             }
 
             // Update global best

--- a/docs/js/modules/prima-algorithms.js
+++ b/docs/js/modules/prima-algorithms.js
@@ -128,13 +128,6 @@ class PRIMA_UOBYQA extends Optimizer {
 
             // Update trust region radius
             rho = Math.max(rho_new, rhoend);
-
-            // Early termination if we found excellent solution
-            if (fopt < 1e-6) { // Relaxed convergence for visualization
-                // Do PDFO-like systematic refinement around best point
-                this.doSystematicRefinement(XPT, FVAL, kopt, xbase);
-                break;
-            }
         }
 
         return {
@@ -803,49 +796,6 @@ class PRIMA_NEWUOA extends Optimizer {
         };
     }
 
-    buildNEWUOAInterpolationSet(XPT, FVAL, xbase, rho) {
-        const n = this.nDim;
-        const npt = this.npt;
-
-        let kptNum = 1; // Start from 1 since XPT[0] is already set
-
-        // Add coordinate directions (both positive and negative if budget allows)
-        for (let i = 0; i < n && kptNum < npt && this.evaluations < this.nTrials; i++) {
-            // Positive direction
-            const step1 = Math.min(rho, 1 - xbase[i]);
-            XPT[kptNum] = Array(n).fill(0);
-            XPT[kptNum][i] = step1;
-
-            const xnew1 = MathUtils.add(xbase, XPT[kptNum]);
-            FVAL[kptNum] = this.evaluate(xnew1);
-            kptNum++;
-
-            if (kptNum >= npt || this.evaluations >= this.nTrials) break;
-
-            // Negative direction
-            const step2 = -Math.min(rho, xbase[i]);
-            XPT[kptNum] = Array(n).fill(0);
-            XPT[kptNum][i] = step2;
-
-            const xnew2 = MathUtils.add(xbase, XPT[kptNum]);
-            FVAL[kptNum] = this.evaluate(xnew2);
-            kptNum++;
-        }
-
-        // Add additional points to reach 2n+1 if needed
-        while (kptNum < npt && this.evaluations < this.nTrials) {
-            XPT[kptNum] = Array(n).fill(0);
-            // Add random perturbation
-            for (let i = 0; i < n; i++) {
-                const pert = (Math.random() - 0.5) * 2 * rho * 0.7;
-                XPT[kptNum][i] = Math.max(-xbase[i], Math.min(1 - xbase[i], pert));
-            }
-            const xnew = MathUtils.add(xbase, XPT[kptNum]);
-            FVAL[kptNum] = this.evaluate(xnew);
-            kptNum++;
-        }
-    }
-
     buildNEWUOAQuadraticModel(XPT, FVAL, xopt) {
         const n = this.nDim;
         const npt = XPT.length;
@@ -1118,20 +1068,6 @@ class PRIMA_NEWUOA extends Optimizer {
         }
     }
 
-    buildNEWUOALagrangeModel(XPT, FVAL, kopt) {
-        // NEWUOA uses same Lagrange interpolation as UOBYQA
-        return this.buildLagrangeQuadraticModel(XPT, FVAL, kopt);
-    }
-
-    updateNEWUOALagrangeSet(XPT, FVAL, xbase, snew, fnew) {
-        // NEWUOA uses same geometry management as UOBYQA
-        this.updateLagrangeInterpolationSet(XPT, FVAL, xbase, snew, fnew);
-    }
-
-    doNEWUOASystematicRefinement(XPT, FVAL, kopt, xbase) {
-        // NEWUOA uses same systematic refinement as UOBYQA
-        this.doSystematicRefinement(XPT, FVAL, kopt, xbase);
-    }
 }
 
 // PRIMA BOBYQA - Bound-constrained Optimization BY Quadratic Approximation.
@@ -1263,14 +1199,17 @@ class PRIMA_BOBYQA extends Optimizer {
 
     _initBOBYQAPoints(xbase, rho, npt, n, xl, xu) {
         // Initial interpolation set, 2n+1 coordinate-axis points respecting bounds.
+        // Each evaluate() is budget-guarded so a restart triggered close to
+        // nTrials can't overshoot via the init-set (mirrors Python fix #141).
         const XPT = [];
         const FVAL = [];
 
         XPT.push(new Array(n).fill(0));
+        if (this.evaluations >= this.nTrials) return { XPT, FVAL };
         FVAL.push(this.evaluate(xbase));
 
         for (let i = 0; i < n; i++) {
-            if (FVAL.length >= npt) return { XPT, FVAL };
+            if (FVAL.length >= npt || this.evaluations >= this.nTrials) return { XPT, FVAL };
             const step_pos = Math.min(rho, xu[i] - xbase[i]);
             if (step_pos > 1e-10) {
                 const offset = new Array(n).fill(0);
@@ -1279,7 +1218,7 @@ class PRIMA_BOBYQA extends Optimizer {
                 FVAL.push(this.evaluate(this._clip01(this._addVec(xbase, offset))));
             }
 
-            if (FVAL.length >= npt) return { XPT, FVAL };
+            if (FVAL.length >= npt || this.evaluations >= this.nTrials) return { XPT, FVAL };
             const step_neg = Math.max(-rho, xl[i] - xbase[i]);
             if (step_neg < -1e-10) {
                 const offset = new Array(n).fill(0);
@@ -1290,7 +1229,7 @@ class PRIMA_BOBYQA extends Optimizer {
         }
 
         // Optional diagonal-direction point.
-        if (FVAL.length < npt) {
+        if (FVAL.length < npt && this.evaluations < this.nTrials) {
             const diag = new Array(n).fill(rho / Math.sqrt(n));
             for (let i = 0; i < n; i++) {
                 const xi = xbase[i] + diag[i];

--- a/docs/js/modules/scipy-algorithms.js
+++ b/docs/js/modules/scipy-algorithms.js
@@ -197,7 +197,7 @@ class Powell extends Optimizer {
 
     lineSearch(x0, direction) {
         let x = [...x0];
-        let fx = this.objective(x);
+        let fx = this.evaluate(x);
 
         const stepSize = 0.1;
         let bestStep = 0;


### PR DESCRIPTION
## Summary

Four issues from the multi-agent JS-vs-Python audit (#154–#164), all in `docs/js/modules/`.

- **#157** — `Powell.lineSearch` was calling `this.objective(x)` directly instead of `this.evaluate(x)`, bypassing the budget counter and skipping `bestValue` / `bestX` tracking. One-line fix.
- **#158** — Removed three magic `if (best < 1e-6) break` early-exits from `PRIMA_UOBYQA`, `ParticleSwarm`, `SimulatedAnnealing`. The Python ports do not have these. On objectives where 0 isn't the true minimum (anything non-sphere) the JS port quit early and silently lost budget.
- **#159** — Deleted a duplicate `buildNEWUOAInterpolationSet` (only the second definition runs per JS class-body resolution; the first was dead) and three orphan stub methods (`buildNEWUOALagrangeModel`, `updateNEWUOALagrangeSet`, `doNEWUOASystematicRefinement`) that called methods only defined on `PRIMA_UOBYQA`. No callers anywhere.
- **#156** — `PRIMA_BOBYQA._initBOBYQAPoints` was calling `evaluate()` up to `2n+1` times without checking the budget. A restart triggered near `n_trials` could overshoot by up to `npt-1` evals. Mirrors the Python fix from #141.

`docs/js/optimizers.js` (the unloaded legacy monolith) contains the same dead patterns but is out of scope for this PR.

## Verification

- `test_python_js_parity_sphere`: all 22 algorithms pass.
- `test_python_js_winrate_rosenbrock` (slow, ran 4×):
  - `PRIMA_UOBYQA` median 2.9 → ~1.1 (still xfailed but big jump)
  - `PRIMA_NEWUOA` now stably balanced (8/12 to 12/8 across runs — divergence resolved, may be removable from `KNOWN_DIVERGENT_PORTS` in a follow-up)
  - `PRIMA_BOBYQA` JS now slightly ahead of Python (0.168 vs 0.197)
  - `Powell` now correctly budget-constrained (the prior 1.84 median was inflated by the bug giving Powell free objective calls)
  - `ParticleSwarm` / `SimulatedAnnealing` well-balanced, no regression

The one pre-existing test failure (`test_prima_vs_real_prima`) is an environmental NumPy 1.x/2.x `pdfo` issue that also fails on `main`.

## Test plan

- [ ] CI passes
- [ ] `pytest tests/test_js_parity.py::test_python_js_parity_sphere -q` locally — all 22 green
- [ ] Spot-check the algorithm-visualization demos in the browser still run

Closes #157, #158, #159, #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)