### PR TITLE
CoordinateDescent: expanding line search per axis (Python + JS)

### DIFF
--- a/benchmarks/reference_alignment.json
+++ b/benchmarks/reference_alignment.json
@@ -574,31 +574,31 @@
       "algorithm": "CoordinateDescent",
       "reference": "scipy Powell (direc=I)",
       "problem": "sphere",
-      "humpday_median": 5.6240397679647395e-08,
+      "humpday_median": 1.934869673211661e-18,
       "reference_median": 0.0,
-      "humpday_to_opt": 5.6240397679647395e-08,
+      "humpday_to_opt": 1.934869673211661e-18,
       "reference_to_opt": 0.0,
-      "ratio_humpday_over_reference": 56240398.679647386
+      "ratio_humpday_over_reference": 1.0019348696732118
     },
     {
       "algorithm": "CoordinateDescent",
       "reference": "scipy Powell (direc=I)",
       "problem": "rosenbrock",
-      "humpday_median": 0.27565088962745843,
+      "humpday_median": 0.18847508441565536,
       "reference_median": 0.06758611872244405,
-      "humpday_to_opt": 0.27565088962745843,
+      "humpday_to_opt": 0.18847508441565536,
       "reference_to_opt": 0.06758611872244405,
-      "ratio_humpday_over_reference": 4.078513381711872
+      "ratio_humpday_over_reference": 2.7886656014331033
     },
     {
       "algorithm": "CoordinateDescent",
       "reference": "scipy Powell (direc=I)",
       "problem": "ackley",
-      "humpday_median": 0.00685738478913267,
+      "humpday_median": 4.4595687587190014e-08,
       "reference_median": 1.4808820836265113e-10,
-      "humpday_to_opt": 0.00685738478913267,
+      "humpday_to_opt": 4.4595687587190014e-08,
       "reference_to_opt": 1.4808820836265113e-10,
-      "ratio_humpday_over_reference": 46305769.77858393
+      "ratio_humpday_over_reference": 301.1407048512339
     },
     {
       "algorithm": "PatternSearch",
@@ -634,5 +634,5 @@
   "n_runs": 4,
   "n_trials": 200,
   "n_dim": 2,
-  "recorded_at": "2026-05-30T22:13:58Z"
+  "recorded_at": "2026-05-30T22:22:57Z"
 }

--- a/docs/js/modules/search-algorithms.js
+++ b/docs/js/modules/search-algorithms.js
@@ -82,6 +82,12 @@ class Rechenberg extends Optimizer {
 const AdaptiveRandomSearch = Rechenberg;
 
 // Coordinate Descent
+// Coordinate descent with an adaptive expanding line search per axis.
+// For each coordinate i, take a step ± step; if it improves, keep
+// stepping in the same direction until it stops improving. After a
+// full sweep over all coordinates with no improvement, halve the
+// step. Mirrors the Python port; replaces the previous fixed-shrink
+// (× 0.8, floor 0.001) variant that could never refine below ~1e-3.
 class CoordinateDescent extends Optimizer {
     constructor(objective, nTrials, nDim) {
         super(objective, nTrials, nDim);
@@ -89,46 +95,53 @@ class CoordinateDescent extends Optimizer {
     }
 
     optimize() {
-        let x = Array(this.nDim).fill(0).map(() => Math.random());
+        const n = this.nDim;
+        let x = Array(n).fill(0).map(() => Math.random());
         let fx = this.evaluate(x);
 
-        let stepSize = 0.1;
+        let step = 0.1;
+        const stepMin = 1e-12;
 
-        while (this.evaluations < this.nTrials) {
-            let improved = false;
+        while (this.evaluations < this.nTrials && step > stepMin) {
+            let improvedAnywhere = false;
 
-            for (let i = 0; i < this.nDim && this.evaluations < this.nTrials - 1; i++) {
-                // Try positive direction
-                const xPos = [...x];
-                xPos[i] = MathUtils.clip(x[i] + stepSize, 0, 1);
-                const fxPos = this.evaluate(xPos);
+            for (let i = 0; i < n; i++) {
+                if (this.evaluations >= this.nTrials) break;
 
-                if (fxPos < fx) {
-                    x = xPos;
-                    fx = fxPos;
-                    improved = true;
-                    continue;
+                let foundDirection = false;
+                for (const sign of [1, -1]) {
+                    if (this.evaluations >= this.nTrials) break;
+
+                    const xiNew = MathUtils.clip(x[i] + sign * step, 0, 1);
+                    if (Math.abs(xiNew - x[i]) < 1e-15) continue;
+
+                    const xTrial = x.slice();
+                    xTrial[i] = xiNew;
+                    const fTrial = this.evaluate(xTrial);
+                    if (fTrial >= fx) continue;
+
+                    x = xTrial;
+                    fx = fTrial;
+                    improvedAnywhere = true;
+                    foundDirection = true;
+
+                    // Greedy expansion in the same direction.
+                    while (this.evaluations < this.nTrials) {
+                        const xiNext = MathUtils.clip(x[i] + sign * step, 0, 1);
+                        if (Math.abs(xiNext - x[i]) < 1e-15) break;
+                        const xTrial2 = x.slice();
+                        xTrial2[i] = xiNext;
+                        const fTrial2 = this.evaluate(xTrial2);
+                        if (fTrial2 >= fx) break;
+                        x = xTrial2;
+                        fx = fTrial2;
+                    }
+                    break;
                 }
-
-                // Try negative direction
-                const xNeg = [...x];
-                xNeg[i] = MathUtils.clip(x[i] - stepSize, 0, 1);
-                const fxNeg = this.evaluate(xNeg);
-
-                if (fxNeg < fx) {
-                    x = xNeg;
-                    fx = fxNeg;
-                    improved = true;
-                }
+                if (!foundDirection) continue;
             }
 
-            // Adapt step size
-            if (improved) {
-                stepSize = Math.min(0.2, stepSize * 1.1);
-            } else {
-                stepSize = Math.max(0.001, stepSize * 0.8);
-                if (stepSize < 0.005) break;
-            }
+            if (!improvedAnywhere) step *= 0.5;
         }
 
         return {

--- a/humpday/optimizers/search_algorithms.py
+++ b/humpday/optimizers/search_algorithms.py
@@ -85,53 +85,74 @@ AdaptiveRandomSearch = Rechenberg
 
 
 class CoordinateDescent(BaseOptimizer):
-    """Coordinate Descent optimization.
+    """Coordinate Descent with an adaptive expanding line search per axis.
 
     Pure-Python via the `humpday._array` shim — no direct numpy use.
-    Cycles through axes; for each, takes a step in both directions and
-    keeps the better. Step size halves when a full sweep makes no progress;
-    resets when it gets too small.
+
+    For each coordinate `i`, take a step `± step_size`; if it improves,
+    keep stepping in the same direction until it stops improving
+    (greedy expansion — the same shape Powell uses). After a full
+    sweep over all coordinates, halve `step_size` until it drops below
+    1e-12.
+
+    The previous implementation shrank `step_size *= 0.8` per failed
+    sweep (so even after 30 sweeps it was only at ~0.001) and reset
+    to 0.05 once `step_size < 1e-6` — a humpday-ism that explicitly
+    prevented convergence below ~1e-3. That's why the snapshot showed
+    a ~5.6e+07× gap vs scipy Powell with `direc=I` on the sphere.
     """
 
     def optimize(self):
-        x = _A.random_uniform(self.n_dim)
+        n = self.n_dim
+        x = _A.random_uniform(n)
         f = self.evaluate(x)
-        step_size = 0.1
 
-        while self.evaluations < self.n_trials:
-            improved = False
+        step = 0.1
+        step_min = 1e-12
 
-            # Cycle through coordinates.
-            for i in range(self.n_dim):
+        while self.evaluations < self.n_trials and step > step_min:
+            improved_anywhere = False
+
+            for i in range(n):
                 if self.evaluations >= self.n_trials:
                     break
 
-                best_xi = x[i]
-                best_f = f
+                # Try both signs along axis i; on the first improving
+                # step, greedily expand in that direction.
+                for sign in (1, -1):
+                    if self.evaluations >= self.n_trials:
+                        break
 
-                # Try steps in both directions along axis `i`.
-                for direction in [-1, 1]:
+                    xi_new = max(0.0, min(1.0, float(x[i]) + sign * step))
+                    if abs(xi_new - float(x[i])) < 1e-15:
+                        continue  # already at the bound in this direction
                     x_trial = x.copy()
-                    # Clip the single perturbed coordinate to [0, 1].
-                    xi_new = x[i] + direction * step_size
-                    x_trial[i] = (
-                        0.0 if xi_new < 0.0 else (1.0 if xi_new > 1.0 else xi_new)
-                    )
+                    x_trial[i] = xi_new
+                    f_trial = self.evaluate(x_trial)
+                    if f_trial >= f:
+                        continue
 
-                    if self.evaluations < self.n_trials:
-                        f_trial = self.evaluate(x_trial)
-                        if f_trial < best_f:
-                            best_xi = x_trial[i]
-                            best_f = f_trial
-                            improved = True
+                    x = x_trial
+                    f = f_trial
+                    improved_anywhere = True
 
-                x[i] = best_xi
-                f = best_f
+                    # Greedy expansion in the same direction.
+                    while self.evaluations < self.n_trials:
+                        xi_next = max(0.0, min(1.0, float(x[i]) + sign * step))
+                        if abs(xi_next - float(x[i])) < 1e-15:
+                            break
+                        x_trial2 = x.copy()
+                        x_trial2[i] = xi_next
+                        f_trial2 = self.evaluate(x_trial2)
+                        if f_trial2 >= f:
+                            break
+                        x = x_trial2
+                        f = f_trial2
 
-            if not improved:
-                step_size *= 0.8
-                if step_size < 1e-6:
-                    step_size = 0.05  # Reset
+                    break  # don't try the other sign on this coordinate
+
+            if not improved_anywhere:
+                step *= 0.5
 
         return self.best_value, self.best_x
 


### PR DESCRIPTION
Replaces the previous fixed `±step` + `0.8×` shrink + `0.05` reset heuristic with a proper coordinate-descent: for each coordinate, take a step `±step`; if it improves, **greedily expand** in the same direction until it stops improving. After a full sweep with no improvement, halve the step. Mirrors Powell's textbook coordinate search and matches the reference adapter `_ref_scipy_powell_diagonal` (scipy Powell with `direc=I`).

The previous implementation had two humpday-isms blocking convergence:
1. `step_size *= 0.8` shrunk only ~20% per failed sweep (so even 30 sweeps left it at ~0.001)
2. The `step_size < 1e-6 → reset to 0.05` rule explicitly prevented high-precision convergence

Result: **~5.6e+07× gap** vs scipy Powell with `direc=I` on the sphere.

## Snapshot impact (`n_trials=200, n_dim=2`, medians)

| problem | before | **after** |
|---|---:|---:|
| sphere | 5.62e-08 (5.6e+07×) | **1.94e-18 (1.00× — tied)** |
| rosenbrock | 2.76e-01 (4.08×) | 1.89e-01 (2.79×) |
| ackley | 6.86e-03 (4.6e+07×) | 4.46e-08 (301×) |

Sphere is now numerically tied with scipy. Rosenbrock improves slightly (Rosenbrock is hard for axis-aligned descent — the valley isn't axis-aligned, so coordinate descent zigzags). Ackley closes **5 orders of magnitude**.

**CoordinateDescent moves from Tier 4 to Tier 1/2 on smooth/separable objectives.**

## Verification

- All 324 main Python tests pass
- All 22 sphere parity tests pass

## Test plan

- [ ] CI passes
- [ ] Manual: `pytest tests/test_reference_alignment.py -m reference -v` — snapshot confirms CD sphere ~1e-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)