### PR TITLE
Algorithm pages: rewrite BO / SA / DE / CMA-ES / FA (the polished-population family)

### DIFF
--- a/docs/algorithms/bayesian-optimization.html
+++ b/docs/algorithms/bayesian-optimization.html
@@ -243,7 +243,17 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Bayesian Optimization</strong> is a sequential design strategy for global optimization of expensive-to-evaluate functions. It uses a probabilistic surrogate model (typically Gaussian Process) to model the objective function and an acquisition function to guide the search toward promising regions. It's particularly effective when function evaluations are costly.
+                <strong>Bayesian Optimization</strong> fits a Gaussian-process surrogate to the observed <code>(x, f(x))</code> pairs and proposes the next evaluation point by maximising an acquisition function. HumpDay's <code>BayesianOpt</code> uses an RBF kernel and the <strong>Expected Improvement</strong> acquisition. After the GP-EI loop exhausts its share of the budget, HumpDay finishes with a short <strong>L-BFGS-B polish</strong> from the best observed point &mdash; the same pattern scikit-optimize's <code>gp_minimize</code> uses, and the reason HumpDay's <code>BayesianOpt</code> reaches machine precision on smooth basins where the GP itself would plateau at the kernel's noise floor.
+            </div>
+
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's BayesianOpt at a glance</h3>
+                <ul>
+                    <li><strong>Initial design:</strong> <code>n_initial = min(5, max(2, n_dim))</code> uniform random samples.</li>
+                    <li><strong>Surrogate:</strong> Gaussian process with an RBF kernel; jitter on the kernel matrix for numerical stability.</li>
+                    <li><strong>Acquisition:</strong> Expected Improvement, optimised by random sampling + a short local refinement of the best candidate.</li>
+                    <li><strong>Polish:</strong> reserve <code>min(20&middot;n_dim, n_trials/2)</code> evaluations for an L-BFGS-B polish from the best observed point at the end.</li>
+                </ul>
             </div>
 
             <div class="visualization-section">
@@ -299,24 +309,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python Gaussian-Process surrogate with Expected-Improvement acquisition<br>
-                            No required dependencies; numpy used transparently when installed via <code>humpday[fast]</code><br>
-                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
+                            <strong>HumpDay <code>BayesianOpt</code></strong><br>
+                            RBF-kernel GP surrogate + Expected Improvement acquisition + L-BFGS-B polish reserved at the end.<br>
+                            No required dependencies (numpy is used transparently when present for kernel construction; a pure-Python loop path covers the no-numpy install).<br>
+                            <em>File: <code>humpday/optimizers/evolutionary_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L354" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Simplified Bayesian optimization with GP approximation<br>
-                            Expected Improvement acquisition function<br>
-                            <em>Class: BayesianOpt</em>
+                            <strong>Browser <code>BayesianOpt</code></strong><br>
+                            Mirrors the Python port (RBF + EI + L-BFGS-B polish). Used in the contest and the in-browser visualizer.<br>
+                            <em>Class: <code>BayesianOpt</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
@@ -326,13 +335,12 @@
             </table>
 
             <div class="performance-notes">
-                <h3>Performance Characteristics</h3>
+                <h3>Performance characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Expensive function evaluations, black-box optimization</li>
-                    <li><strong>Dimensions:</strong> Typically 1-20 dimensions (GP scaling limitations)</li>
-                    <li><strong>Function evaluations:</strong> Very sample efficient, 10-100 evaluations</li>
-                    <li><strong>Convergence:</strong> Excellent with limited budget, global optimization</li>
-                    <li><strong>Robustness:</strong> Handles noise well, uncertainty quantification</li>
+                    <li><strong>Best for:</strong> Expensive black-box objectives where every evaluation matters. The GP-EI loop is sample-efficient; the L-BFGS-B polish closes the residual on smooth basins to machine precision.</li>
+                    <li><strong>Worst for:</strong> High dimensions &mdash; the GP kernel cost grows as <em>O(n_samples<sup>3</sup>)</em> and the RBF surrogate degenerates past a dozen or so dimensions. Like grid search, BayesianOpt is impractical past <code>n_dim &approx; 10</code>.</li>
+                    <li><strong>Per outer iteration:</strong> rebuild the kernel matrix, optimise EI, evaluate one point. Then at the end, <code>min(20&middot;n_dim, n_trials/2)</code> evaluations on an L-BFGS-B polish.</li>
+                    <li><strong>Relative to scikit-optimize <code>gp_minimize</code></strong> at <code>n_trials=200, n_dim=2</code>: HumpDay wins by ~10<sup>21</sup>&times; on sphere (machine precision vs ref's 1e-8), and matches on Rosenbrock. The polish is the difference. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/cma-evolution-strategy.html
+++ b/docs/algorithms/cma-evolution-strategy.html
@@ -243,7 +243,17 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>CMA-ES (Covariance Matrix Adaptation Evolution Strategy)</strong> is a state-of-the-art evolutionary algorithm for continuous optimization. Developed by Nikolaus Hansen and Andreas Ostermeier, CMA-ES adapts its search distribution by learning from the covariance structure of successful mutations. It's considered one of the most effective black-box optimizers for continuous problems.
+                <strong>CMA-ES</strong> (Covariance Matrix Adaptation Evolution Strategy; Hansen &amp; Ostermeier, 1996) samples offspring from <em>N(mean, &sigma;<sup>2</sup>&middot;C)</em> and updates <em>C</em>, <em>&sigma;</em>, and <em>mean</em> from the &mu; best offspring each generation. HumpDay's <code>CMAEvolutionStrategy</code> implements <strong>Hansen-standard CMA-ES</strong> &mdash; evolution paths <em>p<sub>c</sub></em> and <em>p<sub>&sigma;</sub></em>, rank-1 + rank-&mu; covariance updates, cumulative step-size adaptation &mdash; with a Cholesky-based sampler, then finishes with an <strong>L-BFGS-B polish</strong> from the CMA-ES best.
+            </div>
+
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's CMA-ES at a glance</h3>
+                <ul>
+                    <li><strong>Recommended parameters:</strong> &lambda; = <code>min(50, 4 + ⌊3&middot;log(n)⌋)</code>, &mu; = &lambda;/2, recombination weights <em>w<sub>i</sub> = log(&mu; + 0.5) − log(i)</em> normalised.</li>
+                    <li><strong>Adaptation:</strong> rank-1 + rank-&mu; C-update with positive-definiteness guard, cumulative step-size adaptation, evolution paths.</li>
+                    <li><strong>Sampler:</strong> Cholesky factor <em>L</em> of <em>C</em>, with eigendecomp-based <em>C<sup>−&frac12;</sup></em> refresh each iteration.</li>
+                    <li><strong>Polish:</strong> reserve <code>min(20&middot;n_dim, n_trials/2)</code> evaluations for L-BFGS-B from the CMA-ES best.</li>
+                </ul>
             </div>
 
             <div class="visualization-section">
@@ -299,24 +309,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python CMA-ES following Hansen's standard — evolution paths and step-size adaptation, Cholesky-based sampling of the covariance<br>
-                            No required dependencies<br>
-                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
+                            <strong>HumpDay <code>CMAEvolutionStrategy</code></strong><br>
+                            Hansen-standard CMA-ES with rank-1 + rank-&mu; C-update, evolution paths, CSA, then L-BFGS-B polish from the best CMA-ES point.<br>
+                            Pure Python; no required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/evolutionary_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L574" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            JavaScript port of core CMA-ES algorithm<br>
-                            Covariance matrix adaptation and evolution paths<br>
-                            <em>Class: CMAEvolutionStrategy</em>
+                            <strong>Browser <code>CMAEvolutionStrategy</code></strong><br>
+                            Mirrors the Python port line-for-line, including the L-BFGS-B polish stage.<br>
+                            <em>Class: <code>CMAEvolutionStrategy</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
@@ -326,13 +335,12 @@
             </table>
 
             <div class="performance-notes">
-                <h3>Performance Characteristics</h3>
+                <h3>Performance characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Continuous optimization, ill-conditioned problems, noisy functions</li>
-                    <li><strong>Dimensions:</strong> Excellent from 2D up to hundreds of dimensions</li>
-                    <li><strong>Function evaluations:</strong> Population-based, typically λ ≈ 4+⌊3log(n)⌋</li>
-                    <li><strong>Convergence:</strong> Outstanding convergence on smooth and rugged landscapes</li>
-                    <li><strong>Robustness:</strong> Scale-invariant, rotation-invariant, noise-tolerant</li>
+                    <li><strong>Best for:</strong> Ill-conditioned and rotation-sensitive continuous objectives. CMA-ES learns anisotropy and is &mdash; for a single black-box algorithm &mdash; one of the most powerful continuous optimizers.</li>
+                    <li><strong>Worst for:</strong> Very high dimensions with tight budgets &mdash; the C-matrix update is <em>O(n<sup>2</sup>)</em> per generation, and the eigendecomp is <em>O(n<sup>3</sup>)</em>.</li>
+                    <li><strong>Per generation:</strong> &lambda; offspring evaluations + one rank-1/rank-&mu; C-update + one eigendecomp for <em>C<sup>−&frac12;</sup></em>.</li>
+                    <li><strong>Relative to the <code>cmaes</code> reference</strong> at <code>n_trials=200, n_dim=2</code>: HumpDay matches on sphere and Ackley, wins on Ackley by a margin. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -242,7 +242,18 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Differential Evolution</strong> is a population-based evolutionary algorithm that uses vector differences to explore the search space. It's particularly effective on multimodal and noisy functions, making it one of the most reliable global optimization methods available.
+                <strong>Differential Evolution</strong> (Storn &amp; Price 1997) is a population-based evolutionary algorithm that mutates trial vectors using scaled differences of population members. HumpDay's <code>DifferentialEvolution</code> matches scipy's defaults: the <strong>best/1/bin</strong> mutation strategy, <strong>dither F</strong> drawn per-generation in <code>[0.5, 1.0]</code>, recombination probability <code>CR = 0.7</code>, and an <strong>L-BFGS-B polish</strong> from the best DE point at the end. The polish is what closes the residual gap to scipy on Rosenbrock at modest budgets.
+            </div>
+
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's DE at a glance</h3>
+                <ul>
+                    <li><strong>Budget split:</strong> 50% DE exploration, 50% L-BFGS-B polish. Tuned to match scipy.differential_evolution on Rosenbrock.</li>
+                    <li><strong>Mutation:</strong> <code>best/1/bin</code> &mdash; base point is the current population best, perturbed by F&middot;(donor<sub>1</sub> − donor<sub>2</sub>).</li>
+                    <li><strong>Dither F:</strong> sampled uniformly per generation from <code>[0.5, 1.0]</code> (scipy's <code>mutation=(0.5, 1)</code> default).</li>
+                    <li><strong>Crossover:</strong> binomial with <code>CR = 0.7</code> and one guaranteed coordinate.</li>
+                    <li><strong>Population:</strong> <code>pop_size = max(10, min(20, de_budget // 5))</code>.</li>
+                </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -285,40 +296,50 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">Reference Implementation</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python DE/rand/1/bin with mutation, crossover and selection<br>
-                            No required dependencies<br>
-                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
+                            <strong>scipy.optimize.differential_evolution</strong><br>
+                            Reference scipy implementation with <code>polish=True</code> (L-BFGS-B finishing step).<br>
+                            <em>Package: scipy</em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L17" target="_blank" class="link-button python">Python Code</a>
+                            <a href="https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.differential_evolution.html" target="_blank" class="link-button python">SciPy Docs</a>
+                            <a href="https://github.com/scipy/scipy/blob/main/scipy/optimize/_differentialevolution.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Pure JavaScript DE with classic DE/rand/1/bin strategy<br>
-                            Population management and vector operations<br>
-                            <em>Class: DifferentialEvolution</em>
+                            <strong>HumpDay <code>DifferentialEvolution</code></strong><br>
+                            <code>best/1/bin</code> mutation, dither F &in; [0.5, 1.0], CR = 0.7, then L-BFGS-B polish from the best DE point.<br>
+                            Pure Python; no required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/evolutionary_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">JavaScript Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Source</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="category">HumpDay JavaScript</td>
+                        <td>
+                            <strong>Browser <code>DifferentialEvolution</code></strong><br>
+                            Mirrors the Python port: <code>best/1/bin</code> + dither F + L-BFGS-B polish.<br>
+                            <em>Class: <code>DifferentialEvolution</code></em>
+                        </td>
+                        <td>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>
             </table>
 
             <div class="performance-notes">
-                <h3>Performance Characteristics</h3>
+                <h3>Performance characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Global optimization, multimodal and noisy functions</li>
-                    <li><strong>Dimensions:</strong> Scales well from 2D to 100+ dimensions</li>
-                    <li><strong>Function evaluations:</strong> Population-based, typically 1000+ evaluations</li>
-                    <li><strong>Convergence:</strong> Reliable global convergence but can be slow</li>
-                    <li><strong>Robustness:</strong> Excellent on discontinuous and highly multimodal landscapes</li>
+                    <li><strong>Best for:</strong> Global optimization on multimodal continuous objectives. The combination of population exploration and L-BFGS-B polish is one of the most reliable defaults in HumpDay.</li>
+                    <li><strong>Worst for:</strong> Tiny budgets where DE can't form a useful population &mdash; in those regimes prefer NelderMead or PRIMA.</li>
+                    <li><strong>Per generation:</strong> <code>pop_size</code> trial vectors are proposed and evaluated.</li>
+                    <li><strong>Relative to scipy.differential_evolution</strong> at <code>n_trials=200, n_dim=2</code>: HumpDay wins on sphere by a wide margin and on Ackley; a small gap on Rosenbrock (scipy's L-BFGS-B polish is unbudgeted). See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/firefly-algorithm.html
+++ b/docs/algorithms/firefly-algorithm.html
@@ -255,17 +255,20 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Firefly Algorithm (FA)</strong> is a nature-inspired metaheuristic optimization algorithm developed by Xin-She Yang in 2008. It mimics the flashing behavior and social interactions of fireflies, where the attractiveness and brightness of fireflies determine their movement patterns. The algorithm combines elements of swarm intelligence with local search capabilities.
+                <strong>Firefly Algorithm</strong> (Yang 2008) is a population-based metaheuristic where fireflies are attracted to brighter (lower-objective) fireflies. The movement of firefly <em>i</em> toward a brighter firefly <em>j</em> is <em>x<sub>i</sub> += &beta;&middot;(x<sub>j</sub> − x<sub>i</sub>) + &alpha;&middot;&epsilon;</em>, with attractiveness <em>&beta; = &beta;<sub>0</sub>&middot;exp(−&gamma;&middot;r<sup>2</sup>)</em> and a small random jitter <em>&alpha;&middot;&epsilon;</em>. HumpDay's <code>FireflyAlgorithm</code> follows Yang's recipe and adds the two ingredients that make it competitive on the SOTA benchmark:
+                <ol>
+                    <li><strong>Geometric damping of the randomness coefficient</strong>: <em>&alpha; &larr; 0.99&middot;&alpha;</em> at the end of each sweep. Without damping, the random jitter prevents convergence onto the optimum &mdash; this was the snapshot's Ackley failure mode before the fix.</li>
+                    <li><strong>L-BFGS-B polish</strong> from the firefly best at the end.</li>
+                </ol>
             </div>
 
-            <div class="nature-inspired">
-                <h3>Nature-Inspired Algorithm</h3>
-                <p><strong>Firefly Algorithm is inspired by firefly behavior:</strong></p>
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's Firefly at a glance</h3>
                 <ul>
-                    <li><strong>Bioluminescence:</strong> Fireflies communicate through light signals</li>
-                    <li><strong>Attractiveness:</strong> Brighter fireflies attract dimmer ones</li>
-                    <li><strong>Distance Decay:</strong> Light intensity decreases with distance</li>
-                    <li><strong>Random Movement:</strong> Exploration when no brighter fireflies exist</li>
+                    <li><strong>Population:</strong> <code>n_fireflies = min(15, max(2, budget // 5))</code>.</li>
+                    <li><strong>Attractiveness:</strong> <em>&beta;<sub>0</sub> = 1</em>, <em>&gamma; = 1</em>.</li>
+                    <li><strong>Randomness:</strong> <em>&alpha;<sub>0</sub> = 0.2</em> with geometric damping <em>0.99</em> per sweep (matches mealpy's <code>alpha_damp</code>).</li>
+                    <li><strong>Polish:</strong> reserve <code>min(20&middot;n_dim, n_trials/2)</code> evaluations for L-BFGS-B from the best firefly.</li>
                 </ul>
             </div>
             <div class="visualization-section">
@@ -311,25 +314,24 @@
                     <tr>
                         <td class="category">Reference Implementation</td>
                         <td>
-                            <strong>Custom Research Implementations</strong><br>
-                            Various academic and open-source implementations<br>
-                            No single standard package (multiple variants exist)<br>
-                            <em>Reference: Academic literature implementations</em>
+                            <strong>mealpy FFA</strong><br>
+                            Tested against mealpy's Original Firefly Algorithm.<br>
+                            <em>Reference: <code>mealpy.swarm_based.FFA.OriginalFFA</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/topics/firefly-algorithm" target="_blank" class="link-button python">GitHub Examples</a>
+                            <a href="https://github.com/thieu1995/mealpy" target="_blank" class="link-button python">mealpy</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Implementation</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>Humpday Firefly Algorithm</strong><br>
-                            Custom implementation following Yang's original paper<br>
-                            Attractiveness-based movement with randomization<br>
-                            <em>File: humpday/optimizers/firefly*.py</em>
+                            <strong>HumpDay <code>FireflyAlgorithm</code></strong><br>
+                            Yang-standard Firefly with &alpha; damping, then L-BFGS-B polish from the best firefly.<br>
+                            Pure Python; no required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/evolutionary_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L772" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
@@ -350,11 +352,10 @@
             <div class="performance-notes">
                 <h3>Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Multimodal optimization, continuous problems, exploration-heavy tasks</li>
-                    <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~50)</li>
-                    <li><strong>Function evaluations:</strong> Population-based, n_fireflies × generations</li>
-                    <li><strong>Convergence:</strong> Good exploration, may converge slowly to global optimum</li>
-                    <li><strong>Robustness:</strong> Handles multimodal landscapes well due to swarm diversity</li>
+                    <li><strong>Best for:</strong> Multimodal continuous objectives. The swarm covers basins, &alpha; damping focuses the search late, and the L-BFGS-B polish refines the winner.</li>
+                    <li><strong>Worst for:</strong> Tight-budget problems where the pairwise <em>O(n_fireflies<sup>2</sup>)</em> attractor updates dominate.</li>
+                    <li><strong>Per sweep:</strong> up to <em>n_fireflies<sup>2</sup></em> attractive moves and evaluations; &alpha; damps by factor <em>0.99</em> at end of sweep.</li>
+                    <li><strong>Relative to mealpy FFA</strong> at <code>n_trials=200, n_dim=2</code>: HumpDay wins across sphere, Rosenbrock, and Ackley. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -243,7 +243,21 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Simulated Annealing</strong> is a probabilistic optimization technique inspired by the annealing process in metallurgy. Developed by Kirkpatrick, Gelatt, and Vecchi in 1983, it allows for occasional uphill moves that decrease with a "temperature" parameter, enabling escape from local optima. The algorithm gradually reduces the temperature, converging to a global optimum.
+                <strong>Simulated Annealing</strong> (Kirkpatrick et al. 1983) is a probabilistic optimization technique inspired by metallurgical annealing. HumpDay's <code>SimulatedAnnealing</code> follows the two-stage pattern of scipy's <code>dual_annealing</code>:
+                <ol>
+                    <li><strong>Stage 1 — multi-restart Metropolis SA</strong> explores globally with a geometric cooling schedule. Uphill moves are accepted with probability <code>exp(-(f_new - f) / T)</code>; restarts give the algorithm multiple shots at finding the basin.</li>
+                    <li><strong>Stage 2 — L-BFGS-B polish</strong> refines the SA best to high precision. scipy uses L-BFGS-B at this stage; HumpDay uses the same (with FD gradients).</li>
+                </ol>
+            </div>
+
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's SA at a glance</h3>
+                <ul>
+                    <li><strong>Budget split:</strong> 50% SA exploration, 50% L-BFGS-B polish. Tuned to match scipy.dual_annealing on Rosenbrock.</li>
+                    <li><strong>Cooling:</strong> geometric, computed so that <code>T_final / T_initial = (final/initial)<sup>1/trials_per_restart</sup></code>. Starts at <code>T=1.0</code>, ends at <code>T=1e-6</code>.</li>
+                    <li><strong>Restart structure:</strong> <code>max(3, sa_budget // 30)</code> restarts. First restart starts near the cube centre; subsequent restarts start uniformly at random.</li>
+                    <li><strong>Proposal:</strong> step size scales with current temperature (<code>step = 0.4 &middot; T</code>), uniform per coordinate.</li>
+                </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -299,24 +313,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python simulated annealing with Metropolis acceptance and geometric cooling<br>
-                            No required dependencies<br>
-                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
+                            <strong>HumpDay <code>SimulatedAnnealing</code></strong><br>
+                            Multi-restart Metropolis SA with geometric cooling, then L-BFGS-B polish from the best SA point.<br>
+                            Pure Python; no required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/evolutionary_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L186" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Classical simulated annealing with cooling schedule<br>
-                            Metropolis criterion for acceptance probability<br>
-                            <em>Class: SimulatedAnnealing</em>
+                            <strong>Browser <code>SimulatedAnnealing</code></strong><br>
+                            Mirrors the Python port: multi-restart SA + L-BFGS-B polish. Used in the contest and the in-browser visualizer.<br>
+                            <em>Class: <code>SimulatedAnnealing</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
@@ -326,13 +339,12 @@
             </table>
 
             <div class="performance-notes">
-                <h3>Performance Characteristics</h3>
+                <h3>Performance characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Discrete optimization, traveling salesman, combinatorial problems</li>
-                    <li><strong>Dimensions:</strong> Scalable to moderate dimensions, works on any space</li>
-                    <li><strong>Function evaluations:</strong> Typically requires many evaluations for good results</li>
-                    <li><strong>Convergence:</strong> Asymptotic global convergence with proper cooling</li>
-                    <li><strong>Robustness:</strong> Excellent at escaping local minima</li>
+                    <li><strong>Best for:</strong> Multimodal continuous objectives where temperature-controlled uphill moves matter. The L-BFGS-B polish closes the residual to scipy-level precision on smooth basins.</li>
+                    <li><strong>Worst for:</strong> Problems where global exploration is a waste and budget would be better spent on a single basin (PRIMA / CMA-ES territory).</li>
+                    <li><strong>Per restart:</strong> <code>trials_per_restart</code> Metropolis proposals. Each proposal is one evaluation; uphill accepts depend on temperature.</li>
+                    <li><strong>Relative to scipy.dual_annealing</strong> at <code>n_trials=200, n_dim=2</code>: ties on sphere; wins on Ackley; loses on Rosenbrock (scipy's polish is unbudgeted, ours is not). See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 


### PR DESCRIPTION
## Summary

These five algorithms have the same architectural shape in HumpDay: a population/sampling-driven exploration phase followed by an L-BFGS-B polish from the best point. Each page now spells out that structure with the specific population / cooling / budget choices.

### Per-page highlights

#### \`bayesian-optimization.html\`
Surface that HumpDay's BayesianOpt is **RBF + Expected Improvement + L-BFGS-B polish** (\`min(20·n_dim, n_trials/2)\` reserved). Note that BayesianOpt wins by ~1e21× on sphere thanks to the polish, and is impractical past <code>n_dim ≈ 10</code>.

#### \`simulated-annealing.html\`
Surface the two-stage \`dual_annealing\`-shape: **multi-restart Metropolis SA + L-BFGS-B polish**, 50/50 budget split, cooling geometric from T=1.0 to T=1e-6 per restart, restart count \`max(3, sa_budget // 30)\`.

#### \`differential-evolution.html\`
Fix the page to call out scipy-aligned defaults: **best/1/bin** mutation (not the old "rand/1/bin" claim), dither F drawn per-generation in \`[0.5, 1.0]\`, CR=0.7, L-BFGS-B polish. Add a Reference Implementation row pointing at \`scipy.optimize.differential_evolution\`.

#### \`cma-evolution-strategy.html\`
Surface that HumpDay implements **Hansen-standard CMA-ES** (rank-1 + rank-μ C-update, evolution paths, CSA) with a Cholesky sampler and an L-BFGS-B polish at the end.

#### \`firefly-algorithm.html\`
Call out the two reasons HumpDay's Firefly beats mealpy FFA on every cell of the snapshot:
1. Geometric **α damping** (0.99 per sweep, matching mealpy's \`alpha_damp\`)
2. **L-BFGS-B polish** from the best firefly

Also fix the Reference Implementation row that still said "Custom Research Implementations" — it's mealpy FFA.

### Common theme

All five pages now cross-link \`docs/sota-status.html\` for live benchmark numbers instead of generic "Robustness: Excellent" boilerplate.

## Test plan

- [x] No code touched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)