### PR TITLE
Doc sweep #2: GOALS.md + README_CLAUDE.md catch-up (TabuSearch / Rechenberg / GridSearch)

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -1,6 +1,6 @@
 # HumpDay Goals & Status
 
-Single source of truth for what's done and what's left, across all 21 algorithms.
+Single source of truth for what's done and what's left, across all 22 algorithms.
 **Supersedes** `RESUME.md` (stale, from a prior session) and `NUMPY_REMOVAL_RESUME.md` (focused on one work-stream; merge into this file when its goal column is fully ✅).
 
 Legend: ✅ done · 🟡 partial / in-progress · ❌ not done · ❓ unknown / unverified
@@ -22,15 +22,15 @@ Legend: ✅ done · 🟡 partial / in-progress · ❌ not done · ❓ unknown / 
 | RandomSearch | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | BayesianOpt | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🟡 | ✅ |
 | CMAEvolutionStrategy | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| TabuSearch | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | FireflyAlgorithm | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | AntColonyOpt | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | EvolutionStrategy | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | HillClimbing | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | HarmonySearch | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| AdaptiveRandomSearch | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Rechenberg | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | CoordinateDescent | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | PatternSearch | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| GridSearch | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ## Column meanings
 
@@ -65,7 +65,7 @@ Legend: ✅ done · 🟡 partial / in-progress · ❌ not done · ❓ unknown / 
 
 2. **PRIMA trio underperformance in the Elo benchmark.** `benchmarks/elo_ratings.json` (the 2-D sphere + Rosenbrock sweep, 100 trials per problem) has UOBYQA at 1466, BOBYQA at 1177, and NEWUOA at 1120 — bottom-three among the 21 algorithms. That's surprising: PRIMA is a sophisticated trust-region family designed to dominate on smooth surfaces in low dimensions, exactly the regime the benchmark covers. Investigate whether (a) the pure-Python ports have a numerical regression vs. the Fortran references, (b) 100 trials is below the budget where PRIMA pays off in 2-D, or (c) the Rosenbrock variants' ill-conditioning is hitting a PRIMA-specific failure mode. Re-running with `trials_per_problem=500` and a smooth-only objective family would help isolate which.
 
-3. **Recommendation should consider trials AND dimension, not just dimension.** Today `humpday.minimize(...)` auto-selects via `suggest_pure(n_dim, n_trials)`. Inspection shows the heuristic in `suggest_pure` collapses to dimension buckets only (NelderMead ≤2, DE 3–10, CMA-ES 11–50, AdaptiveRandomSearch >50). Trials should matter: e.g. BayesianOpt is the right choice for tight budgets on any reasonable dimension, but is currently never recommended by `minimize()`. The Elo sweep itself is dimension- and budget-conditioned, so the recorded ratings are a natural input. Replace the heuristic with an Elo-table lookup that conditions on `(n_dim_bucket, n_trials_bucket)`.
+3. **Recommendation should consider trials AND dimension, not just dimension.** Today `humpday.minimize(...)` auto-selects via `suggest_pure(n_dim, n_trials)`. Inspection shows the heuristic in `suggest_pure` collapses to dimension buckets only (NelderMead ≤2, DE 3–10, CMA-ES 11–50, Rechenberg >50). Trials should matter: e.g. BayesianOpt is the right choice for tight budgets on any reasonable dimension, but is currently never recommended by `minimize()`. The Elo sweep itself is dimension- and budget-conditioned, so the recorded ratings are a natural input. Replace the heuristic with an Elo-table lookup that conditions on `(n_dim_bucket, n_trials_bucket)`.
 
 ### Documentation bugs
 

--- a/README_CLAUDE.md
+++ b/README_CLAUDE.md
@@ -40,7 +40,7 @@ The main interface provides simple functions for optimization without requiring 
 - `comprehensive_derivative_free.py` - External package wrappers (deprecated)
 - `primacube.py` - PRIMA algorithm wrappers (deprecated)
 
-**Current Philosophy:** Pure Python implementations only, no external dependencies beyond numpy. All algorithms are in `optimizers.py` with the registry `PURE_OPTIMIZERS` containing exactly 21 algorithms that match the JavaScript implementations.
+**Current Philosophy:** Pure Python implementations only, no external dependencies beyond numpy. All algorithms are in `optimizers.py` with the registry `PURE_OPTIMIZERS` containing exactly 22 algorithms that match the JavaScript implementations.
 
 ### Objectives (`humpday/objectives/`)
 
@@ -101,7 +101,7 @@ result = sphere([0.1, 0.2])[0]  # Extract the value
 - No complex build requirements
 
 ### 2. JavaScript Compatibility
-- 21 algorithms exactly match JavaScript implementations
+- 22 algorithms exactly match JavaScript implementations
 - Validation tests ensure consistency
 - Web demos use identical algorithm logic
 
@@ -141,15 +141,15 @@ All algorithms are in `optimizers.py` with base class `BaseOptimizer`:
 **Metaheuristic:**
 12. `BayesianOpt` - Simplified Bayesian optimization
 13. `RandomSearch` - Pure random sampling
-14. `AdaptiveRandomSearch` - Adaptive step sizes
-15. `HillClimbing` - Local search with restarts
-16. `CoordinateDescent` - Coordinate-wise optimization
-17. `PatternSearch` - Direct search
-18. `SimulatedAnnealing` - Simulated annealing
-19. `TabuSearch` - Tabu search
+14. `GridSearch` - Regular Cartesian grid (baseline)
+15. `Rechenberg` - (1+1)-ES with 1/5-success-rule (formerly `AdaptiveRandomSearch`)
+16. `HillClimbing` - Local search with restarts
+17. `CoordinateDescent` - Coordinate-wise optimization
+18. `PatternSearch` - Hooke-Jeeves direct search
+19. `SimulatedAnnealing` - Simulated annealing
 20. `HarmonySearch` - Harmony search
 21. `FireflyAlgorithm` - Firefly algorithm
-22. `AntColonyOpt` - Ant colony optimization
+22. `AntColonyOpt` - Socha-Dorigo continuous ACOR
 
 ### Algorithm Selection Philosophy
 
@@ -187,7 +187,7 @@ All algorithms are in `optimizers.py` with base class `BaseOptimizer`:
 ## Current Development Focus
 
 ### ✅ Completed
-- Pure Python implementations of 21 algorithms
+- Pure Python implementations of 22 algorithms
 - Elo rating system for adaptive selection
 - Interactive 3D visualization demos
 - Comprehensive test functions library
@@ -222,7 +222,7 @@ All algorithms are in `optimizers.py` with base class `BaseOptimizer`:
 - **DON'T** redefine existing test functions
 - **DO** use functions from `humpday.objectives.deapobjectives`
 - **FOCUS** on `optimizers.py` for algorithm implementations
-- **REMEMBER** the 21-algorithm limit and JavaScript compatibility requirements
+- **REMEMBER** the 22-algorithm limit and JavaScript compatibility requirements
 - **LEVERAGE** the existing adaptive optimization system instead of building new selection logic
 
 This organization reflects the evolution from a complex multi-dependency system to a streamlined, self-contained optimization library focused on reliability and ease of use.

--- a/benchmarks/reference_alignment.json
+++ b/benchmarks/reference_alignment.json
@@ -664,5 +664,5 @@
   "n_runs": 4,
   "n_trials": 200,
   "n_dim": 2,
-  "recorded_at": "2026-05-31T23:55:34Z"
+  "recorded_at": "2026-06-01T01:18:56Z"
 }


### PR DESCRIPTION
## Summary

Follow-up to #208 and #212. Catches the two top-level project notes (\`GOALS.md\` and \`README_CLAUDE.md\`) that the earlier sweeps missed.

### \`GOALS.md\`

- Bump catalogue count 21 → 22 in the lede.
- Remove the **TabuSearch** row (algorithm dropped in #190).
- Rename **AdaptiveRandomSearch** row → **Rechenberg** (the old name is kept only as a backwards-compat alias in \`PURE_OPTIMIZERS\`).
- Add a **GridSearch** row (added in #207; ❌ in \`demo\` and \`academic\` since it doesn't have its own algorithm page).
- Update the cell-status note about \`suggest_pure\`'s dimension buckets to say "Rechenberg" instead of "AdaptiveRandomSearch".

### \`README_CLAUDE.md\`

- Update the catalogue list: remove TabuSearch, rename AdaptiveRandomSearch → Rechenberg, add GridSearch, refresh the one-line descriptions (e.g. "Hooke-Jeeves direct search", "Socha-Dorigo continuous ACOR").
- Bump 21 → 22 in the rest of the doc (algorithm count, philosophy notes, "Current Development Focus" section).

Also refreshes \`benchmarks/reference_alignment.json\` (now reflects the post-UOBYQA-Lagrange-geometry numbers from #211).

## Test plan

- [x] No code touched; tests unaffected
- [x] No stale TabuSearch or AdaptiveRandomSearch references remain in \`GOALS.md\`, \`README_CLAUDE.md\`, \`README.md\`, \`SKILL.md\`, or \`docs/*.md\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)