### PR TITLE
Algorithm pages: careful rewrite for 5 pages (CD / PS / Rechenberg / LBFGSB / UOBYQA)

### DIFF
--- a/docs/algorithms/adaptive-random-search.html
+++ b/docs/algorithms/adaptive-random-search.html
@@ -345,13 +345,13 @@
             </table>
 
             <div class="performance-notes">
-                <h3>Performance Characteristics</h3>
+                <h3>Performance characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Problems where pure random search works but can be improved</li>
-                    <li><strong>Dimensions:</strong> Scalable to high dimensions like random search</li>
-                    <li><strong>Function evaluations:</strong> More efficient than pure random search</li>
-                    <li><strong>Convergence:</strong> Better than O(1/√n) through adaptive learning</li>
-                    <li><strong>Robustness:</strong> Maintains random search robustness with added intelligence</li>
+                    <li><strong>Best for:</strong> Smooth basins where the 1/5 rule keeps &sigma; near the right exploration scale.</li>
+                    <li><strong>Worst for:</strong> Multimodal landscapes (Ackley). Rechenberg has no escape from a local basin; once trapped, it refines into the wrong optimum.</li>
+                    <li><strong>Step distribution:</strong> componentwise Gaussian. Each component of the offspring is drawn from <em>N(0, &sigma;<sup>2</sup>)</em>, so the step magnitude varies stochastically (mean &approx; &sigma;&middot;&radic;n with heavier tails). The previous HumpDay variant projected to a unit direction, which damped the stochastic spread; the current implementation matches the canonical (1+1)-ES.</li>
+                    <li><strong>Dimensions:</strong> Inexpensive per iteration; reasonable into the dozens.</li>
+                    <li><strong>Relative to a canonical (1+1)-ES 1/5-rule reference</strong> at <code>n_trials=200, n_dim=2</code>: algorithmically identical to the reference. Per-cell ratios drift with the seed (both implementations trap on Ackley about half the time at 4-seed samples). See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -245,8 +245,8 @@
     </nav>
     <div class="container">
         <div class="header">
-            <h1>Coordinate Descent (Custom)</h1>
-            <p>Alternating Single-Variable Optimization</p>
+            <h1>Coordinate Descent</h1>
+            <p>Greedy expansion per axis, with restart on multimodal landscapes</p>
         </div>
 
         <div class="content">
@@ -255,17 +255,16 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Coordinate Descent</strong> is a fundamental optimization algorithm that cyclically optimizes along individual coordinate directions. At each iteration, it minimizes the objective function with respect to one coordinate while keeping all others fixed. This simple approach is surprisingly effective for many problems and forms the basis for more sophisticated optimization methods.
+                <strong>Coordinate Descent</strong> minimises a black-box objective by sweeping one coordinate at a time. Each sweep tries a step of size <code>step</code> in the &plusmn; direction on each axis; on the first improving move, the algorithm <em>greedily expands</em> &mdash; it keeps stepping in the same direction with the same step size while the objective keeps improving. After a full sweep with no improvement the step is halved.
             </div>
 
             <div class="coordinate-note">
-                <h3>Coordinate-Wise Optimization</h3>
-                <p><strong>Coordinate descent alternates between variables systematically:</strong></p>
+                <h3>HumpDay's coordinate descent at a glance</h3>
                 <ul>
-                    <li><strong>One Variable at a Time:</strong> Optimize x₁, then x₂, then x₃, etc.</li>
-                    <li><strong>Cyclical Updates:</strong> Return to x₁ after reaching xₙ</li>
-                    <li><strong>Line Search:</strong> Exact or approximate minimization along each axis</li>
-                    <li><strong>Simplicity:</strong> Reduces n-dimensional to many 1-dimensional problems</li>
+                    <li><strong>Greedy expansion per axis:</strong> on first improvement at a coordinate, keep stepping in that direction with the same step until f stops improving.</li>
+                    <li><strong>Step halving:</strong> when a full coordinate sweep finds no improvement, halve the step.</li>
+                    <li><strong>Restart on multimodal landscapes:</strong> when <code>step &le; 1e-6</code> with <code>f &gt; 1e-8</code> the run is presumed trapped in a local basin and reinitialises from a random point. On smooth basins (sphere, Rosenbrock) the run exits naturally before the restart fires.</li>
+                    <li><strong>Initial step <code>0.1</code></strong>, floor <code>1e-12</code>, on the unit cube <code>[0, 1]<sup>n</sup></code>.</li>
                 </ul>
             </div>
             <div class="visualization-section">
@@ -299,10 +298,10 @@
                     <tr>
                         <td class="category">Algorithm Foundation</td>
                         <td>
-                            <strong>Classic Optimization Method</strong><br>
-                            Alternating minimization along coordinate axes<br>
-                            Gauss-Seidel style iterative updates<br>
-                            <em>Historical: Early numerical optimization (1950s+)</em>
+                            <strong>Coordinate descent (cyclic)</strong><br>
+                            One of the oldest derivative-free methods; predates the optimization literature.<br>
+                            HumpDay's variant uses Brent-style greedy expansion per axis (no inner line-search subroutine) and step halving on failed sweeps.<br>
+                            <em>Reference: Wright (2015), "Coordinate descent algorithms", Math. Programming 151(1)</em>
                         </td>
                         <td>
                             <a href="https://en.wikipedia.org/wiki/Coordinate_descent" target="_blank" class="link-button info">Wikipedia</a>
@@ -321,24 +320,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Implementation</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>Humpday Coordinate Descent</strong><br>
-                            Custom implementation with line search<br>
-                            Cyclical coordinate selection<br>
-                            <em>File: humpday/optimizers/search_algorithms.py</em>
+                            <strong>HumpDay <code>CoordinateDescent</code></strong><br>
+                            Cyclic sweeps, greedy expansion on the first improving axis step, halve step on failed sweeps, restart trigger on multimodal trapping.<br>
+                            Pure Python; no required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/search_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L90" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Pure JavaScript coordinate descent<br>
-                            Golden section search for line minimization<br>
-                            <em>Class: CoordinateDescent</em>
+                            <strong>Browser <code>CoordinateDescent</code></strong><br>
+                            Same algorithm as the Python port (greedy expansion + restart). Used in the contest and the in-browser visualizer.<br>
+                            <em>Class: <code>CoordinateDescent</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js" target="_blank" class="link-button javascript">JS Implementation</a>
@@ -348,13 +346,13 @@
             </table>
 
             <div class="performance-notes">
-                <h3>Performance Characteristics</h3>
+                <h3>Performance characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Separable problems, sparse optimization, large-scale problems</li>
-                    <li><strong>Dimensions:</strong> Excellent scalability to high dimensions</li>
-                    <li><strong>Function evaluations:</strong> Efficient, especially with exact line search</li>
-                    <li><strong>Convergence:</strong> Linear convergence on smooth, strongly convex problems</li>
-                    <li><strong>Robustness:</strong> Simple, stable, handles non-smooth functions reasonably</li>
+                    <li><strong>Best for:</strong> Smooth, near-axis-aligned objectives where greedy expansion gets traction.</li>
+                    <li><strong>Worst for:</strong> Curved valleys and highly multimodal landscapes &mdash; coordinate moves zigzag down a curved valley (Rosenbrock) and trap easily in Ackley-style basins.</li>
+                    <li><strong>Dimensions:</strong> Each sweep is <em>O(n_dim)</em> function evaluations; the algorithm scales cheaply with dimension but precision suffers as the basin shape becomes less axis-aligned.</li>
+                    <li><strong>Convergence:</strong> Geometric reduction of the step size; a single run halts when step falls to the floor (or the restart trigger fires).</li>
+                    <li><strong>Relative to a textbook greedy coordinate descent reference</strong> at <code>n_trials=200, n_dim=2</code>: matches on Rosenbrock; the restart trigger leaves a precision gap on sphere and Ackley (see <a href="../sota-status.html">SOTA status</a> for the live numbers).</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -233,8 +233,8 @@
     </nav>
     <div class="container">
         <div class="header">
-            <h1>Finite-Difference Quasi-Newton</h1>
-            <p>(HumpDay's <code>LBFGSB</code> class — a derivative-free baseline)</p>
+            <h1>L-BFGS-B</h1>
+            <p>Byrd-Lu-Nocedal-Zhu (1995) limited-memory quasi-Newton with simple bounds, on finite-difference gradients</p>
         </div>
 
         <div class="content">
@@ -243,7 +243,14 @@
             </div>
 
             <div class="algorithm-description">
-                HumpDay is a <strong>derivative-free</strong> library: every algorithm sees only <code>f(x)</code>, never an analytical gradient. This one estimates a descent direction by central finite differences from function calls, then moves along it with an adaptive step size and momentum. It is named <code>LBFGSB</code> in the codebase as a nod to the limited-memory BFGS family it sits closest to in spirit, but it is <em>not</em> a faithful Byrd–Lu–Nocedal–Zhu L-BFGS-B implementation — that algorithm needs true gradients, which HumpDay does not have. Think of this as a finite-difference gradient-descent baseline.
+                HumpDay's <code>LBFGSB</code> is a faithful pure-Python port of scipy's <code>_minimize_lbfgsb</code> with four elements that distinguish it from a textbook two-loop L-BFGS:
+                <ol>
+                    <li><strong>Bound-aware direction projection</strong> &mdash; direction components that would push x past an active bound are zeroed (the simple-bounds reduction of the Cauchy-point step).</li>
+                    <li><strong>Projected-gradient sup-norm</strong> convergence test (<code>pgtol</code>).</li>
+                    <li><strong>f-tolerance termination</strong> &mdash; stop when <code>(f_old − f_new) &lt; factr&middot;eps_mach&middot;max(|f|, 1)</code>, scipy's headline criterion.</li>
+                    <li><strong>Feasibility-capped initial step</strong> &mdash; cap step length so <code>x + step&middot;direction</code> stays in <code>[0,1]<sup>n</sup></code> before backtracking.</li>
+                </ol>
+                HumpDay is a <strong>derivative-free</strong> library &mdash; algorithms see only <code>f(x)</code>, never an analytical gradient. Where scipy's L-BFGS-B uses analytic gradients (or a tighter Fortran-backed FD), HumpDay computes a central finite-difference gradient (2&middot;n_dim evaluations) per L-BFGS iteration. That's the only structural deviation from the reference algorithm.
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -299,24 +306,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python finite-difference gradient descent with momentum<br>
-                            No required dependencies; named after L-BFGS-B but structurally closer to gradient descent + momentum<br>
-                            <em>File: humpday/optimizers/scipy_algorithms.py</em>
+                            <strong>HumpDay <code>LBFGSB</code></strong><br>
+                            Pure-Python port of scipy's <code>_minimize_lbfgsb</code>: two-loop recursion + bound-aware direction projection + projected-gradient pgtol + factr&middot;eps_mach termination + feasibility-capped Armijo line search.<br>
+                            FD gradient (2&middot;n_dim evals per iteration); memory <code>m = min(10, n_dim)</code>.<br>
+                            <em>File: <code>humpday/optimizers/scipy_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L448" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            JavaScript L-BFGS-B with finite difference gradients<br>
-                            Limited-memory Hessian approximation<br>
-                            <em>Class: LBFGSB</em>
+                            <strong>Browser <code>LBFGSB</code></strong><br>
+                            Mirrors the Python port line-for-line. Also shared via <code>BaseOptimizer._lbfgsPolish</code> as the polish stage for DE / SA / BayesianOpt / PSO / CMA-ES / FA.<br>
+                            <em>Class: <code>LBFGSB</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
@@ -326,13 +332,13 @@
             </table>
 
             <div class="performance-notes">
-                <h3>Performance Characteristics</h3>
+                <h3>Performance characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Large-scale smooth optimization with bound constraints</li>
-                    <li><strong>Dimensions:</strong> Excellent for high dimensions (hundreds to thousands)</li>
-                    <li><strong>Function evaluations:</strong> Very efficient, typically O(n) per iteration</li>
-                    <li><strong>Convergence:</strong> Superlinear convergence on smooth problems</li>
-                    <li><strong>Memory:</strong> Limited memory - only stores recent gradient information</li>
+                    <li><strong>Best for:</strong> Smooth, near-quadratic basins where the L-BFGS curvature estimate is informative. Routinely the polish stage of choice at the end of population-based methods.</li>
+                    <li><strong>Worst for:</strong> Multimodal landscapes &mdash; L-BFGS-B is local, not global. The bound-aware direction projection keeps it from wandering off the cube but it has no escape from a wrong basin.</li>
+                    <li><strong>Per iteration:</strong> central FD gradient (2&middot;n_dim evaluations) + one or more line-search trials. Memory <code>m = min(10, n_dim)</code>.</li>
+                    <li><strong>Relative to scipy.optimize L-BFGS-B</strong> at <code>n_trials=200, n_dim=2</code>: ties on sphere and Ackley; a small residual on Rosenbrock from the FD-gradient cost. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
+                    <li><strong>Reused as a polish stage</strong> by DE, SA, BayesianOpt, PSO, CMA-ES, and FireflyAlgorithm via <code>BaseOptimizer._lbfgs_polish</code>.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -233,8 +233,8 @@
     </nav>
     <div class="container">
         <div class="header">
-            <h1>Pattern Search (MATLAB/Custom)</h1>
-            <p>Direct Search with Coordinate Patterns</p>
+            <h1>Pattern Search (Hooke-Jeeves)</h1>
+            <p>Exploratory move + pattern move, with restart on multimodal landscapes</p>
         </div>
 
         <div class="content">
@@ -243,7 +243,18 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Pattern Search</strong> is a family of derivative-free optimization methods that explore the search space using a structured pattern of points around the current best solution. These algorithms use a set of polling directions to systematically search for improvements, making them particularly effective for problems with discontinuities or noise where gradient information is unreliable.
+                <strong>Pattern Search</strong> in HumpDay is the classical <strong>Hooke-Jeeves</strong> algorithm (1961). Each cycle does an <em>exploratory move</em> &mdash; try &plusmn;<code>step</code> on each axis, keep first improvement per coordinate &mdash; followed by a <em>pattern move</em> that extrapolates from the previous base point through the new exploratory point. A second exploratory move from the pattern point either confirms the pattern (accept it) or falls back to the bare exploratory move. The step is halved after sweeps with no improvement.
+            </div>
+
+            <div class="coordinate-note">
+                <h3>HumpDay's pattern search at a glance</h3>
+                <ul>
+                    <li><strong>Exploratory move:</strong> try &plusmn;<code>step</code> on each coordinate, keep first improvement per axis.</li>
+                    <li><strong>Pattern move:</strong> if the exploratory improved, extrapolate <code>new_base = clip(x + (x - base))</code> and re-explore.</li>
+                    <li><strong>Step halving:</strong> failed sweep &rArr; halve the step.</li>
+                    <li><strong>Restart on multimodal trapping:</strong> when <code>step &le; 1e-6</code> with <code>f &gt; 1e-8</code>, reinitialise from a random base. On smooth basins the run exits naturally before the restart fires.</li>
+                    <li><strong>Initial step <code>0.1</code></strong>, floor <code>1e-12</code>, on the unit cube <code>[0, 1]<sup>n</sup></code>.</li>
+                </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -274,15 +285,16 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td class="category">Algorithmic Family</td>
+                        <td class="category">Algorithm</td>
                         <td>
-                            <strong>Direct Search Methods</strong><br>
-                            Generalized Pattern Search (GPS), Mesh Adaptive Direct Search<br>
-                            Coordinate search with adaptive step sizes<br>
-                            <em>Developed: 1950s-1990s (Hooke-Jeeves, Torczon, etc.)</em>
+                            <strong>Hooke-Jeeves direct search (1961)</strong><br>
+                            Exploratory move + pattern move; step halved on failed sweeps.<br>
+                            One of the earliest published derivative-free methods.<br>
+                            <em>Reference: Hooke &amp; Jeeves (1961), "'Direct search' solution of numerical and statistical problems", J. ACM 8(2)</em>
                         </td>
                         <td>
-                            <a href="https://epubs.siam.org/doi/book/10.1137/1.9781611971200" target="_blank" class="link-button paper">Direct Search Book</a>
+                            <a href="https://doi.org/10.1145/321062.321069" target="_blank" class="link-button paper">Original Paper</a>
+                            <a href="https://epubs.siam.org/doi/book/10.1137/1.9781611971200" target="_blank" class="link-button paper">DFO Book</a>
                         </td>
                     </tr>
                     <tr>
@@ -298,24 +310,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python pattern search — probes ±step along each coordinate axis; grows step on success, halves on stall, random-restarts when tiny<br>
-                            No required dependencies<br>
-                            <em>File: humpday/optimizers/search_algorithms.py</em>
+                            <strong>HumpDay <code>PatternSearch</code></strong><br>
+                            Faithful Hooke-Jeeves: exploratory + pattern move, step halved on failed sweep, restart on multimodal trapping.<br>
+                            Pure Python; no required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/search_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py#L181" target="_blank" class="link-button python">Custom Implementation</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/search_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            JavaScript pattern search with coordinate polling<br>
-                            Adaptive mesh refinement and pattern expansion<br>
-                            <em>Class: PatternSearch</em>
+                            <strong>Browser <code>PatternSearch</code></strong><br>
+                            Mirrors the Python port. Used in the contest and the in-browser visualizer.<br>
+                            <em>Class: <code>PatternSearch</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
@@ -325,13 +336,12 @@
             </table>
 
             <div class="performance-notes">
-                <h3>Performance Characteristics</h3>
+                <h3>Performance characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Discontinuous functions, noisy problems, constrained optimization</li>
-                    <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~50)</li>
-                    <li><strong>Function evaluations:</strong> Typically 2n evaluations per iteration</li>
-                    <li><strong>Convergence:</strong> Reliable local convergence, mesh refinement guarantees</li>
-                    <li><strong>Robustness:</strong> Excellent for problems where gradients don't exist</li>
+                    <li><strong>Best for:</strong> Smooth, low-dimensional black-box objectives where the pattern move can race along a valley.</li>
+                    <li><strong>Worst for:</strong> Highly multimodal landscapes (Ackley) where Hooke-Jeeves traps in local basins. HumpDay's restart trigger softens this but doesn't eliminate it &mdash; Hooke-Jeeves is local, not global.</li>
+                    <li><strong>Dimensions:</strong> Each exploratory sweep is <em>O(n_dim)</em> evaluations; pattern move adds one more per cycle.</li>
+                    <li><strong>Relative to a textbook Hooke-Jeeves reference</strong> at <code>n_trials=200, n_dim=2</code>: ties on Rosenbrock; the restart trigger leaves a small precision gap on sphere and Ackley (see <a href="../sota-status.html">SOTA status</a>).</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -233,8 +233,8 @@
     </nav>
     <div class="container">
         <div class="header">
-            <h1>UOBYQA (PDFO)</h1>
-            <p>Unconstrained Optimization BY Quadratic Approximation</p>
+            <h1>PRIMA_UOBYQA</h1>
+            <p>Powell's full-quadratic-model trust-region method, with Steihaug-Toint TR subproblem and Powell-style geometry steps</p>
         </div>
 
         <div class="content">
@@ -243,7 +243,12 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>UOBYQA</strong> is a trust-region method for derivative-free optimization that builds quadratic models using function values only. Developed by M.J.D. Powell, it's one of the foundational algorithms in the Prima library. UOBYQA is particularly effective for smooth, unimodal functions and forms the basis for more advanced methods like NEWUOA and BOBYQA.
+                <strong>UOBYQA</strong> (Unconstrained Optimization BY Quadratic Approximation, Powell 2002) is a trust-region method for derivative-free optimization that builds a full quadratic model from <code>(n+1)(n+2)/2</code> interpolation points. HumpDay's port uses three pieces that matter for correctness on non-quadratic objectives:
+                <ol>
+                    <li><strong>Steihaug-Toint truncated CG</strong> for the trust-region subproblem &mdash; correctly handles indefinite fitted Hessians (the common case for the overdetermined regression on non-quadratic objectives).</li>
+                    <li><strong>Unconditional base-point shifting</strong> at the end of every iteration so the model centre coincides with the current best.</li>
+                    <li><strong>Periodic geometry step</strong> &mdash; every <code>npt</code> TR iterations, pick the worst-positioned interpolation point and find a step in the trust region that maximises its Lagrange polynomial. Closes the residual gap to PDFO on Rosenbrock.</li>
+                </ol>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -299,24 +304,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python port of UOBYQA — quadratic-model trust region, no PDFO/Fortran call<br>
-                            No required dependencies<br>
-                            <em>File: humpday/optimizers/prima_algorithms.py</em>
+                            <strong>HumpDay <code>PRIMA_UOBYQA</code></strong><br>
+                            Pure-Python port: SVD-based regression on <code>(n+1)(n+2)/2</code> points, Steihaug-Toint TR subproblem, periodic geometry step that maximises <code>|&Lambda;<sub>t</sub>(x)|</code> in the trust region.<br>
+                            No required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/prima_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L400" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Pure JavaScript port maintaining core trust-region logic<br>
-                            Simplified quadratic model building for web performance<br>
-                            <em>Class: PRIMA_UOBYQA</em>
+                            <strong>Browser <code>PRIMA_UOBYQA</code></strong><br>
+                            JS port shares the Steihaug-Toint TR solver but uses a different geometry-update path; bringing it into line with the Python port is tracked separately.<br>
+                            <em>Class: <code>PRIMA_UOBYQA</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
@@ -326,13 +330,12 @@
             </table>
 
             <div class="performance-notes">
-                <h3>Performance Characteristics</h3>
+                <h3>Performance characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Smooth, unimodal functions with moderate noise tolerance</li>
-                    <li><strong>Dimensions:</strong> Works well up to ~50 dimensions</li>
-                    <li><strong>Function evaluations:</strong> Typically requires O(n²) evaluations for n dimensions</li>
-                    <li><strong>Convergence:</strong> Fast local convergence on quadratic-like functions</li>
-                    <li><strong>Robustness:</strong> Handles discontinuous derivatives but sensitive to high noise</li>
+                    <li><strong>Best for:</strong> Smooth, low-dimensional problems where the full quadratic model gives a precise trust-region step.</li>
+                    <li><strong>Worst for:</strong> High dimensions &mdash; the interpolation set scales as <code>(n+1)(n+2)/2</code>, which becomes expensive to build and maintain past ~10 dimensions. NEWUOA's <code>2n+1</code> underdetermined model is the better choice there.</li>
+                    <li><strong>Per outer cycle:</strong> one TR descent step + one Steihaug-Toint solve. Every <code>(n+1)(n+2)/2</code> cycles, one additional geometry-step evaluation.</li>
+                    <li><strong>Relative to PDFO uobyqa</strong> at <code>n_trials=200, n_dim=2</code>: matches reference on sphere, Rosenbrock, and Ackley &mdash; all three at the numerical noise floor. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 


### PR DESCRIPTION
## Summary

Per-page pass on 5 algorithm pages I touched intimately during the SOTA campaign. Each page now names the canonical algorithm directly, spells out the specific implementation choices (initial step, restart triggers, termination criteria), and cross-links the SOTA status page for live benchmark numbers — replacing vague "Convergence: Linear" / "Robustness: Excellent" boilerplate.

### Pages rewritten

#### \`coordinate-descent.html\`
Fix JS cell that wrongly claimed **"Golden section search for line minimization"** (humpday's JS CD uses greedy expansion to match Python). Spell out greedy expansion + step halving + restart trigger.

#### \`pattern-search.html\`
Name **Hooke-Jeeves (1961)** directly (was "Pattern Search (MATLAB/Custom)"). Fix JS cell that wrongly claimed "Adaptive mesh refinement and pattern expansion". Spell out exploratory + pattern move + step halving + restart trigger.

#### \`adaptive-random-search.html\` (Rechenberg page)
Rewrite Performance characteristics to call out the **componentwise Gaussian step**. The previous HumpDay variant projected to a unit direction, damping the stochastic spread; the current port matches the canonical (1+1)-ES.

#### \`lbfgsb.html\` — major rewrite
Previous page claimed **"finite-difference gradient descent with momentum"** and "named after L-BFGS-B but structurally closer to gradient descent + momentum". Both statements were wrong: PR #194 made this a faithful pure-Python port of scipy's \`_minimize_lbfgsb\` (two-loop recursion + bound-aware direction projection + projected-gradient pgtol + factr·eps_mach termination + feasibility-capped Armijo line search). Only deviation from the reference is FD vs analytic gradients.

Page now reflects this and notes that the polish is **reused by DE / SA / BO / PSO / CMA-ES / FireflyAlgorithm** via \`BaseOptimizer._lbfgs_polish\`.

#### \`uobyqa.html\`
Rewrite to reflect the current implementation: Steihaug-Toint TR subproblem (#196), unconditional base-point shift, **periodic Powell-style geometry step (#211)**. UOBYQA is now SOLID on the SOTA page and the description acknowledges it.

## Test plan

- [x] No code touched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)