### PR TITLE
Rename site-nav label 'Applications' to 'Demonstrations'

### DIFF
--- a/docs/algorithm-visualization-demo.html
+++ b/docs/algorithm-visualization-demo.html
@@ -160,7 +160,7 @@
             <div class="site-nav-links">
                 <a href="index.html">Home</a>
                 <a href="contest.html">Contest</a>
-                <a href="applications/index.html">Applications</a>
+                <a href="applications/index.html">Demonstrations</a>
                 <a href="algorithms.html">Algorithms</a>
                 <a href="sota-status.html">SOTA status</a>
                 <a href="recommendations.html">Recommendations</a>

--- a/docs/algorithms.html
+++ b/docs/algorithms.html
@@ -147,7 +147,7 @@
             <div class="site-nav-links">
                 <a href="index.html">Home</a>
                 <a href="contest.html">Contest</a>
-                <a href="applications/index.html">Applications</a>
+                <a href="applications/index.html">Demonstrations</a>
                 <a href="algorithms.html">Algorithms</a>
                 <a href="sota-status.html">SOTA status</a>
                 <a href="recommendations.html">Recommendations</a>

--- a/docs/algorithms/adaptive-random-search.html
+++ b/docs/algorithms/adaptive-random-search.html
@@ -238,7 +238,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/ant-colony-optimization.html
+++ b/docs/algorithms/ant-colony-optimization.html
@@ -224,7 +224,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/bayesian-optimization.html
+++ b/docs/algorithms/bayesian-optimization.html
@@ -226,7 +226,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/bobyqa.html
+++ b/docs/algorithms/bobyqa.html
@@ -225,7 +225,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/cma-evolution-strategy.html
+++ b/docs/algorithms/cma-evolution-strategy.html
@@ -226,7 +226,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -238,7 +238,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -225,7 +225,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/evolution-strategy.html
+++ b/docs/algorithms/evolution-strategy.html
@@ -224,7 +224,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/firefly-algorithm.html
+++ b/docs/algorithms/firefly-algorithm.html
@@ -238,7 +238,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/genetic-algorithm.html
+++ b/docs/algorithms/genetic-algorithm.html
@@ -226,7 +226,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/harmony-search.html
+++ b/docs/algorithms/harmony-search.html
@@ -224,7 +224,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -238,7 +238,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -226,7 +226,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -225,7 +225,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -227,7 +227,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/particle-swarm.html
+++ b/docs/algorithms/particle-swarm.html
@@ -237,7 +237,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -226,7 +226,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -226,7 +226,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/random-search.html
+++ b/docs/algorithms/random-search.html
@@ -225,7 +225,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -226,7 +226,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -226,7 +226,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/battery-dispatch.html
+++ b/docs/applications/battery-dispatch.html
@@ -88,7 +88,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/bowling.html
+++ b/docs/applications/bowling.html
@@ -160,7 +160,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/brachistochrone.html
+++ b/docs/applications/brachistochrone.html
@@ -94,7 +94,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/bridge-truss.html
+++ b/docs/applications/bridge-truss.html
@@ -93,7 +93,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/cart-pole.html
+++ b/docs/applications/cart-pole.html
@@ -125,7 +125,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/curling.html
+++ b/docs/applications/curling.html
@@ -92,7 +92,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/free-kick.html
+++ b/docs/applications/free-kick.html
@@ -91,7 +91,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/hvac-nyc.html
+++ b/docs/applications/hvac-nyc.html
@@ -88,7 +88,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/index.html
+++ b/docs/applications/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
-<title>Applications — HumpDay</title>
+<title>Demonstrations — HumpDay</title>
 <style>
   :root {
     --bg: #1a1a22;
@@ -155,7 +155,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>
@@ -165,7 +165,7 @@
     </nav>
 
 <div class="container">
-  <h1>Applications</h1>
+  <h1>Demonstrations</h1>
   <div class="intro">
     <p>
       Pick a problem and compete against any optimizer.

--- a/docs/applications/mini-golf.html
+++ b/docs/applications/mini-golf.html
@@ -81,7 +81,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/pool.html
+++ b/docs/applications/pool.html
@@ -92,7 +92,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/reactor-tprofile.html
+++ b/docs/applications/reactor-tprofile.html
@@ -88,7 +88,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/robot-arm.html
+++ b/docs/applications/robot-arm.html
@@ -88,7 +88,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/rocket-landing.html
+++ b/docs/applications/rocket-landing.html
@@ -89,7 +89,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -93,7 +93,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/trebuchet.html
+++ b/docs/applications/trebuchet.html
@@ -92,7 +92,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/welded-beam.html
+++ b/docs/applications/welded-beam.html
@@ -94,7 +94,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/applications/wind-farm.html
+++ b/docs/applications/wind-farm.html
@@ -89,7 +89,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/contest-modular.html
+++ b/docs/contest-modular.html
@@ -272,7 +272,7 @@
             <div class="site-nav-links">
                 <a href="index.html">Home</a>
                 <a href="contest.html">Contest</a>
-                <a href="applications/index.html">Applications</a>
+                <a href="applications/index.html">Demonstrations</a>
                 <a href="algorithms.html">Algorithms</a>
                 <a href="sota-status.html">SOTA status</a>
                 <a href="recommendations.html">Recommendations</a>

--- a/docs/contest.html
+++ b/docs/contest.html
@@ -595,7 +595,7 @@
             <div class="site-nav-links">
                 <a href="index.html">Home</a>
                 <a href="contest.html">Contest</a>
-                <a href="applications/index.html">Applications</a>
+                <a href="applications/index.html">Demonstrations</a>
                 <a href="algorithms.html">Algorithms</a>
                 <a href="sota-status.html">SOTA status</a>
                 <a href="recommendations.html">Recommendations</a>

--- a/docs/debug-modules.html
+++ b/docs/debug-modules.html
@@ -61,7 +61,7 @@
             <div class="site-nav-links">
                 <a href="index.html">Home</a>
                 <a href="contest.html">Contest</a>
-                <a href="applications/index.html">Applications</a>
+                <a href="applications/index.html">Demonstrations</a>
                 <a href="algorithms.html">Algorithms</a>
                 <a href="sota-status.html">SOTA status</a>
                 <a href="recommendations.html">Recommendations</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -172,7 +172,7 @@
             <div class="site-nav-links">
                 <a href="index.html">Home</a>
                 <a href="contest.html">Contest</a>
-                <a href="applications/index.html">Applications</a>
+                <a href="applications/index.html">Demonstrations</a>
                 <a href="algorithms.html">Algorithms</a>
                 <a href="sota-status.html">SOTA status</a>
                 <a href="recommendations.html">Recommendations</a>
@@ -228,7 +228,7 @@
         <div style="text-align: center; margin: 8px 0; padding: 4px;">
             <a href="contest.html" class="btn" style="margin: 0 10px; padding: 6px 12px;">Run Algorithm Contest</a>
             <a href="https://github.com/microprediction/humpday/tree/main/humpday" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;" target="_blank" rel="noopener">Python Source</a>
-            <a href="applications/index.html" class="btn" style="margin: 0 10px; padding: 6px 12px;">Browse Applications</a>
+            <a href="applications/index.html" class="btn" style="margin: 0 10px; padding: 6px 12px;">Browse Demonstrations</a>
             <a href="https://github.com/microprediction/humpday/tree/main/docs/js/modules" class="btn btn-secondary" style="margin: 0 10px; padding: 6px 12px;" target="_blank" rel="noopener">JavaScript Source</a>
         </div>
 

--- a/docs/recommendations.html
+++ b/docs/recommendations.html
@@ -122,7 +122,7 @@
             <div class="site-nav-links">
                 <a href="index.html">Home</a>
                 <a href="contest.html">Contest</a>
-                <a href="applications/index.html">Applications</a>
+                <a href="applications/index.html">Demonstrations</a>
                 <a href="algorithms.html">Algorithms</a>
                 <a href="sota-status.html">SOTA status</a>
                 <a href="recommendations.html">Recommendations</a>

--- a/docs/sota-status.html
+++ b/docs/sota-status.html
@@ -202,7 +202,7 @@
             <div class="site-nav-links">
                 <a href="index.html">Home</a>
                 <a href="contest.html">Contest</a>
-                <a href="applications/index.html">Applications</a>
+                <a href="applications/index.html">Demonstrations</a>
                 <a href="algorithms.html">Algorithms</a>
                 <a href="sota-status.html">SOTA status</a>
                 <a href="recommendations.html">Recommendations</a>

--- a/docs/stick_breaking_demo.html
+++ b/docs/stick_breaking_demo.html
@@ -273,7 +273,7 @@
             <div class="site-nav-links">
                 <a href="index.html">Home</a>
                 <a href="contest.html">Contest</a>
-                <a href="applications/index.html">Applications</a>
+                <a href="applications/index.html">Demonstrations</a>
                 <a href="algorithms.html">Algorithms</a>
                 <a href="sota-status.html">SOTA status</a>
                 <a href="recommendations.html">Recommendations</a>

--- a/docs/test-modular.html
+++ b/docs/test-modular.html
@@ -70,7 +70,7 @@
             <div class="site-nav-links">
                 <a href="index.html">Home</a>
                 <a href="contest.html">Contest</a>
-                <a href="applications/index.html">Applications</a>
+                <a href="applications/index.html">Demonstrations</a>
                 <a href="algorithms.html">Algorithms</a>
                 <a href="sota-status.html">SOTA status</a>
                 <a href="recommendations.html">Recommendations</a>

--- a/docs/tools/algorithm-template.html
+++ b/docs/tools/algorithm-template.html
@@ -191,7 +191,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/tools/learn-powell.html
+++ b/docs/tools/learn-powell.html
@@ -208,7 +208,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/tools/linkedin_post_generator.html
+++ b/docs/tools/linkedin_post_generator.html
@@ -197,7 +197,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>

--- a/docs/tools/simple_contest.html
+++ b/docs/tools/simple_contest.html
@@ -188,7 +188,7 @@
             <div class="site-nav-links">
                 <a href="../index.html">Home</a>
                 <a href="../contest.html">Contest</a>
-                <a href="../applications/index.html">Applications</a>
+                <a href="../applications/index.html">Demonstrations</a>
                 <a href="../algorithms.html">Algorithms</a>
                 <a href="../sota-status.html">SOTA status</a>
                 <a href="../recommendations.html">Recommendations</a>


### PR DESCRIPTION
The page at \`/applications/\` is really a gallery of live optimizer demos (bowling, pool, brachistochrone, ...) — **"Demonstrations"** is a more honest label than "Applications", which suggests engineering use cases the page doesn't try to be.

## Scope

| Where | Before | After |
|--|--|--|
| Site nav (53 pages) | \`>Applications</a>\` | \`>Demonstrations</a>\` |
| \`docs/applications/index.html\` | \`<title>Applications — HumpDay</title>\` and \`<h1>Applications</h1>\` | \`<title>Demonstrations — HumpDay</title>\` and \`<h1>Demonstrations</h1>\` |
| \`docs/index.html\` button | "Browse Applications" | "Browse Demonstrations" |

## Intentionally left alone

- **Algorithm-page \`<h3>Applications</h3>\` and \`<h2>Practical Applications</h2>\` sections** — those describe real-world use cases of the algorithm itself (e.g. "GA Applications", "BO Applications") and have nothing to do with the site nav.
- **The \`docs/applications/\` URL path** — changing it would break every existing link into the demo gallery.

## Test plan

- [x] All 53 \`docs/**/*.html\` files parse cleanly via \`html.parser.HTMLParser\` after the rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)