### PR TITLE
PRIMA UOBYQA: replace furthest-from-kopt instead of worst-FVAL (~7000× better on Rosenbrock)

### DIFF
--- a/humpday/optimizers/prima_algorithms.py
+++ b/humpday/optimizers/prima_algorithms.py
@@ -475,24 +475,35 @@ class PRIMA_UOBYQA(BaseOptimizer):
             predicted_reduction = -(_A.dot(g, d) + 0.5 * _A.dot(d, Hd))
             actual_reduction = FVAL[kopt] - fnew
 
-            # Update interpolation set: replace the worst-FVAL point only
-            # when the new point is genuinely better, otherwise leave the
-            # set alone. Full PRIMA UOBYQA does Lagrange-polynomial-based
-            # geometry maintenance (BIGLAG/BIGDEN); without that, the
-            # cleaner "furthest from new position" rule from NEWUOA
-            # actually hurts UOBYQA because UOBYQA's overdetermined
-            # regression is more sensitive to placing two nearly-identical
-            # points in the set than NEWUOA's min-Frobenius update is.
+            # Update interpolation set: replace the point furthest from
+            # the current best (geometric outlier). PRIMA UOBYQA's
+            # canonical rule (BIGLAG/BIGDEN) picks the point that
+            # maximises |L_t(x_new)| · ||XPT[t] - XPT[kopt]||^4 where
+            # L_t is the t-th Lagrange polynomial; that's the right
+            # geometry criterion but requires the full Lagrange basis.
+            # The simpler proxy "farthest from kopt" captures the
+            # dominant ||XPT[t] - XPT[kopt]||^4 factor and recovers most
+            # of the win: on 2-D Rosenbrock at n_trials=200, this rule
+            # gives 1.1e-14 vs 8.4e-11 for the previous worst-FVAL rule
+            # (~7000× improvement). The previous attempt at NEWUOA's
+            # "furthest from new position" rule hurt UOBYQA because two
+            # nearly-identical points can land in the overdetermined
+            # regression set; "farthest from kopt" avoids that by
+            # always evicting a geometric outlier.
+            new_pos = xnew - xbase
             if nused < npt:
-                XPT.append(xnew - xbase)
+                XPT.append(new_pos)
                 FVAL.append(fnew)
                 nused += 1
             else:
                 candidates = [i for i in range(nused) if i != kopt]
-                if candidates and fnew < max(FVAL[i] for i in candidates):
-                    worst_idx = max(candidates, key=lambda i: FVAL[i])
-                    XPT[worst_idx] = xnew - xbase
-                    FVAL[worst_idx] = fnew
+                if candidates:
+                    idx = max(
+                        candidates,
+                        key=lambda i: float(_A.norm(XPT[i] - XPT[kopt])),
+                    )
+                    XPT[idx] = new_pos
+                    FVAL[idx] = fnew
 
             kopt = min(range(nused), key=FVAL.__getitem__)
 


### PR DESCRIPTION
## Summary

PRIMA UOBYQA's canonical BIGLAG/BIGDEN rule picks the point t that maximises \`|L_t(x_new)| · ||XPT[t] - XPT[kopt]||^4\` where L_t is the t-th Lagrange polynomial — the right geometry criterion but needs the full Lagrange basis.

The simpler proxy **"farthest from kopt"** captures the dominant \`||XPT[t] - XPT[kopt]||^4\` factor and recovers most of the win.

## Benchmark — n_trials=200, n_dim=2 (8 seeds, median)

| rule | rosenbrock | change |
|---|------:|------:|
| worst-FVAL (was) | 8.401e-11 | — |
| **farthest from kopt (this PR)** | **1.147e-14** | ~7000× better |
| biglag_proxy (d⁴ / d_new+1) | 3.366e-13 | ~250× better |
| worst-FVAL-then-biglag | 4.533e-12 | ~20× better |

## Why not NEWUOA's "farthest from new_pos" rule

Tried that in #196 (the Steihaug-Toint PR) and it stalled UOBYQA — two nearly-identical points landed in the overdetermined regression set and the model became degenerate. "Farthest from kopt" always evicts a geometric outlier, avoiding the clustering pathology.

## Why no acceptance check

The geometry rule already handles this implicitly — replacing an outlier with any new point improves conditioning even when the new point is bad-valued. (The previous "only swap if better than worst" guard was protecting against the same clustering pathology that the new rule prevents.)

Sphere/Ackley still hit machine precision floor at n_dim ∈ {2, 3, 5}.

## JS port

JS UOBYQA uses an entirely separate Lagrange-based update path (\`updateLagrangeInterpolationSet\` in \`docs/js/modules/prima-algorithms.js\`) and is left as a separate follow-up to bring JS in line with the new Python rule. That divergence is tracked in #78.

## Test plan

- [x] \`pytest tests/\` → 321 passed
- [x] \`pytest tests/test_js_parity.py\` → 21 passed
- [x] \`ruff format\` + \`ruff check\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)