### PR TITLE
Algorithm pages: Auto-selection metadata card on all 21

### DIFF
--- a/docs/algorithms/adaptive-random-search.html
+++ b/docs/algorithms/adaptive-random-search.html
@@ -283,6 +283,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 0:</strong> trivial (~&micro;s/iter). Always eligible by the timing filter.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
             <h2>Implementation Details</h2>
             <table class="implementation-table">
                 <thead>

--- a/docs/algorithms/ant-colony-optimization.html
+++ b/docs/algorithms/ant-colony-optimization.html
@@ -272,6 +272,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> <code>n_dim &le; 50</code> &mdash; archive-sample interactions degrade.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
             <h2>Implementation Details</h2>
             <table class="implementation-table">
                 <thead>

--- a/docs/algorithms/bayesian-optimization.html
+++ b/docs/algorithms/bayesian-optimization.html
@@ -273,6 +273,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 4:</strong> very heavy (~100ms/iter; O(n_obs<sup>3</sup>) GP fit). Eligible when measured <code>eval_time &ge; 10 ms</code>.</li>
+                    <li><strong>Dimensional cap:</strong> <code>n_dim &le; 10</code> &mdash; GP cost O(n_obs<sup>3</sup>) + RBF kernel degeneracy.</li>
+                    <li><strong>Minimum trials:</strong> <code>max(30, 5n)</code> &mdash; GP needs initialisation samples to amortise its O(n_obs<sup>3</sup>) fits.</li>
+                </ul>
+            </div>
+
             <h2>Implementation Details</h2>
             <table class="implementation-table">
                 <thead>

--- a/docs/algorithms/bobyqa.html
+++ b/docs/algorithms/bobyqa.html
@@ -272,6 +272,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 2:</strong> medium (~1ms/iter; small linear-algebra updates). Eligible when measured <code>eval_time &ge; 100 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> <code>n_dim &le; 30</code> &mdash; geometry/BIGLAG steps make each call take minutes past n=30.</li>
+                    <li><strong>Minimum trials:</strong> <code>2n + 5</code> &mdash; needs an underdetermined quadratic model fit.</li>
+                </ul>
+            </div>
+
             <h2>Implementation Details</h2>
             <table class="implementation-table">
                 <thead>

--- a/docs/algorithms/cma-evolution-strategy.html
+++ b/docs/algorithms/cma-evolution-strategy.html
@@ -288,6 +288,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 3:</strong> heavy (~10ms/iter; full quadratic model or O(n<sup>3</sup>) eigendecomposition). Eligible when measured <code>eval_time &ge; 1 ms</code>.</li>
+                    <li><strong>Dimensional cap:</strong> <code>n_dim &le; 100</code> &mdash; eigendecomposition O(n<sup>3</sup>) per generation.</li>
+                    <li><strong>Minimum trials:</strong> <code>max(20, 4n)</code> &mdash; CMA-ES wants several generations of &lambda; &approx; 4&middot;n evaluations.</li>
+                </ul>
+            </div>
+
             <h2>Implementation Details</h2>
             <table class="implementation-table">
                 <thead>

--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -284,6 +284,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -272,6 +272,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/evolution-strategy.html
+++ b/docs/algorithms/evolution-strategy.html
@@ -258,6 +258,16 @@
                 </div>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
             <h2>Implementation Details</h2>
             <table class="implementation-table">
                 <thead>

--- a/docs/algorithms/firefly-algorithm.html
+++ b/docs/algorithms/firefly-algorithm.html
@@ -288,6 +288,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> <code>n_dim &le; 50</code> &mdash; O(n_pop<sup>2</sup>) attractions per generation.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/genetic-algorithm.html
+++ b/docs/algorithms/genetic-algorithm.html
@@ -273,6 +273,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/harmony-search.html
+++ b/docs/algorithms/harmony-search.html
@@ -271,6 +271,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
             <h2>Implementation Details</h2>
             <table class="implementation-table">
                 <thead>

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -284,6 +284,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 0:</strong> trivial (~&micro;s/iter). Always eligible by the timing filter.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -269,6 +269,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -278,6 +278,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> <code>n_dim &le; 20</code> &mdash; simplex degenerates past ~20 dims.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -274,6 +274,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 2:</strong> medium (~1ms/iter; small linear-algebra updates). Eligible when measured <code>eval_time &ge; 100 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> <code>n_dim &le; 25</code> &mdash; underdetermined quadratic model fit.</li>
+                    <li><strong>Minimum trials:</strong> <code>2n + 5</code> &mdash; needs an underdetermined quadratic model fit.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/particle-swarm.html
+++ b/docs/algorithms/particle-swarm.html
@@ -254,6 +254,16 @@
         <p>Particle Swarm Optimization (PSO) is a population-based stochastic optimization technique introduced by Kennedy and Eberhart (1995). A swarm of particles flies through the search space; each particle's velocity is steered toward its personal best position and the swarm's global best position. HumpDay's <code>ParticleSwarm</code> uses an annealed inertia / cognitive / social schedule, velocity clamping that shrinks over the run, and finishes with an L-BFGS-B polish from the swarm best.</p>
     </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
     <h2>Algorithm Description</h2>
 
     <p>The Particle Swarm Optimization algorithm maintains a swarm of particles, where each particle $i$ has a position $\mathbf{x}_i$ and velocity $\mathbf{v}_i$ in the $D$-dimensional search space. The algorithm updates these parameters according to the following equations:</p>

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -273,6 +273,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> <code>n_dim &le; 30</code> &mdash; 2n directions per pattern.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -272,6 +272,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> <code>n_dim &le; 30</code> &mdash; direction-set line searches stall.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/random-search.html
+++ b/docs/algorithms/random-search.html
@@ -242,6 +242,16 @@
         <p><strong>RandomSearch is a baseline, not a SOTA algorithm.</strong> It draws <em>n_trials</em> i.i.d. uniform samples from <em>[0, 1]<sup>n</sup></em> and keeps the best. Two reasons to ship it: (1) <em>regression check</em> &mdash; any optimizer worth using should clearly beat RandomSearch on smooth problems; (2) <em>contest sanity floor</em> &mdash; ensures the benchmarking harness scores absolute performance, not just relative ranking among SOTA methods. The companion baseline is <code>GridSearch</code>, which enumerates a regular Cartesian grid instead.</p>
     </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 0:</strong> trivial (~&micro;s/iter). Always eligible by the timing filter.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
     <h2>Algorithm Description</h2>
 
     <p>The Random Search algorithm generates candidate solutions by uniform random sampling from the feasible region. For a $D$-dimensional optimization problem on the unit hypercube $[0,1]^D$, the algorithm operates as follows:</p>

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -276,6 +276,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 1:</strong> light (~100&micro;s/iter). Eligible when measured <code>eval_time &ge; 10 &micro;s</code>.</li>
+                    <li><strong>Dimensional cap:</strong> no cap &mdash; linear-in-dim or better.</li>
+                    <li><strong>Minimum trials:</strong> 10 &mdash; baseline minimum.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -267,6 +267,16 @@
                 </p>
             </div>
 
+            <div class="auto-selection-metadata" style="background:#f8f9fa; border:1px solid #ddd; border-radius:8px; padding:14px 18px; margin:20px 0; font-size:0.95em;">
+                <strong>Auto-selection metadata.</strong>
+                Consulted by <a href="../recommendations.html"><code>humpday.minimize()</code></a> when picking a default algorithm.
+                <ul style="margin:8px 0 0 0;">
+                    <li><strong>Overhead tier 3:</strong> heavy (~10ms/iter; full quadratic model or O(n<sup>3</sup>) eigendecomposition). Eligible when measured <code>eval_time &ge; 1 ms</code>.</li>
+                    <li><strong>Dimensional cap:</strong> <code>n_dim &le; 12</code> &mdash; needs (n+1)(n+2)/2 interpolation points.</li>
+                    <li><strong>Minimum trials:</strong> <code>(n+1)(n+2)/2 + 5</code> &mdash; needs a full quadratic interpolation set.</li>
+                </ul>
+            </div>
+
 
             <h2>Implementation Details</h2>
             <table class="implementation-table">


### PR DESCRIPTION
## Summary

After the smarter-minimize work landed (#221), every algorithm gained structural metadata that \`humpday.minimize()\` consults when picking a default algorithm: an overhead tier (0 trivial → 4 GP-fit-heavy), a dimensional cap, and a min-trials condition. None of the per-algorithm doc pages mentioned any of this — a reader landing on the BayesianOpt page would have no idea that \`minimize()\` auto-filters BO out for \`n_dim > 10\` or \`eval_time < 10 ms\`.

This PR inserts a small **Auto-selection metadata** card just before the first \`<h2>\` on each of the 21 algorithm pages. Each card lists:

- **Overhead tier** (0–4) and the measured \`eval_time\` threshold at which the algorithm becomes eligible.
- **Dimensional cap** (or "no cap" for linear-in-dim algorithms), with a one-line reason.
- **Minimum trials** condition (PRIMA's \`(n+1)(n+2)/2\`, BO's \`max(30, 5n)\`, CMA's \`max(20, 4n)\`, GridSearch's \`3^n\`, default 10).
- A link to \`docs/recommendations.html\` for the full eligibility logic.

Card content was generated from \`humpday.eligibility\` (\`TIER\`, \`DIM_CAP\`, \`min_trials\`, \`MIN_EVAL_TIME_FOR_TIER\`), so it matches what the recommender actually consults.

## Example

For BayesianOpt:

> **Auto-selection metadata.** Consulted by \`humpday.minimize()\` when picking a default algorithm.
> - **Overhead tier 4:** very heavy (~100ms/iter; O(n_obs³) GP fit). Eligible when measured \`eval_time ≥ 10 ms\`.
> - **Dimensional cap:** \`n_dim ≤ 10\` — GP cost O(n_obs³) + RBF kernel degeneracy.
> - **Minimum trials:** \`max(30, 5n)\` — GP needs initialisation samples to amortise its O(n_obs³) fits.

## Test plan

- [x] All 21 pages have the new card (\`grep -l auto-selection-metadata docs/algorithms/*.html | wc -l\` returns 21)
- [x] All 21 pages parse cleanly through \`html.parser.HTMLParser\`
- [x] Card values match \`humpday.eligibility\` definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)