### PR TITLE
tests: add 5 search-algorithm reference adapters (third of #163)

### DIFF
--- a/benchmarks/reference_alignment.json
+++ b/benchmarks/reference_alignment.json
@@ -479,10 +479,160 @@
       "humpday_to_opt": 4.430747567480555,
       "reference_to_opt": 0.24688628159903603,
       "ratio_humpday_over_reference": 17.946511806097202
+    },
+    {
+      "algorithm": "RandomSearch",
+      "reference": "uniform-sample baseline",
+      "problem": "sphere",
+      "humpday_median": 0.0022221176064838584,
+      "reference_median": 0.0003330352940661955,
+      "humpday_to_opt": 0.0022221176064838584,
+      "reference_to_opt": 0.0003330352940661955,
+      "ratio_humpday_over_reference": 6.672318658323668
+    },
+    {
+      "algorithm": "RandomSearch",
+      "reference": "uniform-sample baseline",
+      "problem": "rosenbrock",
+      "humpday_median": 0.09198666650343496,
+      "reference_median": 0.34435870084553954,
+      "humpday_to_opt": 0.09198666650343496,
+      "reference_to_opt": 0.34435870084553954,
+      "ratio_humpday_over_reference": 0.2671245601681366
+    },
+    {
+      "algorithm": "RandomSearch",
+      "reference": "uniform-sample baseline",
+      "problem": "ackley",
+      "humpday_median": 2.8363751866134312,
+      "reference_median": 1.2094120558250663,
+      "humpday_to_opt": 2.8363751866134312,
+      "reference_to_opt": 1.2094120558250663,
+      "ratio_humpday_over_reference": 2.345251292106925
+    },
+    {
+      "algorithm": "HillClimbing",
+      "reference": "(1+1)-ES sigma-decay schedule",
+      "problem": "sphere",
+      "humpday_median": 0.00033426152176908115,
+      "reference_median": 1.390796516429335e-07,
+      "humpday_to_opt": 0.00033426152176908115,
+      "reference_to_opt": 1.390796516429335e-07,
+      "ratio_humpday_over_reference": 2403.3819140190717
+    },
+    {
+      "algorithm": "HillClimbing",
+      "reference": "(1+1)-ES sigma-decay schedule",
+      "problem": "rosenbrock",
+      "humpday_median": 0.35802570586317956,
+      "reference_median": 0.09177438621129817,
+      "humpday_to_opt": 0.35802570586317956,
+      "reference_to_opt": 0.09177438621129817,
+      "ratio_humpday_over_reference": 3.901150643915729
+    },
+    {
+      "algorithm": "HillClimbing",
+      "reference": "(1+1)-ES sigma-decay schedule",
+      "problem": "ackley",
+      "humpday_median": 1.7761777471135543,
+      "reference_median": 0.005230236757765017,
+      "humpday_to_opt": 1.7761777471135543,
+      "reference_to_opt": 0.005230236757765017,
+      "ratio_humpday_over_reference": 339.59796264982305
+    },
+    {
+      "algorithm": "AdaptiveRandomSearch",
+      "reference": "(1+1)-ES 1/5-success-rule (Rechenberg)",
+      "problem": "sphere",
+      "humpday_median": 2.0164074250563785e-05,
+      "reference_median": 3.456938901965887e-14,
+      "humpday_to_opt": 2.0164074250563785e-05,
+      "reference_to_opt": 3.456938901965887e-14,
+      "ratio_humpday_over_reference": 566894029.0320784
+    },
+    {
+      "algorithm": "AdaptiveRandomSearch",
+      "reference": "(1+1)-ES 1/5-success-rule (Rechenberg)",
+      "problem": "rosenbrock",
+      "humpday_median": 0.2001628417931641,
+      "reference_median": 0.0858730002482039,
+      "humpday_to_opt": 0.2001628417931641,
+      "reference_to_opt": 0.0858730002482039,
+      "ratio_humpday_over_reference": 2.3309170660698944
+    },
+    {
+      "algorithm": "AdaptiveRandomSearch",
+      "reference": "(1+1)-ES 1/5-success-rule (Rechenberg)",
+      "problem": "ackley",
+      "humpday_median": 0.20408225616901676,
+      "reference_median": 6.8833607014262554e-06,
+      "humpday_to_opt": 0.20408225616901676,
+      "reference_to_opt": 6.8833607014262554e-06,
+      "ratio_humpday_over_reference": 29648.636035749598
+    },
+    {
+      "algorithm": "CoordinateDescent",
+      "reference": "scipy Powell (direc=I)",
+      "problem": "sphere",
+      "humpday_median": 5.6240397679647395e-08,
+      "reference_median": 0.0,
+      "humpday_to_opt": 5.6240397679647395e-08,
+      "reference_to_opt": 0.0,
+      "ratio_humpday_over_reference": 56240398.679647386
+    },
+    {
+      "algorithm": "CoordinateDescent",
+      "reference": "scipy Powell (direc=I)",
+      "problem": "rosenbrock",
+      "humpday_median": 0.27565088962745843,
+      "reference_median": 0.06758611872244405,
+      "humpday_to_opt": 0.27565088962745843,
+      "reference_to_opt": 0.06758611872244405,
+      "ratio_humpday_over_reference": 4.078513381711872
+    },
+    {
+      "algorithm": "CoordinateDescent",
+      "reference": "scipy Powell (direc=I)",
+      "problem": "ackley",
+      "humpday_median": 0.00685738478913267,
+      "reference_median": 1.4808820836265113e-10,
+      "humpday_to_opt": 0.00685738478913267,
+      "reference_to_opt": 1.4808820836265113e-10,
+      "ratio_humpday_over_reference": 46305769.77858393
+    },
+    {
+      "algorithm": "PatternSearch",
+      "reference": "scipy.optimize.direct (DIRECT)",
+      "problem": "sphere",
+      "humpday_median": 4.2138507759282547e-13,
+      "reference_median": 0.0,
+      "humpday_to_opt": 4.2138507759282547e-13,
+      "reference_to_opt": 0.0,
+      "ratio_humpday_over_reference": 422.38507759282544
+    },
+    {
+      "algorithm": "PatternSearch",
+      "reference": "scipy.optimize.direct (DIRECT)",
+      "problem": "rosenbrock",
+      "humpday_median": 0.15215919320399093,
+      "reference_median": 0.010564870537897215,
+      "humpday_to_opt": 0.15215919320399093,
+      "reference_to_opt": 0.010564870537897215,
+      "ratio_humpday_over_reference": 14.402371771444596
+    },
+    {
+      "algorithm": "PatternSearch",
+      "reference": "scipy.optimize.direct (DIRECT)",
+      "problem": "ackley",
+      "humpday_median": 1.771094968505693e-05,
+      "reference_median": 4.440892098500626e-16,
+      "humpday_to_opt": 1.771094968505693e-05,
+      "reference_to_opt": 4.440892098500626e-16,
+      "ratio_humpday_over_reference": 12264442920.320574
     }
   ],
   "n_runs": 4,
   "n_trials": 200,
   "n_dim": 2,
-  "recorded_at": "2026-05-30T19:21:59Z"
+  "recorded_at": "2026-05-30T19:44:25Z"
 }

--- a/tests/test_reference_alignment.py
+++ b/tests/test_reference_alignment.py
@@ -315,6 +315,126 @@ def _ref_cmaes(func, n_trials, n_dim, seed):
     return {"best_value": float(best), "evals": counter["n"]}
 
 
+def _ref_random_search(func, n_trials, n_dim, seed):
+    """Uniform-sample baseline — draw n_trials i.i.d. samples from
+    `U[0, 1]^n_dim` and return the best. Cheapest possible
+    lower-bound: any algorithm worth using should beat this median.
+    """
+    rng = random.Random(seed)
+    best = float("inf")
+    n_evals = 0
+    for _ in range(n_trials):
+        x = [rng.random() for _ in range(n_dim)]
+        v = func(x)
+        n_evals += 1
+        if v < best:
+            best = v
+    return {"best_value": float(best), "evals": n_evals}
+
+
+def _ref_oneplusone_es_decay(func, n_trials, n_dim, seed):
+    """(1+1)-ES with a geometric sigma decay schedule — the natural
+    reference for HillClimbing. Starts at sigma=0.1 and decays so the
+    final sigma is ~1e-3, matching a "hill-climbing with shrinking
+    perturbations" intuition."""
+    rng = random.Random(seed)
+    x = [_draw_x0(seed, n_dim)[i] for i in range(n_dim)]
+    fx = func(x)
+    n_evals = 1
+    sigma_init = 0.1
+    sigma_final = 1e-3
+    decay = (sigma_final / sigma_init) ** (1.0 / max(1, n_trials - 1))
+    sigma = sigma_init
+
+    for _ in range(n_trials - 1):
+        z = [rng.gauss(0, 1) for _ in range(n_dim)]
+        x_new = [min(1.0, max(0.0, x[i] + sigma * z[i])) for i in range(n_dim)]
+        fx_new = func(x_new)
+        n_evals += 1
+        if fx_new < fx:
+            x, fx = x_new, fx_new
+        sigma *= decay
+    return {"best_value": float(fx), "evals": n_evals}
+
+
+def _ref_oneplusone_es_oneFifth(func, n_trials, n_dim, seed):
+    """(1+1)-ES with Rechenberg's 1/5-success-rule — the natural
+    reference for AdaptiveRandomSearch. Sigma grows by 1.5× when the
+    success rate over the last 10 trials exceeds 1/5, shrinks by 1/1.5
+    otherwise."""
+    rng = random.Random(seed)
+    x = [_draw_x0(seed, n_dim)[i] for i in range(n_dim)]
+    fx = func(x)
+    n_evals = 1
+    sigma = 0.1
+    window = []
+    window_size = 10
+
+    for _ in range(n_trials - 1):
+        z = [rng.gauss(0, 1) for _ in range(n_dim)]
+        x_new = [min(1.0, max(0.0, x[i] + sigma * z[i])) for i in range(n_dim)]
+        fx_new = func(x_new)
+        n_evals += 1
+        accepted = fx_new < fx
+        if accepted:
+            x, fx = x_new, fx_new
+        window.append(accepted)
+        if len(window) > window_size:
+            window.pop(0)
+        if len(window) >= window_size:
+            rate = sum(window) / window_size
+            if rate > 1 / 5:
+                sigma *= 1.5
+            elif rate < 1 / 5:
+                sigma /= 1.5
+    return {"best_value": float(fx), "evals": n_evals}
+
+
+def _ref_scipy_powell_diagonal(func, n_trials, n_dim, seed):
+    """scipy.optimize.minimize(method="Powell", direc=I) — Powell's
+    direction-set method constrained to the cardinal directions. This
+    is the textbook "coordinate descent with a line search per axis"
+    and is the natural reference for HumpDay's CoordinateDescent."""
+    import numpy as np
+    from scipy.optimize import minimize
+
+    counter = {"n": 0}
+
+    def wrapped(x):
+        counter["n"] += 1
+        return func(list(x))
+
+    r = minimize(
+        wrapped,
+        _draw_x0(seed, n_dim),
+        method="Powell",
+        options={
+            "maxfev": n_trials,
+            "xtol": 1e-12,
+            "ftol": 1e-12,
+            "direc": np.eye(n_dim),
+        },
+    )
+    return {"best_value": float(r.fun), "evals": counter["n"]}
+
+
+def _ref_scipy_direct(func, n_trials, n_dim, seed):
+    """scipy.optimize.direct (DIRECT — DIviding RECTangles) — natural
+    reference for HumpDay's PatternSearch. DIRECT is deterministic so
+    `seed` is unused; we still take it to keep the adapter signature
+    uniform. Bounds = [0,1]^n; maxfun caps the budget directly."""
+    from scipy.optimize import direct
+
+    counter = {"n": 0}
+
+    def wrapped(x):
+        counter["n"] += 1
+        return func(list(x))
+
+    r = direct(wrapped, [(0.0, 1.0)] * n_dim, maxfun=n_trials)
+    return {"best_value": float(r.fun), "evals": counter["n"]}
+
+
 def _ref_mealpy(cls_path, func, n_trials, n_dim, seed, pop_size=20, kwargs=None):
     """Run a mealpy algorithm and return {best_value, evals}.
 
@@ -476,6 +596,23 @@ REFERENCES = {
     "HarmonySearch": ("mealpy HS", _ref_mealpy_harmony, ["mealpy", "numpy"]),
     "EvolutionStrategy": ("mealpy ES", _ref_mealpy_es, ["mealpy", "numpy"]),
     "AntColonyOpt": ("mealpy ACOR", _ref_mealpy_acor, ["mealpy", "numpy"]),
+    "RandomSearch": ("uniform-sample baseline", _ref_random_search, []),
+    "HillClimbing": (
+        "(1+1)-ES sigma-decay schedule",
+        _ref_oneplusone_es_decay,
+        [],
+    ),
+    "AdaptiveRandomSearch": (
+        "(1+1)-ES 1/5-success-rule (Rechenberg)",
+        _ref_oneplusone_es_oneFifth,
+        [],
+    ),
+    "CoordinateDescent": (
+        "scipy Powell (direc=I)",
+        _ref_scipy_powell_diagonal,
+        ["scipy"],
+    ),
+    "PatternSearch": ("scipy.optimize.direct (DIRECT)", _ref_scipy_direct, ["scipy"]),
 }
 
 


### PR DESCRIPTION
Third (and final) tranche of #163's reference-adapter umbrella — covers the search-family algorithms that had no reference today.

## Algorithms and chosen references

| humpday algorithm | reference |
|---|---|
| `RandomSearch` | uniform-sample baseline (stdlib only) |
| `HillClimbing` | (1+1)-ES with geometric sigma decay |
| `AdaptiveRandomSearch` | (1+1)-ES with Rechenberg 1/5-success-rule |
| `CoordinateDescent` | scipy Powell with `direc=I` (cardinal axes only) |
| `PatternSearch` | `scipy.optimize.direct` (DIRECT) |

The two (1+1)-ES variants and the uniform-sample baseline are implemented locally (~30 LOC each) so RandomSearch / HillClimbing / AdaptiveRandomSearch have **zero third-party dependencies** in their adapters — they run anywhere stdlib runs. Powell-direc and DIRECT use scipy, already in `[reference]`.

## Snapshot highlights (`n_trials=200, n_dim=2, n_runs=4`, medians)

| algorithm | problem | humpday | ref | ratio |
|---|---|---:|---:|---:|
| RandomSearch | sphere | 2.2e-03 | 3.3e-04 | **6.7×** (humpday LOSES vs uniform baseline) |
| RandomSearch | rosenbrock | 9.2e-02 | 3.4e-01 | 0.27× (humpday wins) |
| HillClimbing | sphere | 3.3e-04 | 1.4e-07 | **2400×** |
| HillClimbing | rosenbrock | 3.6e-01 | 9.2e-02 | 4× |
| AdaptiveRandomSearch | sphere | 2.0e-05 | 3.5e-14 | **5.7e+08** |
| AdaptiveRandomSearch | ackley | 2.0e-01 | 6.9e-06 | 3e+04 |
| CoordinateDescent | sphere | 5.6e-08 | 0 | 5.6e+07 |
| CoordinateDescent | ackley | 6.9e-03 | 1.5e-10 | 4.6e+07 |
| PatternSearch | sphere | 4.2e-13 | 0 | 420× |
| PatternSearch | rosenbrock | 1.5e-01 | 1.1e-02 | 14× |
| PatternSearch | ackley | 1.8e-05 | 4.4e-16 | **1.2e+10** |

## Headline findings

- **RandomSearch** is 6.7× worse than a vanilla uniform-sample baseline on sphere. Suggests humpday's implementation has wasted evaluations (initialisation overhead? duplicate-sample detection?) — worth a follow-up.
- **HillClimbing** is far behind a textbook (1+1)-ES with sigma decay.
- **CoordinateDescent** and **PatternSearch** both have 1e7–1e10 gaps on smooth and unimodal objectives — these are large enough that the humpday implementations are best thought of as different algorithms entirely than the textbook ones the names suggest.

All gaps are *characterisation* data (the test always passes). The next step would be either to rename the divergent ones (per #80 LBFGSB pattern) or to port them faithfully — out of scope for this PR.

## Closes #163

Of the 13 algorithms in #163's umbrella, **12 now have references**:

- PR1 (#175): LBFGSB
- PR2 (#176): 6 mealpy adapters
- This PR: 5 search-family adapters

TabuSearch was explicitly *characterisation-only* in the issue ("No canonical reference exists") and is left without a reference; it can be added via `mealpy.math_based.TS` later if useful.

## Test plan

- [ ] CI passes
- [ ] Manual: `pytest tests/test_reference_alignment.py -m reference -v` — green, snapshot diff visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)