### PR TITLE
AntColonyOpt: replace discrete-bin ACO with Socha-Dorigo ACOR (Python + JS)

### DIFF
--- a/benchmarks/reference_alignment.json
+++ b/benchmarks/reference_alignment.json
@@ -454,31 +454,31 @@
       "algorithm": "AntColonyOpt",
       "reference": "mealpy ACOR",
       "problem": "sphere",
-      "humpday_median": 0.006172839506172845,
+      "humpday_median": 1.8885956216754782e-06,
       "reference_median": 1.3505929043031356e-05,
-      "humpday_to_opt": 0.006172839506172845,
+      "humpday_to_opt": 1.8885956216754782e-06,
       "reference_to_opt": 1.3505929043031356e-05,
-      "ratio_humpday_over_reference": 457.0466412232333
+      "ratio_humpday_over_reference": 0.13983455832755917
     },
     {
       "algorithm": "AntColonyOpt",
       "reference": "mealpy ACOR",
       "problem": "rosenbrock",
-      "humpday_median": 1.536503581771074,
+      "humpday_median": 0.25681925668845496,
       "reference_median": 0.18097209849405424,
-      "humpday_to_opt": 1.536503581771074,
+      "humpday_to_opt": 0.25681925668845496,
       "reference_to_opt": 0.18097209849405424,
-      "ratio_humpday_over_reference": 8.49027885821608
+      "ratio_humpday_over_reference": 1.4191096794785314
     },
     {
       "algorithm": "AntColonyOpt",
       "reference": "mealpy ACOR",
       "problem": "ackley",
-      "humpday_median": 4.430747567480555,
+      "humpday_median": 0.0537007688678135,
       "reference_median": 0.24688628159903603,
-      "humpday_to_opt": 4.430747567480555,
+      "humpday_to_opt": 0.0537007688678135,
       "reference_to_opt": 0.24688628159903603,
-      "ratio_humpday_over_reference": 17.946511806097202
+      "ratio_humpday_over_reference": 0.21751216195571701
     },
     {
       "algorithm": "RandomSearch",
@@ -634,5 +634,5 @@
   "n_runs": 4,
   "n_trials": 200,
   "n_dim": 2,
-  "recorded_at": "2026-05-31T00:51:53Z"
+  "recorded_at": "2026-05-31T01:02:45Z"
 }

--- a/docs/js/modules/evolutionary-algorithms.js
+++ b/docs/js/modules/evolutionary-algorithms.js
@@ -942,6 +942,12 @@ class FireflyAlgorithm extends Optimizer {
 }
 
 // Ant Colony Optimization
+// ACOR — Ant Colony Optimization for continuous domains (Socha &
+// Dorigo, 2008). Maintains an archive of the k best solutions and
+// samples new candidates from a mixture of Gaussian kernels centred
+// on archive points. Mirrors the Python port; replaces humpday's
+// previous discrete-bin "continuous via discretization" ACO that was
+// ~457× off mealpy.swarm_based.ACOR on the sphere benchmark.
 class AntColonyOpt extends Optimizer {
     constructor(objective, nTrials, nDim) {
         super(objective, nTrials, nDim);
@@ -949,58 +955,83 @@ class AntColonyOpt extends Optimizer {
     }
 
     optimize() {
-        const nAnts = Math.min(20, Math.max(8, this.nDim));
-        const rho = 0.1; // Evaporation rate
+        const n = this.nDim;
+        const k = Math.min(50, Math.max(10, Math.floor(this.nTrials / 10)));
+        const nAnts = Math.min(25, Math.max(5, Math.floor(this.nTrials / 20)));
+        const q = 0.5;
+        const xi = 1.0;
 
-        // Discretize search space
-        const nLevels = 20;
-        const pheromones = Array(this.nDim).fill(0).map(() => Array(nLevels).fill(1.0));
+        // Rank weights: w_i ∝ Gaussian on rank i, normalised.
+        const weights = new Array(k);
+        for (let i = 0; i < k; i++) {
+            weights[i] = Math.exp(-(i * i) / (2.0 * q * q * k * k)) /
+                         (q * k * Math.sqrt(2.0 * Math.PI));
+        }
+        let wsum = 0;
+        for (let i = 0; i < k; i++) wsum += weights[i];
+        for (let i = 0; i < k; i++) weights[i] /= wsum;
+
+        // Initial archive: k uniform samples, sorted by f.
+        const archive = [];
+        for (let i = 0; i < k && this.evaluations < this.nTrials; i++) {
+            const x = new Array(n);
+            for (let d = 0; d < n; d++) x[d] = Math.random();
+            archive.push({ x, f: this.evaluate(x) });
+        }
+        if (!archive.length) {
+            return {
+                bestValue: this.bestValue,
+                bestX: this.bestX,
+                evaluations: this.evaluations,
+                success: true,
+                path: this.trackPath ? this.path : null
+            };
+        }
+        archive.sort((a, b) => a.f - b.f);
 
         while (this.evaluations < this.nTrials) {
-            const solutions = [];
-
-            // Construct solutions
-            for (let ant = 0; ant < nAnts && this.evaluations < this.nTrials; ant++) {
-                const solution = [];
-                for (let dim = 0; dim < this.nDim; dim++) {
-                    // Probabilistic selection based on pheromones
-                    const probabilities = pheromones[dim].map(p => Math.pow(p, 2));
-                    const total = probabilities.reduce((sum, p) => sum + p, 0);
-                    const normalizedProb = probabilities.map(p => p / total);
-
-                    let selected = 0;
-                    const rand = Math.random();
-                    let cumProb = 0;
-                    for (let level = 0; level < nLevels; level++) {
-                        cumProb += normalizedProb[level];
-                        if (rand <= cumProb) {
-                            selected = level;
-                            break;
-                        }
-                    }
-
-                    solution.push(selected / (nLevels - 1));
+            // Per-kernel per-dim sigma = xi · mean |x_l[d] − x_i[d]|.
+            const sigmasByKernel = new Array(archive.length);
+            for (let i = 0; i < archive.length; i++) {
+                const xi_vec = archive[i].x;
+                const sigma = new Array(n).fill(0);
+                for (let l = 0; l < archive.length; l++) {
+                    if (l === i) continue;
+                    const xl = archive[l].x;
+                    for (let d = 0; d < n; d++) sigma[d] += Math.abs(xl[d] - xi_vec[d]);
                 }
-
-                const fitness = this.evaluate(solution);
-                solutions.push({ solution, fitness });
+                const denom = Math.max(1, archive.length - 1);
+                for (let d = 0; d < n; d++) sigma[d] = xi * sigma[d] / denom;
+                sigmasByKernel[i] = sigma;
             }
 
-            // Evaporate pheromones
-            for (let dim = 0; dim < this.nDim; dim++) {
-                for (let level = 0; level < nLevels; level++) {
-                    pheromones[dim][level] *= (1 - rho);
+            const newSolutions = [];
+            for (let a = 0; a < nAnts; a++) {
+                if (this.evaluations >= this.nTrials) break;
+
+                // Roulette-pick a kernel by weights.
+                const r = Math.random();
+                let cum = 0;
+                let kernelIdx = archive.length - 1;
+                for (let i = 0; i < archive.length; i++) {
+                    cum += weights[i];
+                    if (r <= cum) { kernelIdx = i; break; }
                 }
+
+                const center = archive[kernelIdx].x;
+                const sigma = sigmasByKernel[kernelIdx];
+                const xNew = new Array(n);
+                for (let d = 0; d < n; d++) {
+                    const s = Math.max(sigma[d], 1e-12);
+                    const z = this._gauss();
+                    xNew[d] = Math.max(0, Math.min(1, center[d] + s * z));
+                }
+                newSolutions.push({ x: xNew, f: this.evaluate(xNew) });
             }
 
-            // Update pheromones (best solution gets more pheromone)
-            solutions.sort((a, b) => a.fitness - b.fitness);
-            const bestSol = solutions[0];
-
-            bestSol.solution.forEach((value, dim) => {
-                const level = Math.round(value * (nLevels - 1));
-                pheromones[dim][level] += 1.0 / (1.0 + bestSol.fitness);
-            });
+            for (const sol of newSolutions) archive.push(sol);
+            archive.sort((a, b) => a.f - b.f);
+            archive.length = k;
         }
 
         return {
@@ -1010,6 +1041,20 @@ class AntColonyOpt extends Optimizer {
             success: true,
             path: this.trackPath ? this.path : null
         };
+    }
+
+    _gauss() {
+        if (this._spare !== undefined) {
+            const s = this._spare;
+            this._spare = undefined;
+            return s;
+        }
+        const u = Math.random();
+        const v = Math.random();
+        const r = Math.sqrt(-2 * Math.log(Math.max(u, 1e-300)));
+        const theta = 2 * Math.PI * v;
+        this._spare = r * Math.sin(theta);
+        return r * Math.cos(theta);
     }
 }
 

--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -839,106 +839,107 @@ class FireflyAlgorithm(BaseOptimizer):
 
 
 class AntColonyOpt(BaseOptimizer):
-    """Ant Colony Optimization (continuous via discretization).
+    """ACOR — Ant Colony Optimization for continuous domains (Socha &
+    Dorigo, 2008).
 
     Pure-Python via the `humpday._array` shim — no direct numpy use.
-    Each dimension is discretized into `n_nodes` bins. Each ant picks one
-    bin per dimension proportional to that dimension's pheromone weights,
-    evaluates the resulting point, and feeds back into the pheromone
-    update.
 
-    Bug fix (was previously a known flake)
-    --------------------------------------
-    The old code used `1.0 / (best_fitness + 1e-10)` as the pheromone
-    deposit. Whenever `best_fitness` was negative — possible on objectives
-    like Schwefel, Sharpe-ratio portfolios, anything below zero — the
-    deposit was negative and pheromone weights drifted downward. After
-    enough updates a weight could go strictly negative, and the next call
-    to multinomial-sample failed with `ValueError: probabilities are not
-    non-negative`. The fix here:
+    Maintains an *archive* of the `k` best solutions found so far,
+    sorted by fitness. Each generation samples `n_ants` new candidates
+    from a mixture of Gaussian kernels centred on the archive points;
+    the kernel weight w_i is a Gaussian on rank i (so better-ranked
+    archive entries are sampled-from more often), and the per-dimension
+    width sigma_d is `xi` times the mean absolute deviation of the
+    archive in that dimension. Better candidates replace the worst
+    archive entries.
 
-      1. Pheromone deposit becomes `1.0 / (1.0 + abs(best_fitness))`,
-         which is strictly positive for any finite best_fitness and
-         bounded in (0, 1]. Better-found solutions still deposit more,
-         preserving ACO's "shorter path = stronger reinforcement" intent.
-      2. After each deposit, the affected weight is floor-clipped at
-         `1e-12` as belt-and-suspenders against any future numerical
-         drift.
-      3. The sampling step clamps weights at zero before normalising,
-         so even if a weight DID go slightly negative from floating-point
-         noise, the multinomial draw would still succeed.
+    Replaces humpday's previous discrete-bin "continuous via
+    discretization" ACO — a humpday-ism that capped precision at
+    ~1/n_nodes per dimension and was ~457× off the mealpy reference
+    on the sphere benchmark.
 
-    Tests that previously had to special-case this error
-    (`test_portfolio.py`'s known_algorithm_bug branch) can now treat it
-    as a real failure.
+    Reference: Socha, K. & Dorigo, M. (2008). "Ant colony optimization
+    for continuous domains." European Journal of Operational Research
+    185(3): 1155–1173. Matches the mealpy `swarm_based.ACOR.OriginalACOR`
+    adapter used by `tests/test_reference_alignment.py`.
     """
 
     def optimize(self):
-        n_ants = min(15, self.n_trials // 5)
-        n_nodes = 10  # Bins per dimension.
-        evaporation = 0.1
+        n = self.n_dim
+        # Hansen-mealpy-style defaults.
+        k = min(50, max(10, self.n_trials // 10))  # archive size
+        n_ants = min(25, max(5, self.n_trials // 20))  # samples per gen
+        q = 0.5  # selection-pressure parameter (smaller → greedier)
+        xi = 1.0  # standard-deviation amplification
 
-        # Pheromone matrix as list-of-rows; rows are plain `list[float]`
-        # (we only ever do scalar indexing into them, no row-level
-        # arithmetic, so no `_Vec` wrapper needed).
-        pheromone = [[1.0] * n_nodes for _ in range(self.n_dim)]
+        # Pre-compute rank weights: w_i ∝ Gaussian on rank i.
+        # w_i = (1 / (q k √(2π))) · exp(−(i)² / (2 q² k²)) for i = 0..k−1
+        weights = []
+        for i in range(k):
+            ex = math.exp(-(i**2) / (2.0 * q * q * k * k))
+            weights.append(ex / (q * k * math.sqrt(2.0 * math.pi)))
+        wsum = sum(weights)
+        weights = [w / wsum for w in weights]
 
-        best_path = None
-        best_fitness = float("inf")
+        # Initial archive: k uniform samples (or as many as budget allows).
+        archive = []  # list of (x, f), sorted ascending by f
+        for _ in range(k):
+            if self.evaluations >= self.n_trials:
+                break
+            x = _A.random_uniform(n)
+            archive.append((x, self.evaluate(x)))
+        if not archive:
+            return self.best_value, self.best_x
+        archive.sort(key=lambda t: t[1])
 
         while self.evaluations < self.n_trials:
-            for _ant in range(n_ants):
+            # Per-dimension standard deviation = xi · mean |x_l[d] − x_i[d]|
+            # for the chosen kernel i. Precompute the absolute-deviation
+            # matrix once per generation (used for every sample).
+            sigmas_by_kernel = []
+            for i in range(len(archive)):
+                xi_vec = archive[i][0]
+                sigma = [0.0] * n
+                for l in range(len(archive)):
+                    if l == i:
+                        continue
+                    xl_vec = archive[l][0]
+                    for d in range(n):
+                        sigma[d] += abs(float(xl_vec[d]) - float(xi_vec[d]))
+                denom = max(1, len(archive) - 1)
+                for d in range(n):
+                    sigma[d] = xi * sigma[d] / denom
+                sigmas_by_kernel.append(sigma)
+
+            new_solutions = []
+            for _ in range(n_ants):
                 if self.evaluations >= self.n_trials:
                     break
+                # Roulette-pick a kernel (= an archive index) by weights.
+                r = _A.random_scalar()
+                cum = 0.0
+                kernel_idx = len(archive) - 1
+                for i, w in enumerate(weights[: len(archive)]):
+                    cum += w
+                    if r <= cum:
+                        kernel_idx = i
+                        break
 
-                # Per dimension, sample a bin index proportional to the
-                # row's pheromone weights via manual cumulative sampling.
-                # This avoids needing a `random_choice(seq, p=weights)`
-                # shim primitive — and gives us explicit control over the
-                # negative-weight defence below.
-                solution = _A.zeros(self.n_dim)
-                for dim in range(self.n_dim):
-                    row = pheromone[dim]
-                    # Floor-clip at 0 in case noise pushed any entry
-                    # slightly negative. Sum >= 1e-10 by the floor we
-                    # apply at deposit time, so this is a small extra
-                    # safety net.
-                    pos = [w if w > 0.0 else 0.0 for w in row]
-                    total = sum(pos)
-                    if total <= 0.0:
-                        # Pathological: every weight is zero. Fall back to
-                        # uniform.
-                        chosen = _A.random_int(n_nodes)
-                    else:
-                        r = _A.random_scalar() * total
-                        cum = 0.0
-                        chosen = n_nodes - 1  # default to last on rounding
-                        for i, w in enumerate(pos):
-                            cum += w
-                            if r <= cum:
-                                chosen = i
-                                break
-                    solution[dim] = chosen / (n_nodes - 1)
+                center = archive[kernel_idx][0]
+                sigma = sigmas_by_kernel[kernel_idx]
+                x_new = _A.zeros(n)
+                for d in range(n):
+                    s = max(sigma[d], 1e-12)
+                    # Box-Muller via the shim's random_normal.
+                    z = float(_A.random_normal(1)[0])
+                    x_new[d] = max(0.0, min(1.0, float(center[d]) + s * z))
+                f_new = self.evaluate(x_new)
+                new_solutions.append((x_new, f_new))
 
-                fitness = self.evaluate(solution)
-                if fitness < best_fitness:
-                    best_fitness = fitness
-                    best_path = solution.copy()
-
-            # Evaporation: every weight decays.
-            decay = 1 - evaporation
-            for row in pheromone:
-                for k in range(n_nodes):
-                    row[k] *= decay
-
-            # Strictly-positive deposit on the best-known path.
-            if best_path is not None:
-                deposit = 1.0 / (1.0 + abs(best_fitness))
-                for dim in range(self.n_dim):
-                    node = int(best_path[dim] * (n_nodes - 1))
-                    pheromone[dim][node] += deposit
-                    if pheromone[dim][node] < 1e-12:
-                        pheromone[dim][node] = 1e-12
+            # Merge: keep the k best across (archive ∪ new_solutions).
+            archive.extend(new_solutions)
+            archive.sort(key=lambda t: t[1])
+            archive = archive[:k]
 
         return self.best_value, self.best_x
 


### PR DESCRIPTION
Replaces humpday's previous "continuous via discretization" ACO — bin each dimension, sample bin index proportional to pheromone weight — with the canonical **ACOR** algorithm from Socha & Dorigo (2008), *Ant Colony Optimization for Continuous Domains*, EJOR 185(3): 1155–1173.

ACOR maintains an *archive* of the `k` best solutions sorted by fitness. Each generation samples `n_ants` new candidates from a mixture of Gaussian kernels centred on the archive points; kernel `i`'s weight is a Gaussian on rank `i` (better archive entries are sampled-from more often) and the per-dimension width `sigma_d` is `xi · mean abs-deviation` of the archive in that dimension. Better candidates replace the worst archive entries.

The old discrete-bin variant capped precision at `~1/n_nodes` per dimension (`n_nodes=10` → ~0.05 floor) and was **~457× off** the mealpy reference on the sphere benchmark.

## Parameters

Match `mealpy.swarm_based.ACOR.OriginalACOR` (the reference adapter):
- `k` (archive size) = `min(50, max(10, n_trials // 10))`
- `n_ants` (samples per gen) = `min(25, max(5, n_trials // 20))`
- `q` (selection pressure) = `0.5`
- `xi` (deviation amplification) = `1.0`

## Snapshot impact (`n_trials=200, n_dim=2`, medians)

| problem | before | **after** |
|---|---:|---:|
| sphere | 6.17e-03 (457×) | **1.89e-06 (0.14× — humpday wins by 7×)** |
| rosenbrock | 1.54e+00 (8.5×) | 2.57e-01 (1.42× — tied) |
| ackley | 4.43e+00 (18×) | **5.37e-02 (0.22× — humpday wins by 4×)** |

**AntColonyOpt moves from Tier 4 to Tier 1** (wins on 2/3, tied on 3rd).

Both Python and JS implementations get the new algorithm; the JS version uses Box-Muller for Gaussian sampling.

## Verification

- All 324 main Python tests pass
- All 22 sphere-parity tests pass

## Test plan

- [ ] CI passes
- [ ] Manual: `pytest tests/test_reference_alignment.py -m reference -v` — snapshot confirms ACOR sphere ~1e-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)