### PR TITLE
docs: sharpen index tagline to emphasise zero-deps + tiny-pure-port

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -181,16 +181,16 @@
     <div class="header">
         <div class="container">
             <h1>HumpDay</h1>
-            <p class="subtitle">A collection of derivative-free optimization algorithms in Python and JavaScript</p>
+            <p class="subtitle">Derivative-free optimization algorithms in Python and JavaScript with no dependencies</p>
         </div>
     </div>
 
     <div class="container">
         <div style="background: var(--section-bg); padding: 24px; border-left: 4px solid var(--accent); margin: 24px 0;">
-            HumpDay provides a unified interface to 22 derivative-free optimization algorithms
-            implemented in pure Python (and also JavaScript). All algorithms operate on the unit
-            hypercube [0,1]ⁿ with automatic domain transformations for bounded and unbounded problems.
-            Each algorithm is cross-validated against an established reference implementation.
+            HumpDay provides a tiny pure implementation of 22 derivative-free optimization algorithms
+            in Python (and also JavaScript), with no external dependencies. All algorithms operate on
+            the unit hypercube [0,1]ⁿ with automatic domain transformations for bounded and unbounded
+            problems. Each algorithm is cross-validated against an established reference implementation.
         </div>
 
         <figure style="margin: 32px 0; text-align: center;">


### PR DESCRIPTION
Two small wording updates to docs/index.html that match the library's stated principle (tiny pure-Python/JS ports of SOTA reference algorithms, no runtime dependencies):

  subtitle:
    "A collection of derivative-free optimization algorithms in
     Python and JavaScript"
    → "Derivative-free optimization algorithms in Python and
       JavaScript with no dependencies"

  intro paragraph:
    "HumpDay provides a unified interface to 22 …"
    → "HumpDay provides a tiny pure implementation of 22 …
       with no external dependencies."

README tagline (line 9) already says "in pure Python. No compilation, no required dependencies." so it's left alone.