### PR TITLE
Format: ruff format pass on 7 files left unformatted by #221

### DIFF
--- a/benchmarks/build_recommendation_grid.py
+++ b/benchmarks/build_recommendation_grid.py
@@ -74,8 +74,13 @@ from typing import Callable
 # every worker spawns its own thread-pool inside numpy/MKL/OpenBLAS, and
 # `--workers N` × ~K BLAS threads each saturates the CPU and slows every
 # task. The combinatorics matter most for BayesianOpt's O(n_obs^3) GP fits.
-for _var in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
-             "VECLIB_MAXIMUM_THREADS", "NUMEXPR_NUM_THREADS"):
+for _var in (
+    "OMP_NUM_THREADS",
+    "OPENBLAS_NUM_THREADS",
+    "MKL_NUM_THREADS",
+    "VECLIB_MAXIMUM_THREADS",
+    "NUMEXPR_NUM_THREADS",
+):
     os.environ.setdefault(_var, "1")
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -132,6 +137,7 @@ PER_RUN_BUDGET_SECONDS = 30.0
 # Worker (process pool)
 # -----------------------------------------------------------------------------
 
+
 def _set_global_seed(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
@@ -153,7 +159,15 @@ def _run_one_in_worker(args) -> tuple:
     try:
         best_value, _ = pure_optimize(obj, algorithm, n_trials, n_dim)
         wall = time.perf_counter() - t0
-        return (cell_key, algorithm, objective_name, seed, float(best_value), wall, None)
+        return (
+            cell_key,
+            algorithm,
+            objective_name,
+            seed,
+            float(best_value),
+            wall,
+            None,
+        )
     except Exception as exc:  # noqa: BLE001
         wall = time.perf_counter() - t0
         return (cell_key, algorithm, objective_name, seed, float("inf"), wall, str(exc))
@@ -162,6 +176,7 @@ def _run_one_in_worker(args) -> tuple:
 # -----------------------------------------------------------------------------
 # Grid management — load, store, aggregate
 # -----------------------------------------------------------------------------
+
 
 def _empty_grid(dims: list[int], trials: list[int], n_seeds: int) -> dict:
     return {
@@ -185,9 +200,7 @@ def _load_or_init(path: Path, dims, trials, n_seeds) -> dict:
         with path.open() as fh:
             grid = json.load(fh)
     except (OSError, json.JSONDecodeError):
-        print(
-            f"  (existing {path} unreadable — starting fresh)", file=sys.stderr
-        )
+        print(f"  (existing {path} unreadable — starting fresh)", file=sys.stderr)
         return _empty_grid(dims, trials, n_seeds)
     # Extend meta with any newly-requested dims/trials.
     grid.setdefault("meta", {})
@@ -196,10 +209,13 @@ def _load_or_init(path: Path, dims, trials, n_seeds) -> dict:
     grid["meta"]["trials"] = sorted(set(grid["meta"].get("trials", [])) | set(trials))
     grid["meta"]["n_seeds"] = max(grid["meta"].get("n_seeds", 0), n_seeds)
     grid["meta"]["per_run_budget_seconds"] = PER_RUN_BUDGET_SECONDS
-    grid["meta"].setdefault("first_built", grid["meta"].get(
+    grid["meta"].setdefault(
         "first_built",
-        time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-    ))
+        grid["meta"].get(
+            "first_built",
+            time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        ),
+    )
     grid.setdefault("cells", {})
     return grid
 
@@ -220,9 +236,7 @@ def _aggregate(entry: dict) -> None:
 def _save_atomic(path: Path, grid: dict) -> None:
     """Write via a sibling temp file + rename so a kill mid-write can't leave
     the grid file truncated or syntactically broken."""
-    grid["meta"]["last_updated"] = time.strftime(
-        "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
-    )
+    grid["meta"]["last_updated"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.parent.mkdir(parents=True, exist_ok=True)
     tmp.write_text(json.dumps(grid, indent=2, sort_keys=True))
@@ -242,6 +256,7 @@ def _is_skipped_too_slow(entry: dict | None) -> bool:
 # -----------------------------------------------------------------------------
 # Task graph
 # -----------------------------------------------------------------------------
+
 
 def _build_tasks(
     grid: dict,
@@ -345,6 +360,7 @@ def _probe_first(
 # Main
 # -----------------------------------------------------------------------------
 
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -394,13 +410,9 @@ def main() -> int:
         trials_list = QUICK_TRIALS
         n_seeds = QUICK_SEEDS
     else:
-        dims = (
-            [int(d) for d in args.dims.split(",")] if args.dims else DEFAULT_DIMS
-        )
+        dims = [int(d) for d in args.dims.split(",")] if args.dims else DEFAULT_DIMS
         trials_list = (
-            [int(t) for t in args.trials.split(",")]
-            if args.trials
-            else DEFAULT_TRIALS
+            [int(t) for t in args.trials.split(",")] if args.trials else DEFAULT_TRIALS
         )
         n_seeds = args.seeds
 

--- a/humpday/eligibility.py
+++ b/humpday/eligibility.py
@@ -42,10 +42,10 @@ from pathlib import Path
 # only when the measured eval_time is at least MIN_EVAL_TIME_FOR_TIER[tier]:
 # this caps HumpDay overhead at roughly ~10% of total wall-clock.
 
-TIER_TRIVIAL = 0   # ~us per iter   — pure RNG draws or single componentwise step
-TIER_LIGHT = 1     # ~100us per iter — small per-iter loops, no linear algebra
-TIER_MEDIUM = 2    # ~1ms per iter   — small linear-algebra updates
-TIER_HEAVY = 3     # ~10ms per iter  — O(n^3) per generation
+TIER_TRIVIAL = 0  # ~us per iter   — pure RNG draws or single componentwise step
+TIER_LIGHT = 1  # ~100us per iter — small per-iter loops, no linear algebra
+TIER_MEDIUM = 2  # ~1ms per iter   — small linear-algebra updates
+TIER_HEAVY = 3  # ~10ms per iter  — O(n^3) per generation
 TIER_VERY_HEAVY = 4  # ~100ms per iter — O(n_obs^3) GP fit per iter
 
 
@@ -86,9 +86,9 @@ TIER: dict[str, int] = {
 # Below the threshold, that tier's overhead dominates wall-clock.
 MIN_EVAL_TIME_FOR_TIER: dict[int, float] = {
     TIER_TRIVIAL: 0.0,
-    TIER_LIGHT: 1e-5,    # 10 us — almost always allowed
-    TIER_MEDIUM: 1e-4,   # 100 us
-    TIER_HEAVY: 1e-3,    # 1 ms
+    TIER_LIGHT: 1e-5,  # 10 us — almost always allowed
+    TIER_MEDIUM: 1e-4,  # 100 us
+    TIER_HEAVY: 1e-3,  # 1 ms
     TIER_VERY_HEAVY: 1e-2,  # 10 ms — GP fit dominates below this
 }
 
@@ -100,18 +100,18 @@ MIN_EVAL_TIME_FOR_TIER: dict[int, float] = {
 # listed here are treated as having no cap (linear-in-dim or better).
 
 DIM_CAP: dict[str, int] = {
-    "GridSearch": 4,        # n_per_axis ** n_dim
-    "BayesianOpt": 10,      # GP cost + RBF kernel degeneracy
-    "PRIMA_UOBYQA": 12,     # (n+1)(n+2)/2 interpolation set
-    "NelderMead": 20,       # simplex degeneracy past ~20 dims
-    "PRIMA_NEWUOA": 25,     # underdetermined quadratic model fit
-    "PRIMA_BOBYQA": 30,     # same model machinery, bounds-aware — past
-                            # n=30 a single optimize() call takes minutes
-                            # because of the geometry/BIGLAG steps
-    "Powell": 30,           # direction-set line searches
-    "PatternSearch": 30,    # 2n directions per pattern
-    "FireflyAlgorithm": 50, # O(n_pop^2) attractions per gen
-    "AntColonyOpt": 50,     # archive-sample interactions
+    "GridSearch": 4,  # n_per_axis ** n_dim
+    "BayesianOpt": 10,  # GP cost + RBF kernel degeneracy
+    "PRIMA_UOBYQA": 12,  # (n+1)(n+2)/2 interpolation set
+    "NelderMead": 20,  # simplex degeneracy past ~20 dims
+    "PRIMA_NEWUOA": 25,  # underdetermined quadratic model fit
+    "PRIMA_BOBYQA": 30,  # same model machinery, bounds-aware — past
+    # n=30 a single optimize() call takes minutes
+    # because of the geometry/BIGLAG steps
+    "Powell": 30,  # direction-set line searches
+    "PatternSearch": 30,  # 2n directions per pattern
+    "FireflyAlgorithm": 50,  # O(n_pop^2) attractions per gen
+    "AntColonyOpt": 50,  # archive-sample interactions
     "CMAEvolutionStrategy": 100,  # eigendecomp O(n^3) per gen
 }
 
@@ -131,13 +131,14 @@ def min_trials(name: str, n_dim: int) -> int:
         return max(20, 4 * n_dim)
     if name == "GridSearch":
         # Need at least 3 points per axis to be meaningfully a grid.
-        return max(3 ** n_dim, 8)
+        return max(3**n_dim, 8)
     return 10
 
 
 # -----------------------------------------------------------------------------
 # Filters
 # -----------------------------------------------------------------------------
+
 
 def passes_dim(name: str, n_dim: int) -> bool:
     return n_dim <= DIM_CAP.get(name, 10_000)
@@ -182,10 +183,11 @@ def eligible(
 # Objective timing
 # -----------------------------------------------------------------------------
 
+
 @dataclass
 class TimingResult:
-    eval_time: float          # seconds per call (median of samples)
-    samples: list[float]      # all measured times
+    eval_time: float  # seconds per call (median of samples)
+    samples: list[float]  # all measured times
     used_for_recommendation: bool  # True if we let timing decide eligibility
 
 
@@ -222,6 +224,7 @@ def time_objective(
 # -----------------------------------------------------------------------------
 # Recommendation
 # -----------------------------------------------------------------------------
+
 
 def _rule_based_ranking(n_dim: int, n_trials: int) -> list[str]:
     """The pre-existing ordering from suggest_pure, copy-pasted here so the
@@ -313,9 +316,7 @@ def _load_grid(path: Path) -> dict | None:
     return grid
 
 
-def _snap_to_grid_cell(
-    grid: dict, n_dim: int, n_trials: int
-) -> dict[str, dict] | None:
+def _snap_to_grid_cell(grid: dict, n_dim: int, n_trials: int) -> dict[str, dict] | None:
     """Find the closest available cell to (n_dim, n_trials) in the grid.
 
     We snap to the nearest n_dim that is ≤ caller's n_dim (so we don't make
@@ -340,9 +341,7 @@ def _snap_to_grid_cell(
         feasible.sort(key=lambda dt: abs(dt[0] - n_dim) + abs(dt[1] - n_trials))
     else:
         # Pick the cell closest to (n_dim, n_trials) under the ≤ constraint.
-        feasible.sort(
-            key=lambda dt: (abs(dt[0] - n_dim), abs(dt[1] - n_trials))
-        )
+        feasible.sort(key=lambda dt: (abs(dt[0] - n_dim), abs(dt[1] - n_trials)))
     d, t = feasible[0]
     return cells.get(f"{d}/{t}")
 

--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -208,7 +208,7 @@ class ParticleSwarm(BaseOptimizer):
                 # keeps its memory, so the swarm continues from the same
                 # global best but with re-energized exploration.
                 ranked = sorted(range(swarm_size), key=personal_best_fit.__getitem__)
-                worst = ranked[swarm_size // 2:]
+                worst = ranked[swarm_size // 2 :]
                 for j in worst:
                     positions[j] = _A.random_uniform(self.n_dim)
                     velocities[j] = (_A.random_uniform(self.n_dim) - 0.5) * 0.2
@@ -673,7 +673,7 @@ class CMAEvolutionStrategy(BaseOptimizer):
             # Hansen's recommended parameters at the current population size.
             lambda_ = min(
                 cmaes_budget - self.evaluations,
-                int(base_lambda * (IPOP_INCPOPSIZE ** restart_count)),
+                int(base_lambda * (IPOP_INCPOPSIZE**restart_count)),
             )
             lambda_ = max(lambda_, 4)
             mu = lambda_ // 2  # number of parents
@@ -691,9 +691,7 @@ class CMAEvolutionStrategy(BaseOptimizer):
             cc = (4 + mueff / n) / (n + 4 + 2 * mueff / n)
             cs = (mueff + 2) / (n + mueff + 5)
             c1 = 2 / ((n + 1.3) ** 2 + mueff)
-            cmu = min(
-                1 - c1, 2 * (mueff - 2 + 1 / mueff) / ((n + 2) ** 2 + mueff)
-            )
+            cmu = min(1 - c1, 2 * (mueff - 2 + 1 / mueff) / ((n + 2) ** 2 + mueff))
             damps = 1 + 2 * max(0, math.sqrt((mueff - 1) / (n + 1)) - 1) + cs
 
             # Fresh state per restart. Initial mean is a random interior
@@ -780,9 +778,9 @@ class CMAEvolutionStrategy(BaseOptimizer):
                 # Evolution paths.
                 y = (mean - old_mean) / sigma
 
-                ps = (1 - cs) * ps + math.sqrt(cs * (2 - cs) * mueff) * _A.linalg.matvec(
-                    invsqrtC, y
-                )
+                ps = (1 - cs) * ps + math.sqrt(
+                    cs * (2 - cs) * mueff
+                ) * _A.linalg.matvec(invsqrtC, y)
 
                 hsig = (
                     1

--- a/humpday/optimizers/scipy_algorithms.py
+++ b/humpday/optimizers/scipy_algorithms.py
@@ -100,7 +100,9 @@ class NelderMead(BaseOptimizer):
                 # max over all (i, k) of |sim[i][k] - sim[0][k]| <= xatol AND
                 # max over i of |fsim[0] - fsim[i]| <= fatol.
                 x_max = max(
-                    abs(sim[i][k] - sim[0][k]) for i in range(1, n + 1) for k in range(n)
+                    abs(sim[i][k] - sim[0][k])
+                    for i in range(1, n + 1)
+                    for k in range(n)
                 )
                 f_max = max(abs(fsim[0] - fsim[i]) for i in range(1, n + 1))
                 if x_max <= xatol and f_max <= fatol:

--- a/tests/algorithms/test_restart_behavior.py
+++ b/tests/algorithms/test_restart_behavior.py
@@ -22,6 +22,7 @@ from humpday.optimizers.evolutionary_algorithms import (
 # ParticleSwarm — SPSO-2011 stagnation reseed
 # -----------------------------------------------------------------------------
 
+
 def _two_basin_1d(x):
     """Misleading shallow basin near 0.2; deeper one at 0.8."""
     x0 = float(x[0])
@@ -55,6 +56,7 @@ def test_pso_stagnation_reseed_escapes_shallow_basin():
 # CMAEvolutionStrategy — IPOP restart
 # -----------------------------------------------------------------------------
 
+
 def test_cma_es_ipop_escapes_local_optimum():
     """A 2D Rastrigin-style landscape with many local minima — vanilla
     CMA-ES converges to whichever basin its initial mean lands in. IPOP
@@ -80,8 +82,7 @@ def test_cma_es_ipop_escapes_local_optimum():
         if v < 0.5:
             near_global += 1
     assert near_global >= 9, (
-        f"CMA-ES IPOP found the global Rastrigin minimum in only "
-        f"{near_global}/15 runs"
+        f"CMA-ES IPOP found the global Rastrigin minimum in only {near_global}/15 runs"
     )
 
 

--- a/tests/test_eligibility.py
+++ b/tests/test_eligibility.py
@@ -16,6 +16,7 @@ from humpday import eligibility as E
 # Catalogue invariants
 # -----------------------------------------------------------------------------
 
+
 def test_every_known_algorithm_has_a_tier():
     """If a new algorithm gets added to PURE_OPTIMIZERS, this test should fail
     until someone classifies its overhead tier in eligibility.TIER."""
@@ -46,6 +47,7 @@ def test_thresholds_are_monotone():
 # -----------------------------------------------------------------------------
 # Dimensional filter
 # -----------------------------------------------------------------------------
+
 
 def test_grid_search_blocked_in_high_dim():
     assert E.passes_dim("GridSearch", 4)
@@ -82,6 +84,7 @@ def test_filter_by_dim_strips_caps():
 # Trials filter
 # -----------------------------------------------------------------------------
 
+
 def test_uobyqa_needs_quadratic_trials():
     # n_dim=10 → (11*12)/2 + 5 = 71 (well below the n_dim=12 hard cap)
     assert E.min_trials("PRIMA_UOBYQA", 10) >= 66
@@ -105,6 +108,7 @@ def test_default_minimum_is_ten():
 # Eval-time filter
 # -----------------------------------------------------------------------------
 
+
 def test_trivial_tier_always_passes_eval_time():
     assert E.passes_eval_time("RandomSearch", 0.0)
     assert E.passes_eval_time("RandomSearch", 1e-9)
@@ -125,6 +129,7 @@ def test_cma_es_threshold_at_one_ms():
 # -----------------------------------------------------------------------------
 # Combined eligibility
 # -----------------------------------------------------------------------------
+
 
 def test_eligible_combines_all_three_filters():
     # 50-dim, 1000 trials, 10us per eval:
@@ -161,6 +166,7 @@ def test_eligible_eval_time_none_skips_overhead_filter():
 # -----------------------------------------------------------------------------
 # Recommendation
 # -----------------------------------------------------------------------------
+
 
 def test_recommend_low_dim_expensive_picks_quadratic_model():
     # 2D, 200 trials, 1 second per eval — UOBYQA dominates
@@ -200,9 +206,10 @@ def test_recommend_respects_available_whitelist():
 # Timing
 # -----------------------------------------------------------------------------
 
+
 def test_time_objective_returns_positive_seconds():
     def f(x):
-        return float(np.sum(x ** 2))
+        return float(np.sum(x**2))
 
     result = E.time_objective(f, np.zeros(5), n_warmup=1, n_measure=3)
     assert result.eval_time > 0.0
@@ -213,7 +220,7 @@ def test_time_objective_returns_positive_seconds():
 def test_time_objective_detects_slow_function():
     def f(x):
         time.sleep(0.005)  # 5 ms per call
-        return float(np.sum(x ** 2))
+        return float(np.sum(x**2))
 
     result = E.time_objective(f, np.zeros(3), n_warmup=1, n_measure=3)
     # Should comfortably exceed the LIGHT-tier threshold (10us) and clear
@@ -245,8 +252,10 @@ def test_time_objective_uses_median():
 # Grid-driven recommendation
 # -----------------------------------------------------------------------------
 
+
 def _write_grid(tmp_path, cells: dict) -> "Path":
     import json
+
     p = tmp_path / "grid.json"
     p.write_text(json.dumps({"meta": {}, "cells": cells}))
     E._clear_grid_cache()
@@ -325,9 +334,7 @@ def test_recommend_grid_snaps_to_nearest_lower_cell(tmp_path):
         },
     )
     # Caller asks for n_dim=8 / n_trials=500 — should snap onto 5/200.
-    pick = E.recommend(
-        n_dim=8, n_trials=500, eval_time=1.0, grid_path=grid_path
-    )
+    pick = E.recommend(n_dim=8, n_trials=500, eval_time=1.0, grid_path=grid_path)
     assert pick == "CMAEvolutionStrategy"
 
 
@@ -346,9 +353,7 @@ def test_recommend_reads_aggregated_median_best_only(tmp_path):
             }
         },
     )
-    pick = E.recommend(
-        n_dim=5, n_trials=200, eval_time=1.0, grid_path=grid_path
-    )
+    pick = E.recommend(n_dim=5, n_trials=200, eval_time=1.0, grid_path=grid_path)
     assert pick == "CMAEvolutionStrategy"
 
 
@@ -367,9 +372,7 @@ def test_recommend_skips_inf_median_best(tmp_path):
             }
         },
     )
-    pick = E.recommend(
-        n_dim=5, n_trials=200, eval_time=1.0, grid_path=grid_path
-    )
+    pick = E.recommend(n_dim=5, n_trials=200, eval_time=1.0, grid_path=grid_path)
     assert pick == "DifferentialEvolution"
 
 
@@ -384,9 +387,7 @@ def test_recommend_grid_with_no_eligible_entries_falls_back_to_rule(tmp_path):
             }
         },
     )
-    pick = E.recommend(
-        n_dim=2, n_trials=100, eval_time=1e-9, grid_path=grid_path
-    )
+    pick = E.recommend(n_dim=2, n_trials=100, eval_time=1e-9, grid_path=grid_path)
     # Eval_time 1ns blocks every non-trivial tier — only tier-0 algorithms
     # remain eligible. HillClimbing is the first tier-0 entry in the
     # n_dim<=2 rule-based ranking, so it wins the fallback.

--- a/tests/test_smart_default_method.py
+++ b/tests/test_smart_default_method.py
@@ -26,7 +26,9 @@ def _quadratic(x):
 
 
 @pytest.mark.parametrize("n_dim", [1, 2, 5, 20, 75])
-def test_minimize_no_method_no_timing_matches_rule_ranking(n_dim, monkeypatch, tmp_path):
+def test_minimize_no_method_no_timing_matches_rule_ranking(
+    n_dim, monkeypatch, tmp_path
+):
     """With auto_timing disabled AND no benchmarks grid, the recommender's
     pick should equal the rule-based top — which is suggest_pure[0] for the
     dimensions tested here when the trial budget is large enough to clear
@@ -34,9 +36,7 @@ def test_minimize_no_method_no_timing_matches_rule_ranking(n_dim, monkeypatch, t
     before it's eligible)."""
     # Point the grid lookup at a path that doesn't exist so we exercise the
     # rule-based fallback rather than the committed benchmarks grid.
-    monkeypatch.setattr(
-        eligibility, "_GRID_PATH_DEFAULT", tmp_path / "no_grid.json"
-    )
+    monkeypatch.setattr(eligibility, "_GRID_PATH_DEFAULT", tmp_path / "no_grid.json")
     eligibility._clear_grid_cache()
 
     bounds = [(-1.0, 1.0)] * n_dim
@@ -76,9 +76,7 @@ def test_minimize_explicit_method_is_respected():
 
 def test_cube_minimize_no_method_no_timing_matches_rule_ranking(monkeypatch, tmp_path):
     """cube_minimize (the lower-level entrypoint) auto-picks too."""
-    monkeypatch.setattr(
-        eligibility, "_GRID_PATH_DEFAULT", tmp_path / "no_grid.json"
-    )
+    monkeypatch.setattr(eligibility, "_GRID_PATH_DEFAULT", tmp_path / "no_grid.json")
     eligibility._clear_grid_cache()
 
     n_dim = 8
@@ -115,6 +113,7 @@ def test_high_dim_rule_pick_prefers_adaptive_random_search():
 # -----------------------------------------------------------------------------
 # Timing-driven auto-pick
 # -----------------------------------------------------------------------------
+
 
 def _stash_method(mock_pure):
     """Pull the method name passed to pure_optimize from a Mock's call_args."""


### PR DESCRIPTION
## Summary

#221 squash-merged the substance of #219 + #220 but didn't pick up my \`ruff format\` commits. After the merge, \`ruff format --check .\` was flagging 7 files:

- \`benchmarks/build_recommendation_grid.py\`
- \`humpday/eligibility.py\`
- \`humpday/optimizers/evolutionary_algorithms.py\`
- \`humpday/optimizers/scipy_algorithms.py\`
- \`tests/algorithms/test_restart_behavior.py\`
- \`tests/test_eligibility.py\`
- \`tests/test_smart_default_method.py\`

This PR is \`ruff format .\` applied to bring main into compliance — pure formatting, no behavior change. Closes #219 and #220 (their substance was already merged via #221; this PR carries only the formatting that didn't ride along).

## Test plan

- [x] \`ruff format --check .\` — passes
- [x] \`ruff check .\` — passes
- [x] \`pytest tests/test_eligibility.py tests/test_smart_default_method.py tests/algorithms/test_restart_behavior.py tests/algorithms/test_scipy_algorithms.py tests/test_scipy_interface.py\` — 81 pass on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)