### PR TITLE
Algorithm pages: rewrite the last 6 (NM / Powell / NEWUOA / BOBYQA / HS / RS)

### DIFF
--- a/docs/algorithms/bobyqa.html
+++ b/docs/algorithms/bobyqa.html
@@ -242,7 +242,17 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>BOBYQA</strong> is Powell's trust-region method specifically designed for bound-constrained optimization. It builds quadratic models while respecting variable bounds, making it ideal for optimization problems with simple constraints like the unit hypercube [0,1]ⁿ used in our competition.
+                <strong>BOBYQA</strong> (Bound Optimization BY Quadratic Approximation; Powell, 2009) is a trust-region method that extends NEWUOA with explicit handling of simple bound constraints <em>l<sub>i</sub> &le; x<sub>i</sub> &le; u<sub>i</sub></em>. Like NEWUOA it uses a <em>2n + 1</em>-point underdetermined interpolation set with the minimum-Frobenius-norm Hessian update, but the trust-region subproblem is solved within the active bound set (the "TRSBOX" subroutine in Powell's original Fortran). HumpDay's <code>PRIMA_BOBYQA</code> ports the algorithm directly with a bound-aware Cauchy/dogleg TR step and a finite-difference gradient fallback when the regression is rank-deficient.
+            </div>
+
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's BOBYQA at a glance</h3>
+                <ul>
+                    <li><strong>Bounds:</strong> the unit cube <code>[0, 1]<sup>n</sup></code>. Initial points are placed inside the cube (not on the boundary).</li>
+                    <li><strong>Interpolation set:</strong> <code>npt = 2&middot;n + 1</code> with the min-Frobenius Hessian update.</li>
+                    <li><strong>Trust-region step:</strong> bound-aware Cauchy / dogleg; projects step components that would push <em>x</em> past an active bound.</li>
+                    <li><strong>Fallback:</strong> finite-difference gradient when the regression is rank-deficient.</li>
+                </ul>
             </div>
 
             <div class="visualization-section">
@@ -298,24 +308,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python port of BOBYQA — bound-constrained trust region, no PDFO/Fortran call<br>
-                            No required dependencies<br>
-                            <em>File: humpday/optimizers/prima_algorithms.py</em>
+                            <strong>HumpDay <code>PRIMA_BOBYQA</code></strong><br>
+                            Pure-Python port: min-Frobenius Hessian update on <em>2n + 1</em> points, bound-aware TR step, FD-gradient fallback.<br>
+                            No required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/prima_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L1101" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Bound-aware trust region implementation<br>
-                            Optimized for unit hypercube constraints<br>
-                            <em>Class: PRIMA_BOBYQA</em>
+                            <strong>Browser <code>PRIMA_BOBYQA</code></strong><br>
+                            Mirrors the Python port (rewritten in PR #83 to match Python's FD-gradient fallback).<br>
+                            <em>Class: <code>PRIMA_BOBYQA</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
@@ -327,11 +336,10 @@
             <div class="performance-notes">
                 <h3>Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Bound-constrained optimization problems, especially [0,1]ⁿ</li>
-                    <li><strong>Dimensions:</strong> Excellent performance up to 100+ dimensions</li>
-                    <li><strong>Function evaluations:</strong> Very efficient with bounds guidance</li>
-                    <li><strong>Convergence:</strong> Superior to UOBYQA/NEWUOA on bounded problems</li>
-                    <li><strong>Robustness:</strong> Handles boundary conditions elegantly</li>
+                    <li><strong>Best for:</strong> Smooth, bound-constrained problems &mdash; especially when the optimum is near a face of the cube where bound handling matters.</li>
+                    <li><strong>Worst for:</strong> Multimodal landscapes &mdash; like all PRIMA algorithms, BOBYQA is a local trust-region method.</li>
+                    <li><strong>Per iteration:</strong> one TR step + one evaluation. Bounds projected on both the step direction and the candidate point.</li>
+                    <li><strong>Relative to Py-BOBYQA</strong> at <code>n_trials=200, n_dim=2</code>: matches reference on sphere and Ackley, with a tiny gap on Rosenbrock. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/harmony-search.html
+++ b/docs/algorithms/harmony-search.html
@@ -241,17 +241,16 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Harmony Search (HS)</strong> is a nature-inspired metaheuristic algorithm based on the improvisation process of musicians. Developed by Zong Woo Geem in 2001, it mimics how musicians compose harmonies by combining existing melodies with new variations. The algorithm maintains a harmony memory of good solutions and generates new candidates through musical improvisation rules.
+                <strong>Harmony Search</strong> (Geem, 2001) maintains a "harmony memory" (HM) of the <em>HMS</em> best solutions found so far and improvises a new candidate each iteration. For each coordinate: with probability <em>HMCR</em>, copy from a randomly selected memory entry, optionally adjusting the value with probability <em>PAR</em>; with probability <em>1 &minus; HMCR</em>, draw a uniform random value. Then evaluate and replace the worst harmony if the new one is better. HumpDay's <code>HarmonySearch</code> is the canonical formulation.
             </div>
 
-            <div class="harmony-note">
-                <h3>Musical Improvisation Metaphor</h3>
-                <p><strong>Harmony Search mimics musical composition process:</strong></p>
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's HarmonySearch at a glance</h3>
                 <ul>
-                    <li><strong>Harmony Memory:</strong> Collection of good musical pieces (solutions)</li>
-                    <li><strong>Memory Consideration:</strong> Play a note from existing harmonies</li>
-                    <li><strong>Pitch Adjustment:</strong> Slightly modify a selected note</li>
-                    <li><strong>Random Selection:</strong> Play a completely new note</li>
+                    <li><strong>Memory size:</strong> <em>HMS</em>, typically 5-15.</li>
+                    <li><strong>Harmony memory considering rate:</strong> <em>HMCR &approx; 0.9</em> &mdash; high memory bias.</li>
+                    <li><strong>Pitch adjusting rate:</strong> <em>PAR &approx; 0.3</em> &mdash; chance of locally perturbing a memory-copied value.</li>
+                    <li><strong>Per iteration:</strong> one new harmony evaluated; if better than the current worst, the worst is replaced and the memory is re-sorted.</li>
                 </ul>
             </div>
 
@@ -297,34 +296,32 @@
                     <tr>
                         <td class="category">Reference Implementation</td>
                         <td>
-                            <strong>pyHarmonySearch</strong><br>
-                            Tested against pyHarmonySearch package<br>
-                            Optional external dependency for validation<br>
-                            <em>Reference: PyPI harmony search implementation</em>
+                            <strong>mealpy HS</strong><br>
+                            Tested against mealpy's Original Harmony Search.<br>
+                            <em>Reference: <code>mealpy.music_based.HS.OriginalHS</code></em>
                         </td>
                         <td>
-                            <a href="https://pypi.org/project/pyHarmonySearch/" target="_blank" class="link-button">PyPI Package</a>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="category">Humpday Python Implementation</td>
-                        <td>
-                            <strong>Humpday Harmony Search</strong><br>
-                            Custom implementation with classical HS operators<br>
-                            Harmony memory, pitch adjustment, and randomization<br>
-                            <em>File: humpday/optimizers/evolutionary_algorithms.py</em>
-                        </td>
-                        <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py#L1045" target="_blank" class="link-button python">Source</a>
+                            <a href="https://github.com/thieu1995/mealpy" target="_blank" class="link-button python">mealpy</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Pure JavaScript harmony search<br>
-                            Memory management and improvisation rules<br>
-                            <em>Class: HarmonySearch</em>
+                            <strong>HumpDay <code>HarmonySearch</code></strong><br>
+                            Canonical Harmony Search: HM + HMCR + PAR + random selection. One new harmony per iteration.<br>
+                            Pure Python; no required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/evolutionary_algorithms.py</code></em>
+                        </td>
+                        <td>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/evolutionary_algorithms.py" target="_blank" class="link-button python">Source</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="category">HumpDay JavaScript</td>
+                        <td>
+                            <strong>Browser <code>HarmonySearch</code></strong><br>
+                            Mirrors the Python port.<br>
+                            <em>Class: <code>HarmonySearch</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/evolutionary-algorithms.js" target="_blank" class="link-button javascript">JS Implementation</a>
@@ -336,11 +333,10 @@
             <div class="performance-notes">
                 <h3>Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Continuous optimization, parameter tuning, engineering design</li>
-                    <li><strong>Dimensions:</strong> Handles moderate to high dimensions well</li>
-                    <li><strong>Function evaluations:</strong> Memory-based, HMS × generations</li>
-                    <li><strong>Convergence:</strong> Steady improvement through memory exploitation</li>
-                    <li><strong>Robustness:</strong> Balance between exploitation and exploration through HS operators</li>
+                    <li><strong>Best for:</strong> Mid-range black-box objectives where memory-based exploitation balances against occasional random exploration.</li>
+                    <li><strong>Worst for:</strong> Smooth basins where directional methods (CMA-ES, PRIMA) converge much faster, and high dimensions where the memory bias struggles.</li>
+                    <li><strong>Per iteration:</strong> one new harmony evaluated; memory update is <em>O(HMS)</em>.</li>
+                    <li><strong>Relative to mealpy HS</strong> at <code>n_trials=200, n_dim=2</code>: HumpDay wins across sphere, Rosenbrock, and Ackley. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -242,7 +242,16 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Nelder-Mead</strong> is a classic derivative-free optimization method that uses a simplex (n+1 vertices in n dimensions) to search the parameter space. It's remarkably robust and intuitive, using geometric operations like reflection, expansion, and contraction to navigate toward the optimum.
+                <strong>Nelder-Mead</strong> (Nelder &amp; Mead, 1965) maintains a simplex of <em>n + 1</em> vertices in <em>n</em>-dimensional space and updates it each iteration via reflection, expansion, contraction, or shrinkage moves. HumpDay's <code>NelderMead</code> is a faithful pure-Python port of scipy's implementation: same canonical coefficients (&rho;=1, &chi;=2, &psi;=&sigma;=&frac12;), same simplex-initialization rules (perturb one coordinate at a time with <code>nonzdelt=0.05</code> / <code>zdelt=0.00025</code>), same convergence test on simplex spread.
+            </div>
+
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's Nelder-Mead at a glance</h3>
+                <ul>
+                    <li><strong>Coefficients:</strong> &rho;=1 (reflection), &chi;=2 (expansion), &psi;=&frac12; (contraction), &sigma;=&frac12; (shrinkage) &mdash; scipy's defaults.</li>
+                    <li><strong>Simplex init:</strong> from a random interior point <em>x<sub>0</sub></em>, the remaining vertices perturb one coordinate at a time by <em>1 + nonzdelt</em> (or <em>zdelt</em> if the coordinate is zero).</li>
+                    <li><strong>Convergence:</strong> <code>xatol = fatol = 1e-12</code> &mdash; tightened from scipy's default 1e-4 so the algorithm uses the full budget where the landscape permits.</li>
+                </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -285,27 +294,37 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">Reference Implementation</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python simplex method, faithful to SciPy's parameters (rho=1, chi=2, psi=sigma=0.5)<br>
-                            No required dependencies<br>
-                            <em>File: humpday/optimizers/scipy_algorithms.py</em>
+                            <strong>scipy.optimize Nelder-Mead</strong><br>
+                            scipy's Fortran-backed simplex method.<br>
+                            <em>Reference: <code>scipy.optimize.minimize(method='Nelder-Mead')</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L18" target="_blank" class="link-button python">Python Code</a>
+                            <a href="https://docs.scipy.org/doc/scipy/reference/optimize.minimize-neldermead.html" target="_blank" class="link-button python">SciPy Docs</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Pure JavaScript port with simplex operations<br>
-                            Maintains geometric transformation logic<br>
-                            <em>Class: NelderMead</em>
+                            <strong>HumpDay <code>NelderMead</code></strong><br>
+                            Pure-Python simplex method, faithful to scipy's parameters and convergence test.<br>
+                            No required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/scipy_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js" target="_blank" class="link-button javascript">JavaScript Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Source</a>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="category">HumpDay JavaScript</td>
+                        <td>
+                            <strong>Browser <code>NelderMead</code></strong><br>
+                            Mirrors the Python port.<br>
+                            <em>Class: <code>NelderMead</code></em>
+                        </td>
+                        <td>
+                            <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
                         </td>
                     </tr>
 </tbody>
@@ -314,11 +333,10 @@
             <div class="performance-notes">
                 <h3>Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Low to medium dimensions (2-20D), robust across function types</li>
-                    <li><strong>Dimensions:</strong> Performance degrades significantly above 10-20 dimensions</li>
-                    <li><strong>Function evaluations:</strong> Typically O(n) evaluations per iteration</li>
-                    <li><strong>Convergence:</strong> Reliable but can be slow on ill-conditioned problems</li>
-                    <li><strong>Robustness:</strong> Excellent on noisy, discontinuous, and multimodal functions</li>
+                    <li><strong>Best for:</strong> Low-dimensional black-box objectives where the simplex moves can navigate the surface without curvature information.</li>
+                    <li><strong>Worst for:</strong> High dimensions &mdash; simplex moves degenerate past ~10-20 dimensions because the relevant geometry becomes too thin.</li>
+                    <li><strong>Per iteration:</strong> 1 reflection eval; possibly 1 expansion or 1-2 contraction evals; rarely <em>n</em>+1 shrinkage evals.</li>
+                    <li><strong>Relative to scipy.optimize Nelder-Mead</strong> at <code>n_trials=200, n_dim=2</code>: ties across sphere, Rosenbrock, and Ackley &mdash; algorithmically identical, differs only in the interpreter tax. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -244,7 +244,18 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>NEWUOA</strong> is an advanced trust-region method that builds underdetermined quadratic models using fewer interpolation points than UOBYQA. Developed by M.J.D. Powell as an improvement over UOBYQA, it uses 2n+1 interpolation points instead of the full (n+1)(n+2)/2, making it more efficient for higher-dimensional problems while maintaining good approximation quality.
+                <strong>NEWUOA</strong> (Powell, 2006) is a trust-region method for derivative-free optimization that builds <em>underdetermined</em> quadratic models from <em>2n + 1</em> interpolation points (compared to UOBYQA's full <em>(n+1)(n+2)/2</em>). The underdetermination is resolved by Powell's <strong>minimum-Frobenius-norm update</strong>: pick the Hessian closest in Frobenius norm to the previous Hessian, subject to the interpolation constraints. This lets NEWUOA capture cross-coupling (e.g., Rosenbrock's <em>(b &minus; a<sup>2</sup>)<sup>2</sup></em> term) despite using only <em>2n + 1</em> points. HumpDay's <code>PRIMA_NEWUOA</code> implements the min-Frobenius update directly, with a dogleg trust-region step and unconditional base-point shifting.
+            </div>
+
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's NEWUOA at a glance</h3>
+                <ul>
+                    <li><strong>Interpolation set:</strong> <code>npt = 2&middot;n + 1</code> points. Initial design: base point + &plusmn;&rho; along each coordinate.</li>
+                    <li><strong>Model fit:</strong> minimum-Frobenius-norm Hessian update (Powell's recipe) &mdash; keeps <em>H</em> as close as possible to the previous Hessian, subject to the interpolation constraints.</li>
+                    <li><strong>Trust-region step:</strong> dogleg path (Cauchy &rarr; Newton).</li>
+                    <li><strong>Geometry:</strong> furthest-from-new-position replacement for the interpolation set.</li>
+                    <li><strong>Base-point shifting:</strong> unconditional at the end of each iteration, so <code>XPT[kopt] &approx; 0</code> at the start of every model fit.</li>
+                </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -300,24 +311,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python port of NEWUOA — underdetermined quadratic trust region, no PDFO/Fortran call<br>
-                            No required dependencies<br>
-                            <em>File: humpday/optimizers/prima_algorithms.py</em>
+                            <strong>HumpDay <code>PRIMA_NEWUOA</code></strong><br>
+                            Pure-Python port: minimum-Frobenius-norm Hessian update on a <em>2n + 1</em>-point interpolation set, dogleg trust-region step, furthest-from-new-position geometry, unconditional base-point shifting.<br>
+                            No required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/prima_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py#L735" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/prima_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            JavaScript port attempting to match PDFO behavior<br>
-                            Underdetermined quadratic model building<br>
-                            <em>Class: PRIMA_NEWUOA</em>
+                            <strong>Browser <code>PRIMA_NEWUOA</code></strong><br>
+                            Mirrors the Python port.<br>
+                            <em>Class: <code>PRIMA_NEWUOA</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/prima-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
@@ -329,11 +339,10 @@
             <div class="performance-notes">
                 <h3>Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Smooth, unconstrained problems in moderate to high dimensions</li>
-                    <li><strong>Dimensions:</strong> Particularly effective for n > 10 where UOBYQA becomes expensive</li>
-                    <li><strong>Function evaluations:</strong> Uses 2n+1 points, more efficient than UOBYQA's (n+1)(n+2)/2</li>
-                    <li><strong>Convergence:</strong> Excellent convergence on smooth functions</li>
-                    <li><strong>Robustness:</strong> Handles moderate noise, good balance of exploration and exploitation</li>
+                    <li><strong>Best for:</strong> Smooth, unconstrained problems in moderate to high dimensions. The <em>2n+1</em>-point design scales better than UOBYQA's full-quadratic and the min-Frobenius update keeps the model curvature informative.</li>
+                    <li><strong>Worst for:</strong> Multimodal landscapes &mdash; like all PRIMA algorithms, NEWUOA is a local trust-region method.</li>
+                    <li><strong>Per iteration:</strong> one TR step + one evaluation. Each iteration also requires a small linear-algebra solve for the min-Frobenius Hessian update.</li>
+                    <li><strong>Relative to PDFO NEWUOA</strong> at <code>n_trials=200, n_dim=2</code>: matches reference across sphere, Rosenbrock, and Ackley. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -243,7 +243,17 @@
             </div>
 
             <div class="algorithm-description">
-                <strong>Powell's Method</strong> is a derivative-free optimization algorithm that builds a set of conjugate search directions. Developed by Michael J.D. Powell in the 1960s, it's particularly effective for quadratic functions and doesn't require gradient information. The method iteratively optimizes along coordinate axes and then along constructed conjugate directions.
+                <strong>Powell's Method</strong> (Powell, 1964) is a derivative-free optimizer that minimises along a set of search directions, then updates the direction set to capture local curvature. Each outer iteration: line-search along every direction <em>d<sub>i</sub></em>, then add the cumulative displacement as a new direction (replacing the one that gave the largest decrease). HumpDay's <code>Powell</code> is a faithful pure-Python port of scipy's <code>method='Powell'</code> with bounded golden-section / Brent-style line search and the standard direction-set update.
+            </div>
+
+            <div class="coordinate-note" style="background:#e8f4fd; border:1px solid #bee5eb; border-radius:8px; padding:15px; margin:20px 0;">
+                <h3 style="color:#0c5460; margin-top:0;">HumpDay's Powell at a glance</h3>
+                <ul>
+                    <li><strong>Initial direction set:</strong> identity matrix &mdash; coordinate directions.</li>
+                    <li><strong>Line search:</strong> bounded Brent search per direction, clipped to the unit cube.</li>
+                    <li><strong>Direction update:</strong> after a full sweep, add <em>x<sub>final</sub> &minus; x<sub>start</sub></em> as a new direction, replacing the direction that gave the largest decrease (standard Powell update).</li>
+                    <li><strong>Convergence:</strong> <code>ftol = 1e-12</code> on relative function change. Tightened from scipy's default 1e-4 so the algorithm uses its budget on smooth basins.</li>
+                </ul>
             </div>
             <div class="visualization-section">
                 <h3>Interactive 3D Visualization</h3>
@@ -299,24 +309,23 @@
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday Python</td>
+                        <td class="category">HumpDay Python</td>
                         <td>
-                            <strong>HumpDay Python Implementation</strong><br>
-                            Pure-Python conjugate-direction method with bounded golden-section line search<br>
-                            No required dependencies<br>
-                            <em>File: humpday/optimizers/scipy_algorithms.py</em>
+                            <strong>HumpDay <code>Powell</code></strong><br>
+                            Pure-Python port of scipy's Powell with direction-set update and bounded Brent line search.<br>
+                            No required dependencies.<br>
+                            <em>File: <code>humpday/optimizers/scipy_algorithms.py</code></em>
                         </td>
                         <td>
-                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py#L148" target="_blank" class="link-button python">Source Code</a>
+                            <a href="https://github.com/microprediction/humpday/blob/main/humpday/optimizers/scipy_algorithms.py" target="_blank" class="link-button python">Source</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="category">Humpday JavaScript</td>
+                        <td class="category">HumpDay JavaScript</td>
                         <td>
-                            <strong>Browser Implementation</strong><br>
-                            Pure JavaScript port of Powell's conjugate direction method<br>
-                            Line search optimization with direction set updates<br>
-                            <em>Class: Powell</em>
+                            <strong>Browser <code>Powell</code></strong><br>
+                            Mirrors the Python port.<br>
+                            <em>Class: <code>Powell</code></em>
                         </td>
                         <td>
                             <a href="https://github.com/microprediction/humpday/blob/main/docs/js/modules/scipy-algorithms.js" target="_blank" class="link-button javascript">JS Port</a>
@@ -328,11 +337,10 @@
             <div class="performance-notes">
                 <h3>Performance Characteristics</h3>
                 <ul>
-                    <li><strong>Best for:</strong> Quadratic functions and smooth, unimodal problems</li>
-                    <li><strong>Dimensions:</strong> Works well up to moderate dimensions (~20-50)</li>
-                    <li><strong>Function evaluations:</strong> Typically O(n²) evaluations per iteration</li>
-                    <li><strong>Convergence:</strong> Excellent on quadratic functions, linear convergence</li>
-                    <li><strong>Robustness:</strong> Can be sensitive to poorly conditioned problems</li>
+                    <li><strong>Best for:</strong> Smooth, low-dimensional objectives where conjugate directions capture curvature without needing gradients.</li>
+                    <li><strong>Worst for:</strong> High dimensions &mdash; the direction-set update degrades and the per-iteration cost grows.</li>
+                    <li><strong>Per outer iteration:</strong> <em>n</em> line searches (each is a 1-D Brent search inside <code>[0, 1]</code>), plus the direction-set update.</li>
+                    <li><strong>Relative to scipy.optimize Powell</strong> at <code>n_trials=200, n_dim=2</code>: ties on sphere and Ackley; a small (2&times;) gap on Rosenbrock from the interpreter tax on the line searches. See <a href="../sota-status.html">SOTA status</a> for the live numbers.</li>
                 </ul>
             </div>
 

--- a/docs/algorithms/random-search.html
+++ b/docs/algorithms/random-search.html
@@ -239,7 +239,7 @@
 
     <div class="abstract">
         <h3>Abstract</h3>
-        <p>Random Search is a fundamental optimization technique that explores the search space by uniformly sampling random points and tracking the best solution found. Despite its simplicity, Random Search serves as an important baseline for evaluating more sophisticated optimization algorithms and can be surprisingly effective for high-dimensional problems with complex landscapes.</p>
+        <p><strong>RandomSearch is a baseline, not a SOTA algorithm.</strong> It draws <em>n_trials</em> i.i.d. uniform samples from <em>[0, 1]<sup>n</sup></em> and keeps the best. Two reasons to ship it: (1) <em>regression check</em> &mdash; any optimizer worth using should clearly beat RandomSearch on smooth problems; (2) <em>contest sanity floor</em> &mdash; ensures the benchmarking harness scores absolute performance, not just relative ranking among SOTA methods. The companion baseline is <code>GridSearch</code>, which enumerates a regular Cartesian grid instead.</p>
     </div>
 
     <h2>Algorithm Description</h2>
@@ -297,7 +297,7 @@
     </table>
 
     <div class="validation-status">
-        <p><strong>Validation Status:</strong> VALIDATED - Random search implementation verified against mathematical specification. Cross-platform consistency confirmed between Python and JavaScript versions.</p>
+        <p>The Python and JS implementations are i.i.d. uniform samplers; the reference adapter in <code>tests/test_reference_alignment.py</code> is also a uniform sampler with a different RNG seed. The ratio on <a href="../sota-status.html">SOTA status</a> is therefore close to 1 and not a quality signal &mdash; it's there as a sanity check that the harness is wired correctly.</p>
     </div>
 
     <h2>Theoretical Properties</h2>


### PR DESCRIPTION
## Summary

Completes the per-page documentation sweep for all 21 algorithm pages (GridSearch doesn't have its own page yet — it would be the 22nd).

### Per-page highlights

**\`nelder-mead.html\`** — call out the specific scipy-matched coefficients (ρ=1, χ=2, ψ=σ=½), the simplex-init perturbation rules (nonzdelt=0.05, zdelt=0.00025), and the tightened tolerances (xatol = fatol = 1e-12). Add Reference Implementation row pointing at scipy NelderMead.

**\`powell.html\`** — name the algorithm components directly: identity direction set, bounded Brent line search per direction, the standard direction-set update (replace the largest-decrease direction with the cumulative displacement). Same tightened ftol = 1e-12.

**\`newuoa.html\`** — focus on what makes NEWUOA NEWUOA: the **minimum-Frobenius-norm Hessian update** on a 2n+1-point underdetermined interpolation set. This is the recipe that captures cross-coupling (like Rosenbrock's b−a² term) despite using only 2n+1 points. Mention the dogleg TR step, furthest-from-new-position replacement, and unconditional base-point shifting.

**\`bobyqa.html\`** — extend the NEWUOA explanation with BOBYQA's contribution: bound-aware trust-region step (Powell's TRSBOX, ported inline with a Cauchy/dogleg variant). Note the FD-gradient fallback when the regression is rank-deficient.

**\`harmony-search.html\`** — replace the musical-metaphor opener with a specific HMCR/PAR/HMS description. Note that HumpDay's HS wins vs mealpy HS on every cell of the snapshot. Update the Reference cell from pyHarmonySearch (which #212 had attempted to fix; the user's edits had reverted it).

**\`random-search.html\`** — make the **"this is a baseline, not a SOTA algorithm"** framing explicit in the abstract. Drop the bogus "Validation Status: VALIDATED" boilerplate and replace with a note that the SOTA ratio for RandomSearch isn't a quality signal.

All six pages now cross-link the SOTA status page for live benchmark numbers.

**This completes 21 of 21 algorithm pages** for the careful improvement goal.

## Test plan

- [x] No code touched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)