### PR TITLE
Add GridSearch baseline algorithm

### DIFF
--- a/docs/js/modules/index.js
+++ b/docs/js/modules/index.js
@@ -14,7 +14,7 @@ if (typeof module !== 'undefined' && module.exports) {
     const { DifferentialEvolution, ParticleSwarm, SimulatedAnnealing, GeneticAlgorithm, RandomSearch,
             BayesianOpt, CMAEvolutionStrategy, FireflyAlgorithm, AntColonyOpt,
             HarmonySearch, EvolutionStrategy } = require('./evolutionary-algorithms.js');
-    const { Rechenberg, AdaptiveRandomSearch, CoordinateDescent, PatternSearch, HillClimbing } = require('./search-algorithms.js');
+    const { Rechenberg, AdaptiveRandomSearch, CoordinateDescent, PatternSearch, HillClimbing, GridSearch } = require('./search-algorithms.js');
 
     // Export everything
     module.exports = {
@@ -51,6 +51,7 @@ if (typeof module !== 'undefined' && module.exports) {
         CoordinateDescent,
         PatternSearch,
         HillClimbing,
+        GridSearch,
 
         // Algorithm registry for factory pattern
         algorithms: {
@@ -75,7 +76,8 @@ if (typeof module !== 'undefined' && module.exports) {
             'AdaptiveRandomSearch': AdaptiveRandomSearch,  // backwards-compat alias
             'CoordinateDescent': CoordinateDescent,
             'PatternSearch': PatternSearch,
-            'HillClimbing': HillClimbing
+            'HillClimbing': HillClimbing,
+            'GridSearch': GridSearch
         }
     };
 } else {
@@ -111,7 +113,8 @@ if (typeof module !== 'undefined' && module.exports) {
         AdaptiveRandomSearch: window.AdaptiveRandomSearch,  // backwards-compat alias
         CoordinateDescent: window.CoordinateDescent,
         PatternSearch: window.PatternSearch,
-        HillClimbing: window.HillClimbing
+        HillClimbing: window.HillClimbing,
+        GridSearch: window.GridSearch
     };
 
     // Factory function for creating optimizers by name

--- a/docs/js/modules/optimizer-factory.js
+++ b/docs/js/modules/optimizer-factory.js
@@ -47,7 +47,8 @@ const OptimizerFactory = {
             'AdaptiveRandomSearch': window.AdaptiveRandomSearch,  // backwards-compat alias
             'CoordinateDescent': window.CoordinateDescent,
             'PatternSearch': window.PatternSearch,
-            'HillClimbing': window.HillClimbing
+            'HillClimbing': window.HillClimbing,
+            'GridSearch': window.GridSearch
         };
 
         const AlgorithmClass = algorithmMap[algorithmName];
@@ -80,7 +81,7 @@ const OptimizerFactory = {
             'GeneticAlgorithm', 'RandomSearch', 'BayesianOpt', 'CMAEvolutionStrategy',
             'FireflyAlgorithm', 'AntColonyOpt', 'HarmonySearch', 'EvolutionStrategy',
             // Search algorithms
-            'Rechenberg', 'CoordinateDescent', 'PatternSearch', 'HillClimbing'
+            'Rechenberg', 'CoordinateDescent', 'PatternSearch', 'HillClimbing', 'GridSearch'
         ];
     },
 

--- a/docs/js/modules/search-algorithms.js
+++ b/docs/js/modules/search-algorithms.js
@@ -328,6 +328,42 @@ class HillClimbing extends Optimizer {
     }
 }
 
+// Regular-grid baseline. Like RandomSearch, this is included as a
+// baseline (regression check, contest sanity floor), not as a SOTA
+// algorithm. Grid size scales as `nPerAxis^nDim`; practically useful
+// for nDim <= 3.
+class GridSearch extends Optimizer {
+    constructor(objective, nTrials, nDim) {
+        super(objective, nTrials, nDim);
+        this.name = 'GridSearch';
+    }
+
+    optimize() {
+        const n = this.nDim;
+        const nPerAxis = Math.max(2, Math.round(Math.pow(this.nTrials, 1.0 / n)));
+        const indices = new Array(n).fill(0);
+        while (this.evaluations < this.nTrials) {
+            const x = indices.map(i => (i + 0.5) / nPerAxis);
+            this.evaluate(x);
+            let d = n - 1;
+            while (d >= 0) {
+                indices[d]++;
+                if (indices[d] < nPerAxis) break;
+                indices[d] = 0;
+                d--;
+            }
+            if (d < 0) break;
+        }
+        return {
+            bestValue: this.bestValue,
+            bestX: this.bestX,
+            evaluations: this.evaluations,
+            success: true,
+            path: this.trackPath ? this.path : null
+        };
+    }
+}
+
 // Export search algorithms
 if (typeof module !== 'undefined' && module.exports) {
     // Node.js environment
@@ -337,6 +373,7 @@ if (typeof module !== 'undefined' && module.exports) {
         CoordinateDescent,
         PatternSearch,
         HillClimbing,
+        GridSearch,
     };
 } else {
     // Browser environment
@@ -345,4 +382,5 @@ if (typeof module !== 'undefined' && module.exports) {
     window.CoordinateDescent = CoordinateDescent;
     window.PatternSearch = PatternSearch;
     window.HillClimbing = HillClimbing;
+    window.GridSearch = GridSearch;
 }

--- a/humpday/optimizers/alloptimizers.py
+++ b/humpday/optimizers/alloptimizers.py
@@ -23,6 +23,7 @@ from .scipy_algorithms import LBFGSB, NelderMead, Powell
 from .search_algorithms import (
     AdaptiveRandomSearch,  # noqa: F401 — backwards-compat alias for Rechenberg
     CoordinateDescent,
+    GridSearch,
     PatternSearch,
     Rechenberg,
 )
@@ -45,6 +46,7 @@ PURE_OPTIMIZERS = {
     "SimulatedAnnealing": SimulatedAnnealing,
     "GeneticAlgorithm": GeneticAlgorithm,
     "RandomSearch": RandomSearch,
+    "GridSearch": GridSearch,
     "BayesianOpt": BayesianOpt,
     "CMAEvolutionStrategy": CMAEvolutionStrategy,
     "FireflyAlgorithm": FireflyAlgorithm,

--- a/humpday/optimizers/search_algorithms.py
+++ b/humpday/optimizers/search_algorithms.py
@@ -265,3 +265,46 @@ class PatternSearch(BaseOptimizer):
                     f = f_trial
                     break  # don't try the other sign on this coord
         return x, f
+
+
+class GridSearch(BaseOptimizer):
+    """Regular-grid baseline.
+
+    Evaluates a uniform Cartesian grid over the unit cube `[0, 1]^n_dim`
+    with `n_per_axis = round(n_trials^(1/n_dim))` points per axis. Each
+    axis is split into equal-width bins; the evaluated point in each bin
+    is the bin centre `(i + 0.5) / n_per_axis`.
+
+    Like RandomSearch, this is included as a baseline (regression check,
+    contest sanity floor), not as a SOTA algorithm.
+
+    Note: grid size scales as `n_per_axis^n_dim`. For modest budgets and
+    `n_dim >= 5` the grid degenerates to fewer than 2 points per axis,
+    making the algorithm equivalent to evaluating a handful of corners.
+    Practically useful for `n_dim <= 3`.
+    """
+
+    def optimize(self):
+        n = self.n_dim
+        n_per_axis = max(2, int(round(self.n_trials ** (1.0 / n))))
+
+        # Lexicographic enumeration of indices across n axes, each in
+        # [0, n_per_axis). Bin-centred coordinates lie at (idx + 0.5) /
+        # n_per_axis, so they are evenly spread inside [0, 1] without
+        # ever sitting exactly on the bounds.
+        indices = [0] * n
+        while self.evaluations < self.n_trials:
+            x = _A.asarray([(idx + 0.5) / n_per_axis for idx in indices])
+            self.evaluate(x)
+            # Increment indices like an odometer; stop once all wrap.
+            d = n - 1
+            while d >= 0:
+                indices[d] += 1
+                if indices[d] < n_per_axis:
+                    break
+                indices[d] = 0
+                d -= 1
+            if d < 0:
+                break  # full grid exhausted
+
+        return self.best_value, self.best_x

--- a/tests/test_complete_validation.py
+++ b/tests/test_complete_validation.py
@@ -469,7 +469,7 @@ class TestOptimizerConsistency:
     """Test that our optimizers work correctly and consistently."""
 
     def test_all_optimizers_functional(self):
-        """Test that all 21 optimizers work on a simple problem."""
+        """Test that all 22 optimizers work on a simple problem."""
         from humpday.optimizers.alloptimizers import PURE_OPTIMIZERS
 
         # Simple quadratic with known minimum
@@ -497,7 +497,7 @@ class TestOptimizerConsistency:
                 failed_optimizers.append((name, str(e)))
 
         # Report results
-        print(f"✅ {len(successful_optimizers)}/21 optimizers working")
+        print(f"✅ {len(successful_optimizers)}/22 optimizers working")
         for name in failed_optimizers:
             print(f"❌ {name[0]}: {name[1]}")
 

--- a/tests/test_implementation_validation.py
+++ b/tests/test_implementation_validation.py
@@ -148,15 +148,15 @@ class TestOptimizerImplementations:
     """Test optimizer implementations."""
 
     def test_all_optimizers_importable(self):
-        """Test that all 21 optimizers can be imported and instantiated."""
+        """Test that all 22 optimizers can be imported and instantiated."""
         from humpday.optimizers.alloptimizers import PURE_OPTIMIZERS
 
         # Simple test objective
         def test_obj(x):
             return np.sum(np.asarray(x) ** 2)
 
-        assert len(PURE_OPTIMIZERS) == 21, (
-            f"Expected 21 optimizers, got {len(PURE_OPTIMIZERS)}"
+        assert len(PURE_OPTIMIZERS) == 22, (
+            f"Expected 22 optimizers, got {len(PURE_OPTIMIZERS)}"
         )
 
         for name, optimizer_class in PURE_OPTIMIZERS.items():

--- a/tests/test_js_parity.py
+++ b/tests/test_js_parity.py
@@ -62,6 +62,7 @@ WEAK_TOL = 1.0
 # Python and JS land in the same ballpark for these.
 WEAK_ON_SMALL_BUDGET = {
     "RandomSearch",
+    "GridSearch",
     "HillClimbing",
     "AntColonyOpt",
     "FireflyAlgorithm",

--- a/tests/test_reference_alignment.py
+++ b/tests/test_reference_alignment.py
@@ -332,6 +332,34 @@ def _ref_random_search(func, n_trials, n_dim, seed):
     return {"best_value": float(best), "evals": n_evals}
 
 
+def _ref_grid_search(func, n_trials, n_dim, seed):
+    """Regular-grid baseline — `n_per_axis^n_dim` evaluations on a
+    uniform Cartesian grid with bin-centred coordinates. Like
+    `_ref_random_search`, this is included as a sanity floor and is
+    deterministic in `n_trials`/`n_dim` (the `seed` is unused)."""
+    n_per_axis = max(2, round(n_trials ** (1.0 / n_dim)))
+    indices = [0] * n_dim
+    best = float("inf")
+    n_evals = 0
+    while n_evals < n_trials:
+        x = [(i + 0.5) / n_per_axis for i in indices]
+        v = func(x)
+        n_evals += 1
+        if v < best:
+            best = v
+        d = n_dim - 1
+        while d >= 0:
+            indices[d] += 1
+            if indices[d] < n_per_axis:
+                break
+            indices[d] = 0
+            d -= 1
+        if d < 0:
+            break
+    _ = seed
+    return {"best_value": float(best), "evals": n_evals}
+
+
 def _ref_oneplusone_es_decay(func, n_trials, n_dim, seed):
     """(1+1)-ES with a geometric sigma decay schedule — the natural
     reference for HillClimbing. Starts at sigma=0.1 and decays so the
@@ -603,6 +631,7 @@ REFERENCES = {
     "EvolutionStrategy": ("mealpy ES", _ref_mealpy_es, ["mealpy", "numpy"]),
     "AntColonyOpt": ("mealpy ACOR", _ref_mealpy_acor, ["mealpy", "numpy"]),
     "RandomSearch": ("uniform-sample baseline", _ref_random_search, []),
+    "GridSearch": ("regular grid baseline", _ref_grid_search, []),
     "HillClimbing": (
         "(1+1)-ES sigma-decay schedule",
         _ref_oneplusone_es_decay,


### PR DESCRIPTION
## Summary

Regular-grid baseline: enumerates a uniform Cartesian grid over the unit cube \`[0, 1]^n_dim\` with \`n_per_axis = round(n_trials^(1/n_dim))\` points per axis, bin-centred coordinates.

Like \`RandomSearch\`, included as a sanity floor and regression check — **not a SOTA algorithm**.

\`\`\`python
from humpday.optimizers.alloptimizers import GridSearch
opt = GridSearch(lambda x: sum((v-.5)**2 for v in x), 100, 2)
print(opt.optimize())
# (0.005, [0.45, 0.45])
\`\`\`

Grid size scales as \`n_per_axis^n_dim\`. Practically useful for \`n_dim ≤ 3\`; at higher dims the grid degenerates to a handful of points per axis (essentially random sampling on a coarse lattice).

## Files

- \`humpday/optimizers/search_algorithms.py\` — \`GridSearch(BaseOptimizer)\`
- \`docs/js/modules/search-algorithms.js\` — JS mirror
- \`docs/js/modules/index.js\`, \`optimizer-factory.js\` — register
- \`humpday/optimizers/alloptimizers.py\` — register in \`PURE_OPTIMIZERS\`
- \`tests/test_js_parity.py\` — add to weak-on-small-budget set
- \`tests/test_implementation_validation.py\`, \`test_complete_validation.py\` — bump count 21 → 22
- \`tests/test_reference_alignment.py\` — \`_ref_grid_search\` reference adapter

## Test plan

- [x] \`pytest tests/\` → 322 passed
- [x] \`pytest tests/test_js_parity.py\` → 22 passed
- [x] \`ruff format\` + \`ruff check\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)