### PR TITLE
Fix Firefly reference: mealpy FA → FFA (Fireworks vs Firefly)

### DIFF
--- a/benchmarks/reference_alignment.json
+++ b/benchmarks/reference_alignment.json
@@ -362,33 +362,33 @@
     },
     {
       "algorithm": "FireflyAlgorithm",
-      "reference": "mealpy FA",
+      "reference": "mealpy FFA",
       "problem": "sphere",
       "humpday_median": 0.0003427641233057633,
-      "reference_median": 6.53310220185996e-05,
+      "reference_median": 0.00012471996637905398,
       "humpday_to_opt": 0.0003427641233057633,
-      "reference_to_opt": 6.53310220185996e-05,
-      "ratio_humpday_over_reference": 5.246575251860173
+      "reference_to_opt": 0.00012471996637905398,
+      "ratio_humpday_over_reference": 2.7482698500917846
     },
     {
       "algorithm": "FireflyAlgorithm",
-      "reference": "mealpy FA",
+      "reference": "mealpy FFA",
       "problem": "rosenbrock",
       "humpday_median": 0.14790456664103044,
-      "reference_median": 0.047434829773585846,
+      "reference_median": 0.053947184329190434,
       "humpday_to_opt": 0.14790456664103044,
-      "reference_to_opt": 0.047434829773585846,
-      "ratio_humpday_over_reference": 3.1180583412442053
+      "reference_to_opt": 0.053947184329190434,
+      "ratio_humpday_over_reference": 2.741654981259116
     },
     {
       "algorithm": "FireflyAlgorithm",
-      "reference": "mealpy FA",
+      "reference": "mealpy FFA",
       "problem": "ackley",
       "humpday_median": 2.6920461682866876,
-      "reference_median": 0.35438596181007087,
+      "reference_median": 0.6221637617983586,
       "humpday_to_opt": 2.6920461682866876,
-      "reference_to_opt": 0.35438596181007087,
-      "ratio_humpday_over_reference": 7.5963679671077164
+      "reference_to_opt": 0.6221637617983586,
+      "ratio_humpday_over_reference": 4.326909301990443
     },
     {
       "algorithm": "HarmonySearch",
@@ -634,5 +634,5 @@
   "n_runs": 4,
   "n_trials": 200,
   "n_dim": 2,
-  "recorded_at": "2026-05-31T01:02:45Z"
+  "recorded_at": "2026-05-31T01:29:50Z"
 }

--- a/tests/test_reference_alignment.py
+++ b/tests/test_reference_alignment.py
@@ -492,7 +492,13 @@ def _ref_mealpy_ga(func, n_trials, n_dim, seed):
 
 
 def _ref_mealpy_firefly(func, n_trials, n_dim, seed):
-    return _ref_mealpy("mealpy.swarm_based.FA.OriginalFA", func, n_trials, n_dim, seed)
+    # Use FFA (Firefly Algorithm) — `mealpy.swarm_based.FA` is the
+    # Fireworks Algorithm (different family). #176 picked the wrong
+    # one; the snapshot's previous "Firefly" comparison was actually
+    # humpday's Firefly vs mealpy's Fireworks.
+    return _ref_mealpy(
+        "mealpy.swarm_based.FFA.OriginalFFA", func, n_trials, n_dim, seed
+    )
 
 
 def _ref_mealpy_harmony(func, n_trials, n_dim, seed):
@@ -592,7 +598,7 @@ REFERENCES = {
     "PRIMA_UOBYQA": ("PDFO uobyqa", _ref_pdfo_uobyqa, ["pdfo", "numpy"]),
     "ParticleSwarm": ("mealpy PSO", _ref_mealpy_pso, ["mealpy", "numpy"]),
     "GeneticAlgorithm": ("mealpy GA", _ref_mealpy_ga, ["mealpy", "numpy"]),
-    "FireflyAlgorithm": ("mealpy FA", _ref_mealpy_firefly, ["mealpy", "numpy"]),
+    "FireflyAlgorithm": ("mealpy FFA", _ref_mealpy_firefly, ["mealpy", "numpy"]),
     "HarmonySearch": ("mealpy HS", _ref_mealpy_harmony, ["mealpy", "numpy"]),
     "EvolutionStrategy": ("mealpy ES", _ref_mealpy_es, ["mealpy", "numpy"]),
     "AntColonyOpt": ("mealpy ACOR", _ref_mealpy_acor, ["mealpy", "numpy"]),


### PR DESCRIPTION
#176 picked `mealpy.swarm_based.FA.OriginalFA` as the reference for humpday's `FireflyAlgorithm`, but **`FA` is the Fireworks Algorithm** (Tan & Zhu, 2010 — explosion-based fireworks spawning sparks). The correct reference for Firefly is **`mealpy.swarm_based.FFA.OriginalFFA`** (Yang, 2010 — Firefly attraction & light-intensity decay).

So the snapshot's previous "FireflyAlgorithm vs mealpy FA" row was actually humpday's Firefly vs mealpy's Fireworks — two unrelated metaheuristics. No wonder humpday looked off.

## With the correct FFA reference

| problem | before (vs FA) | **after (vs FFA)** |
|---|---:|---:|
| sphere | 5.25× | **2.75×** |
| rosenbrock | 3.12× | **2.74×** |
| ackley | 7.60× | **4.33×** |

**FireflyAlgorithm moves from Tier 3 to Tier 2** — within 5× on all three problems against the correct reference, **no algorithm change needed**.

## Verification

- Test is characterisation-only (always passes)
- One line change in `_ref_mealpy_firefly`, one line change in `REFERENCES` dict

## Test plan

- [ ] CI passes
- [ ] Manual: `pytest tests/test_reference_alignment.py -m reference -v` — confirms FFA row at ratios ~3×

🤖 Generated with [Claude Code](https://claude.com/claude-code)