### PR TITLE
tests: add LBFGSB scipy L-BFGS-B reference adapter (first of #163)

### DIFF
--- a/benchmarks/reference_alignment.json
+++ b/benchmarks/reference_alignment.json
@@ -61,6 +61,36 @@
       "ratio_humpday_over_reference": 0.8943944276089192
     },
     {
+      "algorithm": "LBFGSB",
+      "reference": "scipy.optimize L-BFGS-B",
+      "problem": "sphere",
+      "humpday_median": 6.970861327204782e-09,
+      "reference_median": 5.000024586489128e-17,
+      "humpday_to_opt": 6.970861327204782e-09,
+      "reference_to_opt": 5.000024586489128e-17,
+      "ratio_humpday_over_reference": 6638914.947551124
+    },
+    {
+      "algorithm": "LBFGSB",
+      "reference": "scipy.optimize L-BFGS-B",
+      "problem": "rosenbrock",
+      "humpday_median": 0.6135391895992446,
+      "reference_median": 1.4447293952184428e-10,
+      "humpday_to_opt": 0.6135391895992446,
+      "reference_to_opt": 1.4447293952184428e-10,
+      "ratio_humpday_over_reference": 4246711840.4179683
+    },
+    {
+      "algorithm": "LBFGSB",
+      "reference": "scipy.optimize L-BFGS-B",
+      "problem": "ackley",
+      "humpday_median": 2.580224519065084,
+      "reference_median": 3.574451877257808,
+      "humpday_to_opt": 2.580224519065084,
+      "reference_to_opt": 3.574451877257808,
+      "ratio_humpday_over_reference": 0.721851799287487
+    },
+    {
       "algorithm": "DifferentialEvolution",
       "reference": "scipy differential_evolution",
       "problem": "sphere",
@@ -214,5 +244,5 @@
   "n_runs": 4,
   "n_trials": 200,
   "n_dim": 2,
-  "recorded_at": "2026-05-30T18:32:25Z"
+  "recorded_at": "2026-05-30T19:13:47Z"
 }

--- a/tests/test_reference_alignment.py
+++ b/tests/test_reference_alignment.py
@@ -201,6 +201,31 @@ def _ref_scipy_powell(func, n_trials, n_dim, seed):
     return {"best_value": float(r.fun), "evals": counter["n"]}
 
 
+def _ref_scipy_lbfgsb(func, n_trials, n_dim, seed):
+    from scipy.optimize import minimize
+
+    counter = {"n": 0}
+
+    def wrapped(x):
+        counter["n"] += 1
+        return func(list(x))
+
+    bounds = [(0.0, 1.0)] * n_dim
+    # `maxfun` (not `maxiter`) caps function evaluations — L-BFGS-B
+    # uses finite-difference gradient internally so one "iteration"
+    # already eats ~n_dim evals. ftol=1e-12, gtol=1e-12 push the
+    # solver to the same precision floor we use for NelderMead /
+    # Powell (scipy's defaults stop ~1e-7 below the optimum).
+    r = minimize(
+        wrapped,
+        _draw_x0(seed, n_dim),
+        method="L-BFGS-B",
+        bounds=bounds,
+        options={"maxfun": n_trials, "ftol": 1e-12, "gtol": 1e-12},
+    )
+    return {"best_value": float(r.fun), "evals": counter["n"]}
+
+
 def _ref_scipy_de(func, n_trials, n_dim, seed):
     from scipy.optimize import differential_evolution
 
@@ -354,6 +379,7 @@ def _ref_pdfo_uobyqa(func, n_trials, n_dim, seed):
 REFERENCES = {
     "NelderMead": ("scipy.optimize Nelder-Mead", _ref_scipy_neldermead, ["scipy"]),
     "Powell": ("scipy.optimize Powell", _ref_scipy_powell, ["scipy"]),
+    "LBFGSB": ("scipy.optimize L-BFGS-B", _ref_scipy_lbfgsb, ["scipy"]),
     "DifferentialEvolution": ("scipy differential_evolution", _ref_scipy_de, ["scipy"]),
     "SimulatedAnnealing": (
         "scipy dual_annealing",


### PR DESCRIPTION
First adapter from #163's "add reference adapters for unvalidated algorithms" umbrella. Pairs with #80 (humpday's `LBFGSB` is a finite-difference baseline, not actual L-BFGS-B), which the new snapshot data makes concrete.

## What

`tests/test_reference_alignment.py::_ref_scipy_lbfgsb` — straight `scipy.optimize.minimize(method="L-BFGS-B")` with the same `_draw_x0` seeded-x0 distribution every other local-search adapter uses, bounds = `[0,1]^n`, `maxfun=n_trials`, `ftol = gtol = 1e-12` (matching the precision-floor convention NelderMead and Powell use — scipy's defaults stop ~1e-7 above the optimum). Added `"LBFGSB"` to the `REFERENCES` dict.

## Why

`benchmarks/reference_alignment.json` now records:

| problem    | humpday  | scipy L-BFGS-B | ratio    |
|---|---:|---:|---:|
| sphere     | 6.97e-09 | 5.00e-17       | **6.6e+06** |
| rosenbrock | 0.614    | 1.44e-10       | **4.2e+09** |
| ackley     | 2.58     | 3.57           | 0.72 (humpday wins) |

The sphere + Rosenbrock gaps are 6 and 9 orders of magnitude — exactly the "biggest implementation drift" #163 / #80 called out. On Ackley scipy's local-search L-BFGS-B gets stuck at a non-global minimum (the function is multimodal); humpday's FD-gradient + line-search variant wanders enough to find a better basin. Closing the smooth-objective gap is what #80 will need.

This characterisation test always passes (the point is the persisted snapshot). Holding the next two #163 staged PRs (mealpy umbrella; RandomSearch + search-algorithms rows) for separate commits.

## Test plan

- [ ] CI passes
- [ ] Manual: `pytest tests/test_reference_alignment.py -m reference -v` — green, snapshot reflects three new LBFGSB rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)