### PR TITLE
Drop TabuSearch — no canonical continuous-domain reference (closes #163)

### DIFF
--- a/docs/EMBED.md
+++ b/docs/EMBED.md
@@ -40,7 +40,7 @@ document.addEventListener('DOMContentLoaded', function () {
   Python (PRIMA UOBYQA/NEWUOA/BOBYQA, NelderMead, Powell, LBFGSB,
   DifferentialEvolution, ParticleSwarm, SimulatedAnnealing,
   GeneticAlgorithm, RandomSearch, BayesianOpt, CMAEvolutionStrategy,
-  TabuSearch, FireflyAlgorithm, AntColonyOpt, EvolutionStrategy,
+  FireflyAlgorithm, AntColonyOpt, EvolutionStrategy,
   HillClimbing, HarmonySearch, Rechenberg, CoordinateDescent,
   PatternSearch).
 - **12 test surfaces** — Sphere, Rosenbrock, Ackley, Rastrigin,

--- a/docs/algorithms.html
+++ b/docs/algorithms.html
@@ -305,15 +305,6 @@
                 </td>
             </tr>
             <tr>
-                <td class="name"><a href="algorithms/tabu-search.html">TabuSearch</a></td>
-                <td class="desc">Local search with a tabu list that bans recently-visited moves to escape basins.</td>
-                <td class="links">
-                    <a href="algorithms/tabu-search.html">doc</a>
-                    <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L627">py</a>
-                    <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L637">js</a>
-                </td>
-            </tr>
-            <tr>
                 <td class="name"><a href="algorithms/firefly-algorithm.html">FireflyAlgorithm</a></td>
                 <td class="desc">Fireflies attracted toward brighter neighbours; brightness inversely tied to <em>f</em>.</td>
                 <td class="links">

--- a/docs/applications/battery-dispatch.html
+++ b/docs/applications/battery-dispatch.html
@@ -156,7 +156,6 @@
           <!-- BayesianOpt omitted: scales poorly past ~5-D; this is 24-D. -->
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/bowling.html
+++ b/docs/applications/bowling.html
@@ -208,7 +208,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/brachistochrone.html
+++ b/docs/applications/brachistochrone.html
@@ -157,7 +157,6 @@
           <!-- BayesianOpt omitted: scales poorly past ~5-D; this is 8-D. -->
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/bridge-truss.html
+++ b/docs/applications/bridge-truss.html
@@ -151,7 +151,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/cart-pole.html
+++ b/docs/applications/cart-pole.html
@@ -170,7 +170,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/curling.html
+++ b/docs/applications/curling.html
@@ -166,7 +166,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/free-kick.html
+++ b/docs/applications/free-kick.html
@@ -159,7 +159,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/hvac-nyc.html
+++ b/docs/applications/hvac-nyc.html
@@ -156,7 +156,6 @@
           <!-- BayesianOpt omitted: scales poorly past ~5-D; this is 16-D. -->
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/mini-golf.html
+++ b/docs/applications/mini-golf.html
@@ -145,7 +145,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/pool.html
+++ b/docs/applications/pool.html
@@ -159,7 +159,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/reactor-tprofile.html
+++ b/docs/applications/reactor-tprofile.html
@@ -160,7 +160,6 @@
           <!-- BayesianOpt omitted: scales poorly past ~5-D; this is 10-D. -->
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/robot-arm.html
+++ b/docs/applications/robot-arm.html
@@ -154,7 +154,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/rocket-landing.html
+++ b/docs/applications/rocket-landing.html
@@ -159,7 +159,6 @@
           <!-- BayesianOpt omitted: scales poorly past ~5-D; this is 12-D. -->
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -159,7 +159,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/trebuchet.html
+++ b/docs/applications/trebuchet.html
@@ -167,7 +167,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/welded-beam.html
+++ b/docs/applications/welded-beam.html
@@ -169,7 +169,6 @@
           <option value="BayesianOpt">Bayesian Optimization</option>
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/applications/wind-farm.html
+++ b/docs/applications/wind-farm.html
@@ -165,7 +165,6 @@
           <!-- BayesianOpt omitted: scales poorly past ~5-D; this is 16-D. -->
           <option value="FireflyAlgorithm">Firefly Algorithm</option>
           <option value="AntColonyOpt">Ant Colony</option>
-          <option value="TabuSearch">Tabu Search</option>
           <option value="RandomSearch">Random Search</option>
           <option value="Rechenberg">Rechenberg (1+1)-ES</option>
         </optgroup>

--- a/docs/debug-modules.html
+++ b/docs/debug-modules.html
@@ -91,7 +91,7 @@
                 'NelderMead', 'Powell', 'LBFGSB',
                 'DifferentialEvolution', 'ParticleSwarm', 'SimulatedAnnealing',
                 'GeneticAlgorithm', 'RandomSearch', 'BayesianOpt', 'CMAEvolutionStrategy',
-                'TabuSearch', 'FireflyAlgorithm', 'AntColonyOpt', 'HarmonySearch', 'EvolutionStrategy',
+                'FireflyAlgorithm', 'AntColonyOpt', 'HarmonySearch', 'EvolutionStrategy',
                 'Rechenberg', 'CoordinateDescent', 'PatternSearch', 'HillClimbing'
             ];
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -254,7 +254,7 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                     <code>'EvolutionStrategy'</code>, <code>'GeneticAlgorithm'</code>, <code>'BayesianOpt'</code>,
                     <code>'RandomSearch'</code>, <code>'Rechenberg'</code>, <code>'HillClimbing'</code>,
                     <code>'CoordinateDescent'</code>, <code>'PatternSearch'</code>, <code>'SimulatedAnnealing'</code>,
-                    <code>'TabuSearch'</code>, <code>'HarmonySearch'</code>, <code>'FireflyAlgorithm'</code>,
+                    <code>'HarmonySearch'</code>, <code>'FireflyAlgorithm'</code>,
                     <code>'AntColonyOpt'</code>
                 </div>
             </details>
@@ -405,14 +405,6 @@ print(f"Solution: {result.x}")  # [2.0, 3.0]</code></pre>
                         <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L408" target="_blank">evolutionary-algorithms.js#L408</a></td>
                         <td><a href="https://arxiv.org/abs/1604.00772" target="_blank">Hansen (2016)</a></td>
                         <td><a href="algorithms/cma-evolution-strategy.html">View →</a></td>
-                    </tr>
-                    <tr>
-                        <td><code>TabuSearch</code></td>
-                        <td>Metaheuristic</td>
-                        <td><a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L630" target="_blank">evolutionary_algorithms.py#L630</a></td>
-                        <td><a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js#L463" target="_blank">evolutionary-algorithms.js#L463</a></td>
-                        <td><a href="https://doi.org/10.1287/ijoc.1.3.190" target="_blank">Glover (1989)</a></td>
-                        <td><a href="algorithms/tabu-search.html">View →</a></td>
                     </tr>
                     <tr>
                         <td><code>FireflyAlgorithm</code></td>

--- a/docs/js/modules/evolutionary-algorithms.js
+++ b/docs/js/modules/evolutionary-algorithms.js
@@ -998,68 +998,6 @@ class CMAEvolutionStrategy extends Optimizer {
     }
 }
 
-// Tabu Search
-class TabuSearch extends Optimizer {
-    constructor(objective, nTrials, nDim) {
-        super(objective, nTrials, nDim);
-        this.name = 'TabuSearch';
-        this.tabuList = [];
-        this.tabuTenure = Math.min(20, Math.max(5, this.nDim));
-    }
-
-    optimize() {
-        let x = Array(this.nDim).fill(0).map(() => Math.random());
-        let fx = this.evaluate(x);
-
-        while (this.evaluations < this.nTrials) {
-            let bestNeighbor = null;
-            let bestNeighborFx = Infinity;
-
-            // Generate multiple neighbors
-            for (let i = 0; i < Math.min(20, this.nTrials - this.evaluations); i++) {
-                const neighbor = x.map(xi =>
-                    MathUtils.clip(xi + (Math.random() - 0.5) * 0.15, 0, 1)
-                );
-
-                // Check if tabu
-                const isTabu = this.tabuList.some(tabu =>
-                    MathUtils.norm(MathUtils.subtract(neighbor, tabu)) < 0.05
-                );
-
-                if (!isTabu) {
-                    const neighborFx = this.evaluate(neighbor);
-                    if (neighborFx < bestNeighborFx) {
-                        bestNeighbor = neighbor;
-                        bestNeighborFx = neighborFx;
-                    }
-                }
-            }
-
-            if (bestNeighbor) {
-                // Add current solution to tabu list
-                this.tabuList.push([...x]);
-                if (this.tabuList.length > this.tabuTenure) {
-                    this.tabuList.shift();
-                }
-
-                x = bestNeighbor;
-                fx = bestNeighborFx;
-            } else {
-                // If all neighbors are tabu, clear tabu list
-                this.tabuList = [];
-            }
-        }
-
-        return {
-            bestValue: this.bestValue,
-            bestX: this.bestX,
-            evaluations: this.evaluations,
-            success: true,
-            path: this.trackPath ? this.path : null
-        };
-    }
-}
-
 // Firefly Algorithm
 class FireflyAlgorithm extends Optimizer {
     constructor(objective, nTrials, nDim) {
@@ -1362,7 +1300,7 @@ if (typeof module !== 'undefined' && module.exports) {
     // Node.js environment
     module.exports = {
         DifferentialEvolution, ParticleSwarm, SimulatedAnnealing, GeneticAlgorithm, RandomSearch,
-        BayesianOpt, CMAEvolutionStrategy, TabuSearch, FireflyAlgorithm, AntColonyOpt,
+        BayesianOpt, CMAEvolutionStrategy, FireflyAlgorithm, AntColonyOpt,
         HarmonySearch, EvolutionStrategy
     };
 } else {
@@ -1374,7 +1312,6 @@ if (typeof module !== 'undefined' && module.exports) {
     window.RandomSearch = RandomSearch;
     window.BayesianOpt = BayesianOpt;
     window.CMAEvolutionStrategy = CMAEvolutionStrategy;
-    window.TabuSearch = TabuSearch;
     window.FireflyAlgorithm = FireflyAlgorithm;
     window.AntColonyOpt = AntColonyOpt;
     window.HarmonySearch = HarmonySearch;

--- a/docs/js/modules/index.js
+++ b/docs/js/modules/index.js
@@ -12,7 +12,7 @@ if (typeof module !== 'undefined' && module.exports) {
     const { PRIMA_UOBYQA, PRIMA_NEWUOA, PRIMA_BOBYQA } = require('./prima-algorithms.js');
     const { NelderMead, Powell, LBFGSB } = require('./scipy-algorithms.js');
     const { DifferentialEvolution, ParticleSwarm, SimulatedAnnealing, GeneticAlgorithm, RandomSearch,
-            BayesianOpt, CMAEvolutionStrategy, TabuSearch, FireflyAlgorithm, AntColonyOpt,
+            BayesianOpt, CMAEvolutionStrategy, FireflyAlgorithm, AntColonyOpt,
             HarmonySearch, EvolutionStrategy } = require('./evolutionary-algorithms.js');
     const { Rechenberg, AdaptiveRandomSearch, CoordinateDescent, PatternSearch, HillClimbing } = require('./search-algorithms.js');
 
@@ -40,7 +40,6 @@ if (typeof module !== 'undefined' && module.exports) {
         RandomSearch,
         BayesianOpt,
         CMAEvolutionStrategy,
-        TabuSearch,
         FireflyAlgorithm,
         AntColonyOpt,
         HarmonySearch,
@@ -68,7 +67,6 @@ if (typeof module !== 'undefined' && module.exports) {
             'RandomSearch': RandomSearch,
             'BayesianOpt': BayesianOpt,
             'CMAEvolutionStrategy': CMAEvolutionStrategy,
-            'TabuSearch': TabuSearch,
             'FireflyAlgorithm': FireflyAlgorithm,
             'AntColonyOpt': AntColonyOpt,
             'HarmonySearch': HarmonySearch,
@@ -103,7 +101,6 @@ if (typeof module !== 'undefined' && module.exports) {
         RandomSearch: window.RandomSearch,
         BayesianOpt: window.BayesianOpt,
         CMAEvolutionStrategy: window.CMAEvolutionStrategy,
-        TabuSearch: window.TabuSearch,
         FireflyAlgorithm: window.FireflyAlgorithm,
         AntColonyOpt: window.AntColonyOpt,
         HarmonySearch: window.HarmonySearch,

--- a/docs/js/modules/optimizer-factory.js
+++ b/docs/js/modules/optimizer-factory.js
@@ -37,7 +37,6 @@ const OptimizerFactory = {
             'RandomSearch': window.RandomSearch,
             'BayesianOpt': window.BayesianOpt,
             'CMAEvolutionStrategy': window.CMAEvolutionStrategy,
-            'TabuSearch': window.TabuSearch,
             'FireflyAlgorithm': window.FireflyAlgorithm,
             'AntColonyOpt': window.AntColonyOpt,
             'HarmonySearch': window.HarmonySearch,
@@ -79,7 +78,7 @@ const OptimizerFactory = {
             // Evolutionary algorithms
             'DifferentialEvolution', 'ParticleSwarm', 'SimulatedAnnealing',
             'GeneticAlgorithm', 'RandomSearch', 'BayesianOpt', 'CMAEvolutionStrategy',
-            'TabuSearch', 'FireflyAlgorithm', 'AntColonyOpt', 'HarmonySearch', 'EvolutionStrategy',
+            'FireflyAlgorithm', 'AntColonyOpt', 'HarmonySearch', 'EvolutionStrategy',
             // Search algorithms
             'Rechenberg', 'CoordinateDescent', 'PatternSearch', 'HillClimbing'
         ];

--- a/docs/js/optimizers.js
+++ b/docs/js/optimizers.js
@@ -3118,7 +3118,7 @@ const OptimizerFactory = {
             'PRIMA_UOBYQA', 'PRIMA_NEWUOA', 'SciPy_BFGS', 'SciPy_Powell', 'SciPy_NelderMead',
             'DifferentialEvolution', 'ParticleSwarm', 'SimulatedAnnealing', 'GeneticAlgorithm',
             'RandomSearch', 'BayesianOpt', 'CMAEvolutionStrategy', 'Rechenberg',
-            'CoordinateDescent', 'PatternSearch', 'HillClimbing', 'TabuSearch', 'FireflyAlgorithm',
+            'CoordinateDescent', 'PatternSearch', 'HillClimbing', 'FireflyAlgorithm',
             'AntColonyOpt', 'HarmonySearch', 'EvolutionStrategy'
         ];
     }

--- a/docs/js_algorithm_test.js
+++ b/docs/js_algorithm_test.js
@@ -8,7 +8,7 @@ const expectedAlgorithms = [
     // Evolutionary algorithms
     'DifferentialEvolution', 'ParticleSwarm', 'SimulatedAnnealing',
     'GeneticAlgorithm', 'RandomSearch', 'BayesianOpt', 'CMAEvolutionStrategy',
-    'TabuSearch', 'FireflyAlgorithm', 'AntColonyOpt', 'HarmonySearch', 'EvolutionStrategy',
+    'FireflyAlgorithm', 'AntColonyOpt', 'HarmonySearch', 'EvolutionStrategy',
     // Search algorithms
     'Rechenberg', 'CoordinateDescent', 'PatternSearch', 'HillClimbing'
 ];

--- a/docs/scipy-interface.md
+++ b/docs/scipy-interface.md
@@ -45,7 +45,7 @@ cube_minimize(
   - `'CMAEvolutionStrategy'`, `'EvolutionStrategy'`, `'GeneticAlgorithm'`
   - `'BayesianOpt'`, `'RandomSearch'`, `'Rechenberg'`
   - `'HillClimbing'`, `'CoordinateDescent'`, `'PatternSearch'`
-  - `'SimulatedAnnealing'`, `'TabuSearch'`, `'HarmonySearch'`
+  - `'SimulatedAnnealing'`, `'HarmonySearch'`
   - `'FireflyAlgorithm'`, `'AntColonyOpt'`, `'Powell'`, `'LBFGSB'`
 - **`bounds`**: Bounds specification (see below)
 - **`options`**: Dictionary with `'maxiter'` for function evaluation limit

--- a/docs/test-modular.html
+++ b/docs/test-modular.html
@@ -102,7 +102,7 @@
             // Evolutionary algorithms
             'DifferentialEvolution', 'ParticleSwarm', 'SimulatedAnnealing',
             'GeneticAlgorithm', 'RandomSearch', 'BayesianOpt', 'CMAEvolutionStrategy',
-            'TabuSearch', 'FireflyAlgorithm', 'AntColonyOpt', 'HarmonySearch', 'EvolutionStrategy',
+            'FireflyAlgorithm', 'AntColonyOpt', 'HarmonySearch', 'EvolutionStrategy',
             // Search algorithms
             'Rechenberg', 'CoordinateDescent', 'PatternSearch', 'HillClimbing'
         ];

--- a/humpday/optimizers/alloptimizers.py
+++ b/humpday/optimizers/alloptimizers.py
@@ -17,7 +17,6 @@ from .evolutionary_algorithms import (
     ParticleSwarm,
     RandomSearch,
     SimulatedAnnealing,
-    TabuSearch,
 )
 from .prima_algorithms import PRIMA_BOBYQA, PRIMA_NEWUOA, PRIMA_UOBYQA
 from .scipy_algorithms import LBFGSB, NelderMead, Powell
@@ -28,7 +27,9 @@ from .search_algorithms import (
     Rechenberg,
 )
 
-# Define PURE_OPTIMIZERS for backward compatibility - all 22 algorithms
+# Define PURE_OPTIMIZERS for backward compatibility - all 21 algorithms.
+# TabuSearch was removed in this commit — no canonical continuous-domain
+# reference exists for it, so it lived purely as a humpday-ism.
 PURE_OPTIMIZERS = {
     # PRIMA algorithms
     "PRIMA_UOBYQA": PRIMA_UOBYQA,
@@ -46,7 +47,6 @@ PURE_OPTIMIZERS = {
     "RandomSearch": RandomSearch,
     "BayesianOpt": BayesianOpt,
     "CMAEvolutionStrategy": CMAEvolutionStrategy,
-    "TabuSearch": TabuSearch,
     "FireflyAlgorithm": FireflyAlgorithm,
     "AntColonyOpt": AntColonyOpt,
     "EvolutionStrategy": EvolutionStrategy,
@@ -102,7 +102,6 @@ genetic_algorithm = create_optimizer_function(GeneticAlgorithm)
 random_search = create_optimizer_function(RandomSearch)
 bayesian_opt = create_optimizer_function(BayesianOpt)
 cma_evolution_strategy = create_optimizer_function(CMAEvolutionStrategy)
-tabu_search = create_optimizer_function(TabuSearch)
 firefly_algorithm = create_optimizer_function(FireflyAlgorithm)
 ant_colony_opt = create_optimizer_function(AntColonyOpt)
 evolution_strategy = create_optimizer_function(EvolutionStrategy)
@@ -163,7 +162,6 @@ def suggest_pure(n_dim, n_trials):
             "GeneticAlgorithm",
             "PatternSearch",
             "EvolutionStrategy",
-            "TabuSearch",
         ]
     elif n_dim <= 50:
         return [
@@ -192,7 +190,6 @@ def suggest_pure(n_dim, n_trials):
             "HillClimbing",
             "CoordinateDescent",
             "SimulatedAnnealing",
-            "TabuSearch",
             "EvolutionStrategy",
             "GeneticAlgorithm",
         ]
@@ -219,7 +216,6 @@ __all__ = [
     "random_search",
     "bayesian_opt",
     "cma_evolution_strategy",
-    "tabu_search",
     "firefly_algorithm",
     "ant_colony_opt",
     "evolution_strategy",

--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -919,55 +919,6 @@ class CMAEvolutionStrategy(BaseOptimizer):
         return self.best_value, self.best_x
 
 
-class TabuSearch(BaseOptimizer):
-    """Tabu Search algorithm.
-
-    Pure-Python via the `humpday._array` shim — no direct numpy use.
-    Maintains a small FIFO list of recently-visited points and rejects
-    neighbours that are within 0.05 (L2) of any of them.
-    """
-
-    def optimize(self):
-        x = _A.random_uniform(self.n_dim)
-        f = self.evaluate(x)
-
-        tabu_list = []
-        tabu_tenure = 5
-        step_size = 0.1
-
-        while self.evaluations < self.n_trials:
-            best_neighbor = None
-            best_neighbor_f = float("inf")
-
-            # Generate neighbours and accept the best non-tabu one.
-            for _ in range(min(10, self.n_trials - self.evaluations)):
-                if self.evaluations >= self.n_trials:
-                    break
-
-                # Random neighbour with sigma = step_size.
-                neighbor = _A.clip(x + step_size * _A.random_normal(self.n_dim), 0, 1)
-
-                # Check tabu: reject if too close to any recently-visited point.
-                is_tabu = any(_A.norm(neighbor - tabu_x) < 0.05 for tabu_x in tabu_list)
-
-                if not is_tabu:
-                    neighbor_f = self.evaluate(neighbor)
-                    if neighbor_f < best_neighbor_f:
-                        best_neighbor = neighbor
-                        best_neighbor_f = neighbor_f
-
-            if best_neighbor is not None:
-                x = best_neighbor
-                f = best_neighbor_f
-
-                # Update tabu list (FIFO).
-                tabu_list.append(x.copy())
-                if len(tabu_list) > tabu_tenure:
-                    tabu_list.pop(0)
-
-        return self.best_value, self.best_x
-
-
 class FireflyAlgorithm(BaseOptimizer):
     """Firefly Algorithm.
 

--- a/tests/test_complete_validation.py
+++ b/tests/test_complete_validation.py
@@ -469,7 +469,7 @@ class TestOptimizerConsistency:
     """Test that our optimizers work correctly and consistently."""
 
     def test_all_optimizers_functional(self):
-        """Test that all 22 optimizers work on a simple problem."""
+        """Test that all 21 optimizers work on a simple problem."""
         from humpday.optimizers.alloptimizers import PURE_OPTIMIZERS
 
         # Simple quadratic with known minimum
@@ -497,7 +497,7 @@ class TestOptimizerConsistency:
                 failed_optimizers.append((name, str(e)))
 
         # Report results
-        print(f"✅ {len(successful_optimizers)}/22 optimizers working")
+        print(f"✅ {len(successful_optimizers)}/21 optimizers working")
         for name in failed_optimizers:
             print(f"❌ {name[0]}: {name[1]}")
 

--- a/tests/test_comprehensive_coverage.py
+++ b/tests/test_comprehensive_coverage.py
@@ -194,7 +194,6 @@ class TestComprehensiveCoverage:
             GeneticAlgorithm,
             HarmonySearch,
             PatternSearch,
-            TabuSearch,
         )
 
         def edge_objective(x):
@@ -205,7 +204,6 @@ class TestComprehensiveCoverage:
             PatternSearch,
             HarmonySearch,
             FireflyAlgorithm,
-            TabuSearch,
             GeneticAlgorithm,
         ]
 

--- a/tests/test_core_coverage.py
+++ b/tests/test_core_coverage.py
@@ -100,7 +100,6 @@ class TestOptimizersCoverage:
             HarmonySearch,
             HillClimbing,
             SimulatedAnnealing,
-            TabuSearch,
         )
 
         def objective(x):
@@ -112,7 +111,6 @@ class TestOptimizersCoverage:
             SimulatedAnnealing,
             HarmonySearch,
             FireflyAlgorithm,
-            TabuSearch,
         ]
 
         for alg_class in algorithms:

--- a/tests/test_implementation_validation.py
+++ b/tests/test_implementation_validation.py
@@ -148,15 +148,15 @@ class TestOptimizerImplementations:
     """Test optimizer implementations."""
 
     def test_all_optimizers_importable(self):
-        """Test that all 22 optimizers can be imported and instantiated."""
+        """Test that all 21 optimizers can be imported and instantiated."""
         from humpday.optimizers.alloptimizers import PURE_OPTIMIZERS
 
         # Simple test objective
         def test_obj(x):
             return np.sum(np.asarray(x) ** 2)
 
-        assert len(PURE_OPTIMIZERS) == 22, (
-            f"Expected 22 optimizers, got {len(PURE_OPTIMIZERS)}"
+        assert len(PURE_OPTIMIZERS) == 21, (
+            f"Expected 21 optimizers, got {len(PURE_OPTIMIZERS)}"
         )
 
         for name, optimizer_class in PURE_OPTIMIZERS.items():

--- a/tests/test_js_parity.py
+++ b/tests/test_js_parity.py
@@ -64,7 +64,6 @@ WEAK_ON_SMALL_BUDGET = {
     "RandomSearch",
     "HillClimbing",
     "AntColonyOpt",
-    "TabuSearch",
     "FireflyAlgorithm",
     "HarmonySearch",
     "Rechenberg",
@@ -74,7 +73,7 @@ WEAK_ON_SMALL_BUDGET = {
     "CoordinateDescent",
 }
 
-# All 22 algorithms (the keys of PURE_OPTIMIZERS). Each algorithm
+# All 21 algorithms (the keys of PURE_OPTIMIZERS). Each algorithm
 # spawns one Node subprocess, so the sweep runs in seconds, not minutes.
 PARITY_ALGORITHMS = list(PURE_OPTIMIZERS.keys())
 
@@ -241,7 +240,6 @@ KNOWN_DIVERGENT_PORTS = {
     "Powell",
     "BayesianOpt",
     "AntColonyOpt",
-    "TabuSearch",
     "HillClimbing",
 }
 

--- a/tests/test_missing_lines_coverage.py
+++ b/tests/test_missing_lines_coverage.py
@@ -201,17 +201,6 @@ class TestMissingLinesCoverage:
         result = optimizer.optimize()
         assert len(result) == 2
 
-    def test_tabu_search_tabu_conditions(self):
-        """Test TabuSearch tabu list conditions (line 814, 836)."""
-        from humpday.optimizers.alloptimizers import TabuSearch
-
-        def tabu_objective(x):
-            return sum((xi - 0.25) ** 2 for xi in x)
-
-        optimizer = TabuSearch(tabu_objective, n_trials=25, n_dim=2)
-        result = optimizer.optimize()
-        assert len(result) == 2
-
     def test_genetic_algorithm_selection_conditions(self):
         """Test GeneticAlgorithm selection conditions (line 896)."""
         from humpday.optimizers.alloptimizers import GeneticAlgorithm

--- a/tests/test_ported_algorithms.py
+++ b/tests/test_ported_algorithms.py
@@ -36,7 +36,6 @@ PORTED = [
     ("evolutionary_algorithms", "HillClimbing"),
     ("evolutionary_algorithms", "SimulatedAnnealing"),
     ("evolutionary_algorithms", "HarmonySearch"),
-    ("evolutionary_algorithms", "TabuSearch"),
     ("evolutionary_algorithms", "FireflyAlgorithm"),
     ("evolutionary_algorithms", "ParticleSwarm"),
     ("evolutionary_algorithms", "DifferentialEvolution"),
@@ -96,7 +95,7 @@ def test_pure_backend_works_for_ported_algorithms(tmp_path):
 
         from humpday.optimizers.evolutionary_algorithms import (
             RandomSearch, HillClimbing, SimulatedAnnealing, HarmonySearch,
-            TabuSearch, FireflyAlgorithm,
+            FireflyAlgorithm,
             ParticleSwarm, DifferentialEvolution, GeneticAlgorithm,
             EvolutionStrategy,
             AntColonyOpt, CMAEvolutionStrategy, BayesianOpt,
@@ -115,7 +114,7 @@ def test_pure_backend_works_for_ported_algorithms(tmp_path):
         results = {}
         ALGORITHMS = [
             RandomSearch, HillClimbing, SimulatedAnnealing, HarmonySearch,
-            TabuSearch, FireflyAlgorithm,
+            FireflyAlgorithm,
             ParticleSwarm, DifferentialEvolution, GeneticAlgorithm,
             EvolutionStrategy,
             AntColonyOpt, CMAEvolutionStrategy, BayesianOpt,


### PR DESCRIPTION
## Summary

TabuSearch (Glover 1989) is a fundamentally discrete-space metaheuristic. Our continuous adaptation was never anchored to a specific reference implementation and couldn't be aligned with mealpy or any other 3rd-party SOTA port. Per the library intent — faithful ports of reference algorithms, no humpday-isms — dropping the algorithm is better than shipping a vague characterization.

- Removes TabuSearch from Python: `alloptimizers`, `evolutionary_algorithms`
- Removes from JS: modules/evolutionary-algorithms, modules/index, modules/optimizer-factory, legacy optimizers.js
- Removes from tests: parity, validation, ported algorithms, missing-lines coverage, complete validation, comprehensive coverage
- Removes from docs: `algorithms.html` row, `index.html` row/list, all 17 application dropdowns, `scipy-interface.md`, `EMBED.md`, `debug-modules.html`, `test-modular.html`, `js_algorithm_test.js`

Catalogue is now 21 algorithms.

Closes #163.

## Test plan

- [x] `pytest tests/` → 321 passed (was 324 — 3 TabuSearch-specific tests removed)
- [x] `pytest tests/test_js_parity.py` → 21 passed (was 22)
- [x] `ruff format` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)