### PR TITLE
Release v0.21.0 — recommendation matrix overhaul

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "humpday"
-version = "0.20.0"
+version = "0.21.0"
 description = "Taking the pain out of choosing a Python global optimizer"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps \`pyproject.toml\` from 0.20.0 to 0.21.0 ahead of the v0.21.0 GitHub Release. Trigger flow:

1. Merge this PR to main.
2. Tag \`v0.21.0\`.
3. Create the GitHub Release (which triggers \`publish.yml\` → PyPI upload).

## v0.21.0 — recommendation matrix overhaul

The recommendation \`humpday.minimize()\` gives you changed substantively across PRs #225, #226, and #227 — enough to warrant a minor bump.

### Before (v0.20.0) vs after (v0.21.0)

| n_dim | v0.20.0 cheap | v0.21.0 cheap | v0.20.0 expensive | v0.21.0 expensive |
|--:|:--|:--|:--|:--|
| 2 | HillClimbing | GridSearch | PRIMA_NEWUOA | PRIMA_NEWUOA |
| 3 | (snapped to n=2) | GridSearch | (snapped to n=2) | PRIMA_BOBYQA |
| 4 | (snapped to n=5) | RandomSearch | (snapped to n=5) | Powell |
| 5 | HillClimbing | RandomSearch | PRIMA_UOBYQA | Powell |
| 6 | (snapped to n=5) | RandomSearch | (snapped to n=5) | Powell |
| 7 | (snapped to n=5) | RandomSearch | (snapped to n=5) | PRIMA_NEWUOA |
| 8 | (snapped to n=10) | RandomSearch | (snapped to n=10) | PRIMA_UOBYQA |
| 10 | HillClimbing | RandomSearch | PRIMA_NEWUOA | PRIMA_NEWUOA |
| 20 | HillClimbing | RandomSearch | Powell | PRIMA_BOBYQA |
| 50 | HillClimbing | RandomSearch | CoordinateDescent | CoordinateDescent |
| 100 | Rechenberg | RandomSearch | SimulatedAnnealing | SimulatedAnnealing |

### What changed

- **HillClimbing dropped out of the recommended algorithms entirely.** It had been winning cheap-objective cells in 0.20.0 as a sampling-bias artefact (the suite skewed toward separable benchmarks where HC's componentwise restart shines). Tier-0 is now just RandomSearch + GridSearch.
- **Powell promoted at n=4..6**; **PRIMA family wins n=7..10** (UOBYQA at n=8, NEWUOA at n=10, BOBYQA at n=20). 0.20.0 was picking HillClimbing / Powell almost uniformly at low dim.
- **CMA-ES now competitive on rotated benchmarks** — rank ~1.3 on rotated Ackley vs 10.0 for CoordinateDescent — thanks to the IPOP restart + rotation-invariant test set added in #226.
- **Dense low-dim grid** (n=2,3,4,5,6,7,8,10,20,50,100) so the recommender snaps to the right cell for any low-dim user instead of falling back to n=2 or n=5.
- **Recommender now scores by Borda mean-rank** across the 12-objective suite rather than median_best, rewarding reliability over occasional brilliance.

### What was added to the test suite

- **12 objectives** (was 5): added Ackley, Schwefel, Michalewicz, Styblinski-Tang as deceptive multimodal benchmarks; added rotated_Rosenbrock, rotated_Rastrigin, rotated_Ackley to strip the axis-alignment bonus from coordinate-wise methods.
- **8247 → 36000+ grid runs** across the expanded dim × trial × objective grid.

### Compatibility

No API breaks. \`OptimizeResult\` field additions are additive; \`minimize()\` accepts \`options={'auto_timing': False}\` to opt out of the new timing behavior.

## Test plan

- [x] \`pip install -e . && python -c "import humpday; assert humpday.__version__ == '0.21.0'"\` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)