### PR TITLE
Algorithm pages: rewrite PSO / GA / ES / HC / ACO

### DIFF
--- a/docs/algorithms/ant-colony-optimization.html
+++ b/docs/algorithms/ant-colony-optimization.html
@@ -285,46 +285,44 @@
                     <tr>
                         <td class="category">Original Algorithm</td>
                         <td>
-                            <strong>Zong Woo Geem</strong><br>
-                            Music-inspired optimization metaheuristic<br>
-                            Based on musical improvisation and harmony composition<br>
-                            <em>Published: 2001</em>
+                            <strong>Marco Dorigo</strong><br>
+                            Pheromone-based metaheuristic inspired by ant foraging.<br>
+                            Continuous variant: ACOR (Socha &amp; Dorigo, 2008).<br>
+                            <em>Published: 1992 (ACO), 2008 (ACOR)</em>
                         </td>
                         <td>
-                            <a href="https://doi.org/10.1109/3477.484436" target="_blank" class="link-button paper">Original Paper</a>
+                            <a href="https://doi.org/10.1016/j.ejor.2006.06.046" target="_blank" class="link-button paper">ACOR Paper</a>
                         </td>
                     </tr>
                     <tr>
                         <td class="category">Reference Implementation</td>
                         <td>
-                            <strong>pyHarmonySearch</strong><br>
-                            Tested against pyHarmonySearch package<br>
-                            Optional external dependency for validation<br>
-                            <em>Reference: PyPI harmony search implementation</em>
+                            <strong>mealpy ACOR</strong><br>
+                            Tested against mealpy's continuous ACOR.<br>
+                            <em>Reference: <code>mealpy.swarm_based.ACOR.OriginalACOR</code></em>
                         </td>
                         <td>
-                            <a href="https://pypi.org/project/pyHarmonySearch/" target="_blank" class="link-button">PyPI Package</a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="category">Humpday Python Implementation</td>
-                        <td>
-                            <strong>Humpday Harmony Search</strong><br>
-                            Custom implementation with classical HS operators<br>
-                            Harmony memory, pitch adjustment, and randomization<br>
-                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
-                        </td>
-                        <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L840" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/thieu1995/mealpy" target="_blank" class="link-button">mealpy</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Pure JavaScript harmony search<br>
-                            Memory management and improvisation rules<br>
-                            <em>Class: HarmonySearch</em>
+                            <strong>HumpDay <code>AntColonyOpt</code></strong><br>
+                            Socha-Dorigo continuous ACOR: maintain an archive of <em>k</em> solutions ranked by fitness; sample new solutions from a Gaussian kernel over the archive (mixture weights from rank-based probabilities).<br>
+                            Pure Python; no required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/evolutionary_algorithms.py</code></em>
+                        </td>
+                        <td>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Source</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="category">HumpDay JavaScript</td>
+                        <td>
+                            <strong>Browser <code>AntColonyOpt</code></strong><br>
+                            Mirrors the Python ACOR port.<br>
+                            <em>Class: <code>AntColonyOpt</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">JS Implementation</a>
@@ -334,13 +332,12 @@
             </table>
 
             <div class="performance-notes">
-                <h3>Performance Characteristics</h3>
+                <h3>Performance characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Continuous optimization, parameter tuning, engineering design</li>
-                    <li><strong>Dimensions:</strong> Handles moderate to high dimensions well</li>
-                    <li><strong>Function evaluations:</strong> Memory-based, HMS × generations</li>
-                    <li><strong>Convergence:</strong> Steady improvement through memory exploitation</li>
-                    <li><strong>Robustness:</strong> Balance between exploitation and exploration through HS operators</li>
+                    <li><strong>Best for:</strong> Continuous optimization with multimodal landscapes. The archive sampler keeps diversity while concentrating mass near good solutions.</li>
+                    <li><strong>Worst for:</strong> Tight-budget smooth problems where a directional method (CMA-ES, PRIMA) would converge faster.</li>
+                    <li><strong>Per generation:</strong> draw new samples from the Gaussian-kernel mixture over the archive; evaluate; merge into the archive and keep the top <em>k</em>.</li>
+                    <li><strong>Relative to mealpy ACOR</strong> at <code>n_trials=200, n_dim=2</code>: HumpDay wins on sphere and Ackley; ties on Rosenbrock. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 
@@ -348,157 +345,19 @@
             <div class="more-section">
                 <button class="more-toggle" onclick="toggleMore()">More Resources</button>
                 <div id="moreContent" class="more-content">
-                    <h3>Educational Resources</h3>
+                    <h3>Educational resources</h3>
                     <ul>
-                        <li><a href="https://en.wikipedia.org/wiki/Harmony_search" target="_blank">Harmony Search Wikipedia</a></li>
-                        <li><a href="https://doi.org/10.1109/3477.484436" target="_blank">Original HS Paper (Geem et al., 2001)</a></li>
-                        <li><a href="https://www.springer.com/gp/book/9783642007378" target="_blank">Music-Inspired Harmony Search Algorithm</a></li>
-                        <li><a href="https://ieeexplore.ieee.org/document/4531873" target="_blank">Improved Harmony Search Algorithm</a></li>
-                        <li><a href="https://link.springer.com/journal/10287" target="_blank">International Journal of Optimization</a></li>
+                        <li><a href="https://en.wikipedia.org/wiki/Ant_colony_optimization_algorithms" target="_blank">Ant Colony Optimization Wikipedia</a></li>
+                        <li><a href="https://doi.org/10.1016/j.ejor.2006.06.046" target="_blank">Socha &amp; Dorigo (2008): ACOR for continuous domains</a></li>
+                        <li><a href="https://www.iridia.ulb.ac.be/~mdorigo/HomePageDorigo/" target="_blank">Marco Dorigo's homepage</a></li>
                     </ul>
 
-                    <h3>Core Algorithm Components</h3>
+                    <h3>Core algorithm components</h3>
                     <ul>
-                        <li><strong>Harmony Memory (HM):</strong> Population of HMS best solutions found</li>
-                        <li><strong>Harmony Memory Size (HMS):</strong> Number of solutions stored</li>
-                        <li><strong>Memory Consideration Rate (HMCR):</strong> Probability of choosing from memory</li>
-                        <li><strong>Pitch Adjusting Rate (PAR):</strong> Probability of local adjustment</li>
-                        <li><strong>Pitch Adjustment:</strong> Local search around selected value</li>
-                        <li><strong>Random Selection:</strong> Generate completely new value</li>
-                    </ul>
-
-                    <h3>Mathematical Formulation</h3>
-                    <ul>
-                        <li><strong>Memory Selection:</strong> x'ᵢ = HMⱼ(i) with probability HMCR</li>
-                        <li><strong>Pitch Adjustment:</strong> x'ᵢ = x'ᵢ ± rand() × bw with probability PAR</li>
-                        <li><strong>Random Selection:</strong> x'ᵢ ~ Uniform(LBᵢ, UBᵢ) with probability (1-HMCR)</li>
-                        <li><strong>Memory Update:</strong> Replace worst harmony if new harmony is better</li>
-                    </ul>
-
-                    <h3>️ Key Parameters</h3>
-                    <ul>
-                        <li><strong>HMS:</strong> Harmony Memory Size, typically 10-50</li>
-                        <li><strong>HMCR:</strong> Memory Consideration Rate, usually 0.7-0.95</li>
-                        <li><strong>PAR:</strong> Pitch Adjusting Rate, usually 0.1-0.5</li>
-                        <li><strong>bw:</strong> Bandwidth for pitch adjustment</li>
-                        <li><strong>Termination:</strong> Maximum iterations or convergence criteria</li>
-                    </ul>
-
-                    <h3>Harmony Search Algorithm Pseudocode</h3>
-                    <pre style="background: #f8f9fa; padding: 15px; border-radius: 8px; font-family: monospace;">
-function harmonySearch(objectiveFunction, HMS, HMCR, PAR, maxIter):
-    // Step 1: Initialize Harmony Memory
-    HM = []
-    for i in 1 to HMS:
-        harmony = generateRandomSolution()
-        HM.add(harmony, objectiveFunction(harmony))
-
-    sortByFitness(HM)
-
-    // Step 2: Improvise New Harmony
-    for iteration in 1 to maxIter:
-        newHarmony = []
-
-        for j in 1 to problemDimension:
-            if random() < HMCR:  // Memory consideration
-                // Choose value from memory
-                randomHarmonyIndex = randomInt(0, HMS-1)
-                newValue = HM[randomHarmonyIndex][j]
-
-                if random() < PAR:  // Pitch adjustment
-                    newValue += (random() - 0.5) * 2 * bandwidth
-                    newValue = clip(newValue, lowerBound, upperBound)
-
-            else:  // Random selection
-                newValue = random() * (upperBound - lowerBound) + lowerBound
-
-            newHarmony[j] = newValue
-
-        // Step 3: Update Harmony Memory
-        newFitness = objectiveFunction(newHarmony)
-
-        if newFitness < HM[HMS-1].fitness:  // Better than worst
-            HM[HMS-1] = (newHarmony, newFitness)
-            sortByFitness(HM)
-
-    return HM[0]  // Best harmony
-                    </pre>
-
-                    <h3>Harmony Search Variants</h3>
-                    <ul>
-                        <li><strong>Classical HS:</strong> Original algorithm with fixed parameters</li>
-                        <li><strong>Improved HS (IHS):</strong> Dynamic PAR and bandwidth adjustment</li>
-                        <li><strong>Self-Adaptive HS:</strong> Automatic parameter tuning</li>
-                        <li><strong>Global-Best HS:</strong> Use best harmony for pitch adjustment</li>
-                        <li><strong>Differential HS:</strong> Incorporate differential evolution operators</li>
-                        <li><strong>Multi-Objective HS:</strong> Pareto-based harmony search</li>
-                    </ul>
-
-                    <h3>Musical Analogy Details</h3>
-                    <ul>
-                        <li><strong>Musician:</strong> Decision variable (instrument)</li>
-                        <li><strong>Musical Note:</strong> Value of decision variable</li>
-                        <li><strong>Harmony:</strong> Complete solution vector</li>
-                        <li><strong>Harmony Memory:</strong> Collection of good musical pieces</li>
-                        <li><strong>Improvisation:</strong> Generation of new solution</li>
-                        <li><strong>Aesthetic Quality:</strong> Objective function value</li>
-                    </ul>
-
-                    <h3>Applications</h3>
-                    <ul>
-                        <li><strong>Engineering Design:</strong> Structural optimization, water distribution</li>
-                        <li><strong>Energy Systems:</strong> Power system optimization, renewable energy</li>
-                        <li><strong>Manufacturing:</strong> Production scheduling, resource allocation</li>
-                        <li><strong>Transportation:</strong> Vehicle routing, traffic optimization</li>
-                        <li><strong>Machine Learning:</strong> Feature selection, neural network training</li>
-                        <li><strong>Economics:</strong> Portfolio optimization, supply chain management</li>
-                    </ul>
-
-                    <h3>Advantages of Harmony Search</h3>
-                    <ul>
-                        <li><strong>Simplicity:</strong> Easy to understand and implement</li>
-                        <li><strong>Few Parameters:</strong> Only HMS, HMCR, PAR to tune</li>
-                        <li><strong>Memory-Based:</strong> Maintains population of good solutions</li>
-                        <li><strong>Flexibility:</strong> Adapts to continuous and discrete problems</li>
-                        <li><strong>Balance:</strong> Good trade-off between exploration and exploitation</li>
-                        <li><strong>No Gradient Needed:</strong> Works with black-box functions</li>
-                    </ul>
-
-                    <h3>️ Limitations</h3>
-                    <ul>
-                        <li><strong>Parameter Sensitivity:</strong> Performance depends on HMCR and PAR</li>
-                        <li><strong>Premature Convergence:</strong> May converge too quickly with wrong parameters</li>
-                        <li><strong>Slow Convergence:</strong> Can be slow on some problem types</li>
-                        <li><strong>Local Search Ability:</strong> Limited fine-tuning capability</li>
-                        <li><strong>Memory Management:</strong> Fixed memory size may be suboptimal</li>
-                    </ul>
-
-                    <h3>Parameter Guidelines</h3>
-                    <ul>
-                        <li><strong>HMCR = 0.9:</strong> High memory consideration for exploitation</li>
-                        <li><strong>HMCR = 0.1:</strong> Low memory consideration for exploration</li>
-                        <li><strong>PAR = 0.3:</strong> Moderate pitch adjustment</li>
-                        <li><strong>HMS = 10-30:</strong> Small memory for fast convergence</li>
-                        <li><strong>HMS = 50-100:</strong> Large memory for diverse population</li>
-                        <li><strong>Dynamic Parameters:</strong> Adapt HMCR, PAR during search</li>
-                    </ul>
-
-                    <h3>Creative Aspects</h3>
-                    <ul>
-                        <li><strong>Artistic Inspiration:</strong> Based on human creativity and musical composition</li>
-                        <li><strong>Improvisation Process:</strong> Mimics how musicians create new melodies</li>
-                        <li><strong>Harmony Aesthetics:</strong> Better solutions are like more beautiful music</li>
-                        <li><strong>Cultural Bridge:</strong> Connects optimization with arts and music</li>
-                        <li><strong>Intuitive Understanding:</strong> Easy to explain through musical metaphor</li>
-                    </ul>
-
-                    <h3>Comparison with Other Metaheuristics</h3>
-                    <ul>
-                        <li><strong>vs GA:</strong> Memory-based vs generation-based evolution</li>
-                        <li><strong>vs PSO:</strong> Discrete memory vs continuous population movement</li>
-                        <li><strong>vs SA:</strong> Population-based vs single solution approach</li>
-                        <li><strong>vs ACO:</strong> Direct memory vs pheromone-based communication</li>
-                        <li><strong>vs DE:</strong> Musical improvisation vs biological evolution</li>
+                        <li><strong>Archive:</strong> a sorted set of the <em>k</em> best solutions found so far. Each archive entry is a vector in <code>[0, 1]<sup>n</sup></code>.</li>
+                        <li><strong>Rank-based weights:</strong> archive entry <em>i</em> gets sampling weight <em>w<sub>i</sub> &propto; exp(−i<sup>2</sup>/(2q<sup>2</sup>k<sup>2</sup>))</em>, concentrating mass at the top.</li>
+                        <li><strong>Gaussian kernel sampler:</strong> draw a new solution by (1) picking an archive entry by weight, then (2) sampling each coordinate from a Gaussian centred on that entry's coordinate, with bandwidth equal to a scaled mean absolute deviation across the archive.</li>
+                        <li><strong>Archive update:</strong> evaluate the new sample and merge it into the archive; drop the worst entry to maintain size <em>k</em>.</li>
                     </ul>
                 </div>
             </div>

--- a/docs/algorithms/evolution-strategy.html
+++ b/docs/algorithms/evolution-strategy.html
@@ -241,7 +241,7 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Evolution Strategy</strong> is one of the oldest evolutionary algorithms, dating to Rechenberg and Schwefel's work in 1960s Berlin. The (μ+λ) variant maintains μ parents, generates λ mutated offspring each generation, and selects the best μ individuals from the combined parent+offspring pool to form the next generation. It is the conceptual ancestor of CMA-ES.
+                <strong>Evolution Strategy</strong> dates to Rechenberg and Schwefel's work in 1960s Berlin and is the conceptual ancestor of CMA-ES. The (μ+λ) variant maintains μ parents, generates λ Gaussian-perturbed offspring each generation, and selects the best μ individuals from the combined parent + offspring pool. HumpDay's <code>EvolutionStrategy</code> uses a fixed step size σ=0.2 (no covariance adaptation — that's CMA-ES's contribution).
             </div>
 
             <div class="visualization-section">
@@ -310,11 +310,10 @@
             <div class="performance-notes">
                 <h3>Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Continuous unconstrained optimization on moderate-dimensional problems</li>
-                    <li><strong>Dimensions:</strong> Works well from 2 up to a few dozen; favoured for "high-dimensional complex" routing in HumpDay's adaptive optimizer</li>
-                    <li><strong>Function evaluations:</strong> Each generation costs up to λ evaluations; total budget is set by <code>n_trials</code></li>
-                    <li><strong>Convergence:</strong> Reliable progress on smooth landscapes; can stall on highly multimodal surfaces without self-adaptation</li>
-                    <li><strong>Robustness:</strong> Tolerates noise via its population-and-selection structure; less robust than CMA-ES because step size σ is fixed</li>
+                    <li><strong>Best for:</strong> Continuous unconstrained objectives where rotation-invariance isn't critical and a fixed-σ baseline suffices.</li>
+                    <li><strong>Worst for:</strong> Ill-conditioned problems &mdash; without covariance adaptation, σ can't match the basin geometry the way CMA-ES does.</li>
+                    <li><strong>Per generation:</strong> up to λ evaluations; sort by fitness, keep μ best.</li>
+                    <li><strong>Relative to mealpy <code>OriginalES</code></strong> at <code>n_trials=200, n_dim=2</code>: HumpDay wins across sphere, Rosenbrock, and Ackley. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/genetic-algorithm.html
+++ b/docs/algorithms/genetic-algorithm.html
@@ -243,7 +243,18 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Genetic Algorithms (GA)</strong> are population-based metaheuristics inspired by the process of natural selection. Introduced by John Holland in the 1970s, GAs evolve a population of candidate solutions using selection, crossover, and mutation operators. They're particularly effective for combinatorial optimization and problems where the search space is large and complex.
+                <strong>Genetic Algorithm</strong> (Holland, 1970s) evolves a population of candidate solutions through selection, crossover, and mutation. HumpDay's <code>GeneticAlgorithm</code> uses a real-valued representation (no binary encoding), <strong>tournament-of-3 selection</strong>, one-point crossover, and per-coordinate Bernoulli mutation with uniform noise. The reference adapter for the SOTA snapshot is mealpy's <code>BaseGA</code>, not DEAP &mdash; mealpy is what the benchmark actually compares against.
+            </div>
+
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's GA at a glance</h3>
+                <ul>
+                    <li><strong>Representation:</strong> real-valued vectors in <code>[0, 1]<sup>n</sup></code>.</li>
+                    <li><strong>Selection:</strong> tournament-of-3.</li>
+                    <li><strong>Crossover:</strong> one-point.</li>
+                    <li><strong>Mutation:</strong> per-coordinate Bernoulli with uniform noise.</li>
+                    <li><strong>Elitism:</strong> the best individual is carried over each generation.</li>
+                </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -299,24 +310,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python GA — tournament-of-3 selection, one-point crossover, per-coordinate Bernoulli mutation with uniform noise<br>
-                            No required dependencies<br>
-                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
+                            <strong>HumpDay <code>GeneticAlgorithm</code></strong><br>
+                            Real-valued GA: tournament-of-3 selection, one-point crossover, per-coordinate Bernoulli mutation with uniform noise, elitism on the best individual.<br>
+                            Pure Python; no required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/evolutionary_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L267" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Pure JavaScript GA with selection, crossover, mutation<br>
-                            Real-valued representation for continuous problems<br>
-                            <em>Class: GeneticAlgorithm</em>
+                            <strong>Browser <code>GeneticAlgorithm</code></strong><br>
+                            Mirrors the Python port.<br>
+                            <em>Class: <code>GeneticAlgorithm</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
@@ -328,11 +338,10 @@
             <div class="performance-notes">
                 <h3>Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Combinatorial optimization, multimodal landscapes, large search spaces</li>
-                    <li><strong>Dimensions:</strong> Scales to hundreds of dimensions</li>
-                    <li><strong>Function evaluations:</strong> Population size × generations</li>
-                    <li><strong>Convergence:</strong> Good global exploration, premature convergence possible</li>
-                    <li><strong>Robustness:</strong> Robust to noise, handles discontinuous functions well</li>
+                    <li><strong>Best for:</strong> Multimodal continuous objectives where population diversity matters more than rapid local refinement.</li>
+                    <li><strong>Worst for:</strong> Tight-budget smooth basins &mdash; the population/generation overhead is a tax compared to CMA-ES or DE on the same problems.</li>
+                    <li><strong>Per generation:</strong> population_size evaluations + selection/crossover/mutation operators.</li>
+                    <li><strong>Relative to mealpy <code>BaseGA</code></strong> at <code>n_trials=200, n_dim=2</code>: HumpDay wins on sphere, Rosenbrock, and Ackley. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -255,17 +255,16 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Hill Climbing</strong> is one of the simplest local search optimization algorithms. It repeatedly moves to neighboring solutions that improve the objective function, stopping when no better neighbors exist. Despite its simplicity, hill climbing forms the foundation for many more sophisticated optimization methods and serves as an important baseline for local search techniques.
+                <strong>Hill Climbing</strong> in HumpDay is a <strong>(1+1)-Evolution Strategy with a deterministic &sigma; decay schedule</strong>. Each iteration proposes one Gaussian-perturbed offspring; the offspring is accepted if it improves the objective. There is no 1/5-success rule (that's the <a href="adaptive-random-search.html">Rechenberg</a> variant) &mdash; &sigma; decays geometrically from <em>&sigma;<sub>init</sub> = 0.1</em> to <em>&sigma;<sub>final</sub> = 1e&minus;3</em> over the budget. This matches the textbook "hill climbing with shrinking perturbations" intuition and what <code>tests/test_reference_alignment.py</code> compares against.
             </div>
 
             <div class="local-search-note">
-                <h3>️ Local Search Algorithm Notice</h3>
-                <p><strong>Hill Climbing is a pure local search method:</strong></p>
+                <h3>HumpDay's HillClimbing at a glance</h3>
                 <ul>
-                    <li><strong>Local Optima:</strong> Gets trapped in local minima - no global search capability</li>
-                    <li><strong>Starting Point Dependent:</strong> Final solution depends heavily on initialization</li>
-                    <li><strong>Fast Convergence:</strong> Very efficient for local refinement</li>
-                    <li><strong>Baseline Method:</strong> Useful as starting point or component in hybrid algorithms</li>
+                    <li><strong>Initial &sigma;:</strong> <code>0.1</code>.</li>
+                    <li><strong>Decay:</strong> geometric, computed so that &sigma; ends at <code>1e-3</code> after <code>n_trials &minus; 1</code> iterations.</li>
+                    <li><strong>Acceptance:</strong> greedy (1+1) selection &mdash; accept only if <em>f<sub>new</sub> &lt; f</em>.</li>
+                    <li><strong>Proposal:</strong> componentwise Gaussian, <em>x<sub>new</sub> = clip(x + &sigma;&middot;z)</em> with <em>z &sim; N(0, I)</em>.</li>
                 </ul>
             </div>
             <div class="visualization-section">
@@ -321,24 +320,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python Implementation</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>Humpday Hill Climbing</strong><br>
-                            Custom local search with neighborhood generation<br>
-                            Steepest ascent or first improvement strategies<br>
-                            <em>File: humpday/optimizers/localsearch*.py</em>
+                            <strong>HumpDay <code>HillClimbing</code></strong><br>
+                            (1+1)-ES with geometric &sigma; decay from 0.1 to 1e&minus;3 over the budget. Greedy acceptance, componentwise Gaussian proposals.<br>
+                            Pure Python; no required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/evolutionary_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L1003" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Pure JavaScript hill climbing with random neighbors<br>
-                            Configurable step size and neighborhood sampling<br>
-                            <em>Class: HillClimbing</em>
+                            <strong>Browser <code>HillClimbing</code></strong><br>
+                            Mirrors the Python port.<br>
+                            <em>Class: <code>HillClimbing</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/search-algorithms.js" target="_blank" class="link-button javascript">JS Implementation</a>
@@ -350,11 +348,10 @@
             <div class="performance-notes">
                 <h3>Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Local refinement, unimodal functions, quick improvements</li>
-                    <li><strong>Dimensions:</strong> Scalable to any dimension</li>
-                    <li><strong>Function evaluations:</strong> Very efficient, minimal evaluations per step</li>
-                    <li><strong>Convergence:</strong> Fast local convergence, no global guarantees</li>
-                    <li><strong>Robustness:</strong> Simple and reliable, but limited by local optima</li>
+                    <li><strong>Best for:</strong> Smooth basins where the geometric &sigma; schedule lines up with the budget. One evaluation per iteration makes it cheap.</li>
+                    <li><strong>Worst for:</strong> Multimodal landscapes &mdash; HillClimbing has no escape mechanism. Once trapped in a local basin, it refines into it.</li>
+                    <li><strong>Per iteration:</strong> one Gaussian proposal, one evaluation, one greedy comparison.</li>
+                    <li><strong>Relative to its inline (1+1)-ES &sigma;-decay reference</strong> at <code>n_trials=200, n_dim=2</code>: HumpDay matches across sphere, Rosenbrock, and Ackley &mdash; algorithmically identical. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/particle-swarm.html
+++ b/docs/algorithms/particle-swarm.html
@@ -251,7 +251,7 @@
 
     <div class="abstract">
         <h3>Abstract</h3>
-        <p>Particle Swarm Optimization (PSO) is a population-based stochastic optimization technique inspired by the social behavior of bird flocking and fish schooling. Originally developed by Kennedy and Eberhart (1995), PSO optimizes a problem by iteratively improving candidate solutions (particles) with regard to a given measure of quality. Each particle adjusts its position based on its own best-known position and the swarm's best-known position, guided by velocity vectors that balance exploration and exploitation.</p>
+        <p>Particle Swarm Optimization (PSO) is a population-based stochastic optimization technique introduced by Kennedy and Eberhart (1995). A swarm of particles flies through the search space; each particle's velocity is steered toward its personal best position and the swarm's global best position. HumpDay's <code>ParticleSwarm</code> uses an annealed inertia / cognitive / social schedule, velocity clamping that shrinks over the run, and finishes with an L-BFGS-B polish from the swarm best.</p>
     </div>
 
     <h2>Algorithm Description</h2>
@@ -310,7 +310,7 @@
     </table>
 
     <div class="performance-note">
-        <p><strong>Implementation Notes:</strong> This implementation includes adaptive parameters, velocity clamping, and diversification mechanisms for improved convergence and global search capabilities. The swarm size scales with problem dimensionality, and the algorithm includes early termination criteria for efficient resource utilization.</p>
+        <p><strong>HumpDay's PSO at a glance.</strong> Annealed coefficients (<em>w</em>: 0.9 &rarr; 0.4, <em>c<sub>1</sub></em>: 2.5 &rarr; 1.5, <em>c<sub>2</sub></em>: 1.5 &rarr; 2.5) over the run shift the balance from exploration to exploitation. Velocity is clamped to <em>v<sub>max</sub> = 0.2&middot;(1 &minus; 0.5&middot;t/T)</em>. After the swarm exhausts its share of the budget, an <strong>L-BFGS-B polish</strong> from the swarm best (<code>min(20&middot;n_dim, n_trials/2)</code> evals) refines to high precision &mdash; this is the change that pushes HumpDay's PSO past mealpy PSO on the SOTA snapshot.</p>
     </div>
 
     <h2>Algorithmic Parameters</h2>


### PR DESCRIPTION
## Summary

Five more algorithm pages get a careful pass. Each is a population/sampling method without an L-BFGS-B polish stage, so the page focuses on the population operators and the relationship to the reference.

### Per-page highlights

**\`particle-swarm.html\`** — replace the vague "adaptive parameters" / "PySwarms" boilerplate with specifics: annealed inertia (0.9→0.4), cognitive (2.5→1.5) and social (1.5→2.5) coefficients, velocity clamping that shrinks over the run, **L-BFGS-B polish** from the swarm best.

**\`genetic-algorithm.html\`** — replace the DEAP-themed cells with what HumpDay's GA actually does: real-valued representation, **tournament-of-3 selection**, one-point crossover, per-coordinate Bernoulli mutation with uniform noise, elitism on the best individual.

**\`evolution-strategy.html\`** — reframe as the canonical (μ+λ) ES with fixed σ=0.2 (no covariance adaptation — that's CMA-ES's contribution). Point readers to CMA-ES for ill-conditioned problems.

**\`hill-climbing.html\`** — big rewrite. HumpDay's HillClimbing is *not* a textbook greedy local search — it's a **(1+1)-ES with deterministic geometric σ decay** (σ_init=0.1, σ_final=1e−3). Page now reflects this, with the same description the reference adapter in \`_ref_oneplusone_es_decay\` uses.

**\`ant-colony-optimization.html\`** — catastrophic fix. The page's body content was still **~80% Harmony Search residue** (Harmony Memory, HMS, HMCR, PAR, "Musical Analogy Details", "Creative Aspects"…) — clearly forked from \`harmony-search.html\` and never finished. Replaced the whole "More Resources" section with proper ACO content: archive structure, rank-based sampling weights, Gaussian-kernel sampler, archive update. This is the **Socha-Dorigo continuous ACOR (2008)** algorithm HumpDay actually implements.

All five pages now cross-link \`docs/sota-status.html\` for live benchmark numbers.

## Test plan

- [x] No code touched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)