### PR TITLE
JS: tighten Powell tolerance + port rotated benchmarks

### DIFF
--- a/docs/js/modules/scipy-algorithms.js
+++ b/docs/js/modules/scipy-algorithms.js
@@ -170,8 +170,12 @@ class Powell extends Optimizer {
                 fx = result.fx;
             }
 
-            // Check for improvement
-            if (Math.abs(fx - fx_start) < 1e-8) break;
+            // Check for improvement. Tightened from 1e-8 to 1e-12 to
+            // match the Python port — scipy's default 1e-4 stops far
+            // below Powell's potential; 1e-12 lets the direction set
+            // run to numerical noise on smooth landscapes with no
+            // downside on multimodal ones (the budget cap kicks in).
+            if (Math.abs(fx - fx_start) < 1e-12) break;
 
             // Update direction set
             const newDirection = MathUtils.subtract(x, x_start);

--- a/docs/js/surfaces.js
+++ b/docs/js/surfaces.js
@@ -135,7 +135,121 @@ const TestSurfaces = {
             }
             return sum / 2; // Normalize
         };
-    }
+    },
+
+    // Rotated benchmarks — Rosenbrock, Rastrigin, and Ackley
+    // pre-multiplied by a deterministic uniform-random orthogonal Q.
+    // Each strips the axis-alignment bonus that coordinate-wise methods
+    // collect on the standard benchmarks above. Q is computed once per
+    // n_dim by a seeded Linear Congruential Generator + Mezzadri-2007
+    // sign-corrected QR (see _rotationFor below), so the landscape is
+    // reproducible and parity-test-safe but no longer coordinate-
+    // aligned. Matches `humpday.objectives.classic.rotated_*_on_cube`.
+    rotatedRosenbrock(params = {}) {
+        return function(x) {
+            const n = x.length;
+            const Q = TestSurfaces._rotationFor(n);
+            const s = x.map(xi => 4.0 * (xi - 0.5)); // [-2, 2]^n
+            const y = TestSurfaces._matvec(Q, s);
+            let sum = 0;
+            for (let i = 0; i < n - 1; i++) {
+                sum += 100.0 * Math.pow(y[i + 1] - y[i] * y[i], 2)
+                     + Math.pow(1 - y[i], 2);
+            }
+            return sum;
+        };
+    },
+
+    rotatedRastrigin(params = {}) {
+        return function(x) {
+            const n = x.length;
+            const Q = TestSurfaces._rotationFor(n);
+            const s = x.map(xi => 10.24 * (xi - 0.5)); // [-5.12, 5.12]^n
+            const y = TestSurfaces._matvec(Q, s);
+            let sum = 10.0 * n;
+            for (let i = 0; i < n; i++) {
+                sum += y[i] * y[i] - 10.0 * Math.cos(2.0 * Math.PI * y[i]);
+            }
+            return sum;
+        };
+    },
+
+    rotatedAckley(params = {}) {
+        return function(x) {
+            const n = x.length;
+            if (n === 0) return 0;
+            const Q = TestSurfaces._rotationFor(n);
+            const s = x.map(xi => 65.536 * (xi - 0.5)); // [-32.768, 32.768]^n
+            const y = TestSurfaces._matvec(Q, s);
+            const a = 20.0, b = 0.2, c = 2.0 * Math.PI;
+            let sum1 = 0, sum2 = 0;
+            for (let i = 0; i < n; i++) {
+                sum1 += y[i] * y[i];
+                sum2 += Math.cos(c * y[i]);
+            }
+            return -a * Math.exp(-b * Math.sqrt(sum1 / n))
+                 - Math.exp(sum2 / n)
+                 + a + Math.E;
+        };
+    },
+
+    // Cache of deterministic rotation matrices, keyed by n_dim. Uses a
+    // simple LCG (Park-Miller, period 2^31 - 2) seeded by 12345 + n_dim
+    // so JS and Python don't need to share an RNG — each side just
+    // needs a deterministic-per-n_dim orthogonal matrix. The matrix Q
+    // is uniformly distributed on O(n) via Mezzadri's (2007)
+    // sign-corrected QR construction: take Q from QR of a Gaussian
+    // matrix, then sign-correct by diag(sign(diag(R))).
+    _rotationCache: {},
+
+    _rotationFor(n) {
+        if (TestSurfaces._rotationCache[n]) return TestSurfaces._rotationCache[n];
+
+        // Seeded RNG.
+        let s = (12345 + n) | 0;
+        if (s === 0) s = 1;
+        const rand = () => {
+            s = (s * 48271) % 2147483647;
+            return s / 2147483647;
+        };
+        // Box-Muller for standard normal.
+        const gauss = () => {
+            const u1 = Math.max(rand(), 1e-12);
+            const u2 = rand();
+            return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+        };
+
+        // Random Gaussian matrix A (n × n).
+        const A = new Array(n);
+        for (let i = 0; i < n; i++) {
+            A[i] = new Array(n);
+            for (let j = 0; j < n; j++) A[i][j] = gauss();
+        }
+
+        // QR via Linalg.householderQR (loaded as a script before this
+        // file in the browser; in Node we require it manually below).
+        const _Linalg = (typeof Linalg !== 'undefined')
+            ? Linalg
+            : require('./modules/linalg.js');
+        const { Q, R } = _Linalg.householderQR(A);
+
+        // Sign-correct so Q is uniform on O(n) per Mezzadri (2007).
+        for (let j = 0; j < n; j++) {
+            const sign = R[j][j] >= 0 ? 1 : -1;
+            for (let i = 0; i < n; i++) Q[i][j] *= sign;
+        }
+
+        TestSurfaces._rotationCache[n] = Q;
+        return Q;
+    },
+
+    _matvec(M, v) {
+        const out = new Array(M.length).fill(0);
+        for (let i = 0; i < M.length; i++) {
+            for (let j = 0; j < v.length; j++) out[i] += M[i][j] * v[j];
+        }
+        return out;
+    },
 };
 
 // Surface generator for contests


### PR DESCRIPTION
Two more items from the GOALS.md JS-parity audit (#230). Independent of #231 (different files), so they land as their own follow-up.

## Powell tolerance (\`docs/js/modules/scipy-algorithms.js\`)

The JS Powell port was stopping on \`|fx - fx_start| < 1e-8\` — the Python port tightened this to \`1e-12\` alongside the NM restart work (scipy's default is even looser at \`1e-4\`). Below the new threshold the direction set just runs to numerical noise on smooth landscapes; no downside on multimodal ones because the budget cap takes over.

## Rotated benchmarks (\`docs/js/surfaces.js\`)

Adds \`rotatedRosenbrock\`, \`rotatedRastrigin\`, \`rotatedAckley\` to \`TestSurfaces\`. Each multiplies the unit-cube input by a deterministic uniform-random orthogonal matrix Q before evaluating the underlying function — same construction the Python port uses (Mezzadri 2007 sign-corrected QR of a Gaussian matrix), with Q cached per \`n_dim\`.

The rotation matrix is computed via:

1. A Park-Miller LCG seeded \`12345 + n_dim\` for reproducibility without needing to coordinate RNG state with Python (each side just produces a deterministic-per-\`n_dim\` orthogonal matrix).
2. Box-Muller transform from the LCG to standard Gaussian samples.
3. \`Linalg.householderQR\` (already in \`linalg.js\`, exposes both Q and R).
4. Sign-correction \`Q ← Q · diag(sign(diag(R)))\` so Q is uniform on O(n) per Mezzadri's construction.

### Smoke validation

| Check | Result |
|--|--|
| \`_rotationFor(5)\` same on repeat call | true |
| \`|Q Qᵀ − I|_max\` | \`4.44e-16\` |
| \`rotatedAckley\` at cube centre | \`4.44e-16\` (numerical zero) |
| \`rotatedRastrigin\` at cube centre | \`0\` |

Both rotated values at the cube centre being numerical zero is the right answer: rotation preserves the origin of an even function.

## Test plan

- [x] **22/22 enabled JS parity tests pass**
- [x] \`ruff format --check .\` and \`ruff check .\` both clean

## Remaining JS parity gap

Just the \`humpday.eligibility\` auto-selector. That's a wholly new JS module plus the grid JSON as a shippable asset, so it's a substantively bigger PR — saving it for last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)