### PR TITLE
humpday.eligibility: opt-in cost-aware recommender (papers/§4 result shipped)

### DIFF
--- a/humpday/eligibility.py
+++ b/humpday/eligibility.py
@@ -29,6 +29,7 @@ filter logic without instantiating any optimizers.
 from __future__ import annotations
 
 import json
+import math
 import time
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
@@ -364,12 +365,47 @@ def _snap_to_grid_cell(grid: dict, n_dim: int, n_trials: int) -> dict[str, dict]
     return cells.get(f"{d}/{t}")
 
 
+# -----------------------------------------------------------------------------
+# Soft cost-weighted Borda schedule (opt-in cost-aware recommender)
+# -----------------------------------------------------------------------------
+# A per-eval-time λ schedule that replaces the hard tier filter with a
+# continuous overhead penalty. Derived empirically in
+# papers/dfo_recommender/ as the row-wise envelope of the λ sweep —
+# at each eval_time, the λ that maximised cost-aware match. λ=0
+# reproduces the existing quality-only recommender; λ>0 trades raw
+# solution quality for wall-clock cost.
+
+# Schedule: (eval_time_threshold, lambda). Uses the first match where
+# eval_time ≤ threshold. The current values come from Table 5 of
+# papers/dfo_recommender/OUTLINE.md.
+_COST_WEIGHT_SCHEDULE: tuple[tuple[float, float], ...] = (
+    (1e-5, 3.0),  # ≤ 10 µs
+    (1e-4, 1.0),  # ≤ 100 µs
+    (1e-3, 1.0),  # ≤ 1 ms
+    (1e-2, 1.0),  # ≤ 10 ms
+)
+
+
+def _lambda_for(eval_time: float | None) -> float:
+    """Pick λ from the per-eval-time schedule. Beyond the schedule's largest
+    threshold (currently 10 ms), λ = 0 — the cost-aware mode collapses to
+    the quality-only recommender for expensive objectives where overhead
+    is irrelevant."""
+    if eval_time is None:
+        return 0.0
+    for threshold, lam in _COST_WEIGHT_SCHEDULE:
+        if eval_time <= threshold:
+            return lam
+    return 0.0
+
+
 def recommend(
     n_dim: int,
     n_trials: int,
     eval_time: float | None = None,
     available: Iterable[str] | None = None,
     grid_path: Path | None = None,
+    cost_weight: float | str = 0.0,
 ) -> str:
     """Pick the best algorithm name for (n_dim, n_trials, eval_time).
 
@@ -385,12 +421,44 @@ def recommend(
     we fall through to the rule-based ranking that mirrors
     :func:`suggest_pure`.
 
+    ``cost_weight`` activates the opt-in cost-aware recommender (the soft
+    cost-weighted Borda variant from papers/dfo_recommender/ §4). The
+    score becomes ``borda + cost_weight·log(1 + mean_wall/(n_trials·eval_time))``
+    so high-overhead algorithms get penalised when the user's objective is
+    cheap to evaluate. The hard tier-eligibility filter is bypassed in this
+    mode — the soft penalty replaces it. Accepted values:
+
+      * ``0.0`` (default) — quality-only recommender, current behavior.
+      * a positive float — fixed λ across all eval_times.
+      * ``"auto"`` — per-eval-time schedule (3.0 at ≤ 10 µs, 1.0 in
+        the µs–ms band, 0 at ≥ 1 s). Closes the 100 µs cost-aware gap
+        identified in the paper. Recommended setting when wall-clock
+        cost matters.
+
     If nothing passes the filters (e.g. n_trials too small for any sane
     algorithm), falls back to RandomSearch — it works at any
     (n_dim, n_trials) and gives a defensible baseline.
     """
     universe = list(available) if available is not None else list(TIER.keys())
-    candidates = set(eligible(universe, n_dim, n_trials, eval_time))
+
+    # Resolve cost_weight into a concrete λ. The hard tier filter only
+    # applies when cost_weight == 0 (quality-only mode); otherwise the
+    # soft penalty replaces it.
+    if cost_weight == "auto":
+        lam: float = _lambda_for(eval_time)
+    else:
+        lam = float(cost_weight)
+    cost_aware = lam > 0
+
+    if cost_aware:
+        # Apply dim cap + min trials, but skip the tier filter.
+        candidates = {
+            n
+            for n in universe
+            if passes_dim(n, n_dim) and passes_trials(n, n_dim, n_trials)
+        }
+    else:
+        candidates = set(eligible(universe, n_dim, n_trials, eval_time))
 
     # Grid-driven pick when available.
     grid = _load_grid(grid_path or _GRID_PATH_DEFAULT)
@@ -400,6 +468,7 @@ def recommend(
             # Prefer Borda mean-rank (reliability) when the grid carries it;
             # fall back to median_best for grids built by an older script.
             scored: list[tuple[float, str]] = []
+            user_baseline = max((eval_time or 0.0) * n_trials, 1e-15)
             for name in candidates:
                 if name not in cell:
                     continue
@@ -409,8 +478,13 @@ def recommend(
                     score = entry.get("median_best")
                 if score is None or score == float("inf"):
                     continue
+                if cost_aware:
+                    overhead = entry.get("mean_wall", 0.0)
+                    score = score + lam * math.log(1.0 + overhead / user_baseline)
                 scored.append((score, name))
             if scored:
+                # Sort by (score, name) so ties break on algorithm name —
+                # same convention as the JS port (test_js_eligibility_parity).
                 scored.sort()
                 return scored[0][1]
 

--- a/humpday/optimizers/scipy_interface.py
+++ b/humpday/optimizers/scipy_interface.py
@@ -220,11 +220,16 @@ def cube_minimize(
                 # If the objective throws on a random feasible point, skip
                 # timing and let recommend() fall back to dim/trials only.
                 eval_time_used = None
+        # `options['cost_weight']` opts in to the cost-aware recommender
+        # described in papers/dfo_recommender/ §4. Default 0.0 preserves the
+        # original quality-only behavior; "auto" picks λ from the per-eval-
+        # time schedule; a numeric value pins λ across all eval-times.
         method = _E.recommend(
             n_dim=n_dim,
             n_trials=maxiter,
             eval_time=eval_time_used,
             available=list(PURE_OPTIMIZERS.keys()),
+            cost_weight=options.get("cost_weight", 0.0),
         )
 
     # Validate method

--- a/papers/dfo_recommender/OUTLINE.md
+++ b/papers/dfo_recommender/OUTLINE.md
@@ -241,10 +241,12 @@ both metrics agree.
 - (c) Per-eval-time λ schedule + comparison vs single λ. **Done.**
 - (d) Figure 1 (heatmap) + Figure 2 (Pareto). **Done.**
 - (e) Wire the soft schedule into `humpday/eligibility.py` as an
-  opt-in recommender mode (probably `recommend(..., cost_weight=λ)`),
-  so users can choose between solution-quality optimization and
-  wall-clock-aware optimization. Open question for the paper: should
-  the schedule become the default?
+  opt-in recommender mode. **Done.** `humpday.eligibility.recommend`
+  now accepts `cost_weight=0.0` (default, current behavior),
+  `cost_weight=<float>` (fixed λ), or `cost_weight="auto"` (the
+  per-eval-time schedule). `humpday.minimize` reads it from
+  `options={"cost_weight": ...}`. Open question for the paper: should
+  `"auto"` become the default in a future release?
 - (f) Cost-of-mistake distribution — when the recommender (or its soft
   variant) misses the oracle, how bad is the miss?
 - (g) Companion paper on benchmark-to-demonstration transfer: do the

--- a/papers/dfo_recommender/analysis.py
+++ b/papers/dfo_recommender/analysis.py
@@ -49,27 +49,33 @@ EVAL_TIMES = [
 # Grid helpers
 # -----------------------------------------------------------------------------
 
+
 def load_grid() -> dict:
     return json.loads(GRID_PATH.read_text())
 
 
 def algos_with_runs(cell: dict) -> list[str]:
-    return [n for n, e in cell.items()
-            if e.get("runs") and not e.get("skipped_too_slow")]
+    return [
+        n for n, e in cell.items() if e.get("runs") and not e.get("skipped_too_slow")
+    ]
 
 
 def borda_oracle(cell: dict) -> str | None:
-    scored = [(e.get("borda_score", float("inf")), n) for n, e in cell.items()
-              if not e.get("skipped_too_slow")
-              and e.get("borda_score", float("inf")) != float("inf")]
+    scored = [
+        (e.get("borda_score", float("inf")), n)
+        for n, e in cell.items()
+        if not e.get("skipped_too_slow")
+        and e.get("borda_score", float("inf")) != float("inf")
+    ]
     if not scored:
         return None
     scored.sort()
     return scored[0][1]
 
 
-def cost_aware_oracle(cell: dict, n_trials: int, eval_time: float,
-                      overhead_budget: float = 1.0) -> str | None:
+def cost_aware_oracle(
+    cell: dict, n_trials: int, eval_time: float, overhead_budget: float = 1.0
+) -> str | None:
     """Best Borda among algorithms whose recorded mean_wall is within
     `overhead_budget` × (n_trials × eval_time). At expensive eval_times this
     converges to `borda_oracle`; at cheap eval_times it strips out heavy
@@ -79,7 +85,10 @@ def cost_aware_oracle(cell: dict, n_trials: int, eval_time: float,
     for a, e in cell.items():
         if e.get("skipped_too_slow"):
             continue
-        if user_baseline > 0 and e.get("mean_wall", 0.0) > overhead_budget * user_baseline:
+        if (
+            user_baseline > 0
+            and e.get("mean_wall", 0.0) > overhead_budget * user_baseline
+        ):
             continue
         borda = e.get("borda_score", float("inf"))
         if borda == float("inf"):
@@ -92,6 +101,7 @@ def cost_aware_oracle(cell: dict, n_trials: int, eval_time: float,
 # -----------------------------------------------------------------------------
 # § 3.1 Oracle gap — recommender vs oracle vs baselines
 # -----------------------------------------------------------------------------
+
 
 def oracle_gap_table(grid: dict) -> None:
     """Table 1: recommender vs naive oracle vs three baselines."""
@@ -125,7 +135,9 @@ def oracle_gap_table(grid: dict) -> None:
                 continue
             picks = {
                 "recommender": E.recommend(n_dim, n_trials, et, grid_path=GRID_PATH),
-                "fixed_best": fixed_best if fixed_best in eligible_names else "RandomSearch",
+                "fixed_best": fixed_best
+                if fixed_best in eligible_names
+                else "RandomSearch",
                 "suggest_pure": next(
                     (a for a in suggest_pure(n_dim, n_trials) if a in eligible_names),
                     "RandomSearch",
@@ -143,35 +155,46 @@ def oracle_gap_table(grid: dict) -> None:
                 if p_med != float("inf") and o_med > 0:
                     r["ratio_best"].append(p_med / o_med)
 
-    print(f"# Table 1: Recommender vs oracle vs baselines\n")
+    print("# Table 1: Recommender vs oracle vs baselines\n")
     print(f"Fixed-best baseline algorithm: {fixed_best}\n")
-    print(f"{'strategy':>14s}  {'match':>8s}  {'mean reg':>10s}  {'med reg':>10s}  {'med ratio':>12s}  {'n':>4s}")
-    print(f"{'-' * 14:>14s}  {'-' * 8:>8s}  {'-' * 10:>10s}  {'-' * 10:>10s}  {'-' * 12:>12s}  {'-' * 4:>4s}")
+    print(
+        f"{'strategy':>14s}  {'match':>8s}  {'mean reg':>10s}  {'med reg':>10s}  {'med ratio':>12s}  {'n':>4s}"
+    )
+    print(
+        f"{'-' * 14:>14s}  {'-' * 8:>8s}  {'-' * 10:>10s}  {'-' * 10:>10s}  {'-' * 12:>12s}  {'-' * 4:>4s}"
+    )
     for name in ("recommender", "fixed_best", "suggest_pure", "random"):
         r = results[name]
         if r["n"] == 0:
             continue
-        print(f"{name:>14s}  {r['match'] / r['n']:>8.1%}  "
-              f"{mean(r['regret_borda']):>10.2f}  "
-              f"{median(r['regret_borda']):>10.2f}  "
-              f"{median(r['ratio_best']):>12.2e}  "
-              f"{r['n']:>4d}")
+        print(
+            f"{name:>14s}  {r['match'] / r['n']:>8.1%}  "
+            f"{mean(r['regret_borda']):>10.2f}  "
+            f"{median(r['regret_borda']):>10.2f}  "
+            f"{median(r['ratio_best']):>12.2e}  "
+            f"{r['n']:>4d}"
+        )
 
 
 # -----------------------------------------------------------------------------
 # § 3.2 Wall-clock-aware oracle — the 100µs gap finding
 # -----------------------------------------------------------------------------
 
+
 def wallclock_table(grid: dict, overhead_budget: float = 1.0) -> None:
     """Table 2: recommender matches naive vs cost-aware oracle per eval_time."""
     cells = grid["cells"]
 
-    print(f"\n# Table 2: Recommender vs naive oracle vs wall-clock-aware oracle")
+    print("\n# Table 2: Recommender vs naive oracle vs wall-clock-aware oracle")
     print(f"# (overhead_budget = {overhead_budget}× user wall-clock)\n")
-    print(f"{'eval_time':>10s}  {'naive match':>12s}  {'cost-aware':>12s}  "
-          f"{'oracles ≠':>10s}  {'n':>4s}")
-    print(f"{'-' * 10:>10s}  {'-' * 12:>12s}  {'-' * 12:>12s}  "
-          f"{'-' * 10:>10s}  {'-' * 4:>4s}")
+    print(
+        f"{'eval_time':>10s}  {'naive match':>12s}  {'cost-aware':>12s}  "
+        f"{'oracles ≠':>10s}  {'n':>4s}"
+    )
+    print(
+        f"{'-' * 10:>10s}  {'-' * 12:>12s}  {'-' * 12:>12s}  "
+        f"{'-' * 10:>10s}  {'-' * 4:>4s}"
+    )
 
     for label, et in EVAL_TIMES:
         naive = cost = diff = n = 0
@@ -191,16 +214,20 @@ def wallclock_table(grid: dict, overhead_budget: float = 1.0) -> None:
                 diff += 1
         if n == 0:
             continue
-        print(f"{label:>10s}  {naive / n:>12.0%}  {cost / n:>12.0%}  "
-              f"{diff / n:>10.0%}  {n:>4d}")
+        print(
+            f"{label:>10s}  {naive / n:>12.0%}  {cost / n:>12.0%}  "
+            f"{diff / n:>10.0%}  {n:>4d}"
+        )
 
 
 # -----------------------------------------------------------------------------
 # § 3.3 Leave-one-objective-out cross-validation
 # -----------------------------------------------------------------------------
 
-def borda_excluding(cell: dict, objectives: list[str], seeds: list[int],
-                    excluded: str) -> dict[str, float]:
+
+def borda_excluding(
+    cell: dict, objectives: list[str], seeds: list[int], excluded: str
+) -> dict[str, float]:
     """Recompute per-algorithm Borda mean-rank using all (objective, seed)
     runs in `cell` except those where objective == excluded."""
     candidates = algos_with_runs(cell)
@@ -232,13 +259,16 @@ def borda_excluding(cell: dict, objectives: list[str], seeds: list[int],
     return {a: (mean(rs) if rs else float("inf")) for a, rs in ranks_by_algo.items()}
 
 
-def median_best_on_objective(cell: dict, algo: str, objective: str,
-                             seeds: list[int]) -> float:
+def median_best_on_objective(
+    cell: dict, algo: str, objective: str, seeds: list[int]
+) -> float:
     runs = cell.get(algo, {}).get("runs", {})
-    vals = [runs[f"{objective}/{s}"]["best"]
-            for s in seeds
-            if f"{objective}/{s}" in runs
-            and runs[f"{objective}/{s}"]["best"] != float("inf")]
+    vals = [
+        runs[f"{objective}/{s}"]["best"]
+        for s in seeds
+        if f"{objective}/{s}" in runs
+        and runs[f"{objective}/{s}"]["best"] != float("inf")
+    ]
     return median(vals) if vals else float("inf")
 
 
@@ -248,11 +278,15 @@ def loo_table(grid: dict) -> None:
     objectives = grid["meta"]["objectives"]
     seeds = list(range(grid["meta"]["n_seeds"]))
 
-    print(f"\n# Table 3: Leave-one-objective-out reproducibility\n")
-    print(f"{'held-out objective':>22s}  {'LOO match':>10s}  "
-          f"{'med ratio':>10s}  {'mean ratio':>12s}  {'n':>4s}")
-    print(f"{'-' * 22:>22s}  {'-' * 10:>10s}  {'-' * 10:>10s}  "
-          f"{'-' * 12:>12s}  {'-' * 4:>4s}")
+    print("\n# Table 3: Leave-one-objective-out reproducibility\n")
+    print(
+        f"{'held-out objective':>22s}  {'LOO match':>10s}  "
+        f"{'med ratio':>10s}  {'mean ratio':>12s}  {'n':>4s}"
+    )
+    print(
+        f"{'-' * 22:>22s}  {'-' * 10:>10s}  {'-' * 10:>10s}  "
+        f"{'-' * 12:>12s}  {'-' * 4:>4s}"
+    )
 
     all_match = 0
     all_n = 0
@@ -267,8 +301,10 @@ def loo_table(grid: dict) -> None:
             if not new_borda or all(v == float("inf") for v in new_borda.values()):
                 continue
             loo_pick = min(new_borda, key=new_borda.get)
-            scored = [(median_best_on_objective(cell, a, held, seeds), a)
-                      for a in algos_with_runs(cell)]
+            scored = [
+                (median_best_on_objective(cell, a, held, seeds), a)
+                for a in algos_with_runs(cell)
+            ]
             scored = [(s, a) for s, a in scored if s != float("inf")]
             if not scored:
                 continue
@@ -286,10 +322,14 @@ def loo_table(grid: dict) -> None:
         all_match += matches
         all_n += n
         all_ratios.extend(ratios)
-        print(f"{held:>22s}  {matches / n:>10.0%}  {median(ratios):>10.2e}  "
-              f"{mean(ratios):>12.2e}  {n:>4d}")
-    print(f"{'OVERALL':>22s}  {all_match / all_n:>10.0%}  "
-          f"{median(all_ratios):>10.2e}  {mean(all_ratios):>12.2e}  {all_n:>4d}")
+        print(
+            f"{held:>22s}  {matches / n:>10.0%}  {median(ratios):>10.2e}  "
+            f"{mean(ratios):>12.2e}  {n:>4d}"
+        )
+    print(
+        f"{'OVERALL':>22s}  {all_match / all_n:>10.0%}  "
+        f"{median(all_ratios):>10.2e}  {mean(all_ratios):>12.2e}  {all_n:>4d}"
+    )
 
 
 # -----------------------------------------------------------------------------
@@ -314,8 +354,9 @@ def loo_table(grid: dict) -> None:
 import math
 
 
-def soft_cost_pick(cell: dict, n_dim: int, n_trials: int, eval_time: float,
-                   lam: float) -> str | None:
+def soft_cost_pick(
+    cell: dict, n_dim: int, n_trials: int, eval_time: float, lam: float
+) -> str | None:
     """Pick the algorithm with the lowest adjusted_borda among algorithms
     that pass the dim cap and min-trials filters at this cell. Tier filter
     is intentionally not applied — that's what the soft penalty replaces."""
@@ -347,10 +388,10 @@ LAMBDA_SWEEP = [0.0, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0]
 LAMBDA_SCHEDULE = [
     # (eval_time_threshold, lambda_) — uses the first match where
     # eval_time ≤ threshold. Beyond the last entry, λ=0.
-    (1e-5, 3.0),    # ≤10 µs
-    (1e-4, 1.0),    # ≤100 µs
-    (1e-3, 1.0),    # ≤1 ms
-    (1e-2, 1.0),    # ≤10 ms
+    (1e-5, 3.0),  # ≤10 µs
+    (1e-4, 1.0),  # ≤100 µs
+    (1e-3, 1.0),  # ≤1 ms
+    (1e-2, 1.0),  # ≤10 ms
     (float("inf"), 0.0),
 ]
 
@@ -366,11 +407,13 @@ def soft_borda_sweep(grid: dict, overhead_budget: float = 1.0) -> None:
     """Table 4: λ sweep of the soft cost-weighted Borda recommender,
     evaluated against both naive and cost-aware oracles at each eval_time."""
     cells = grid["cells"]
-    print(f"\n# Table 4: λ sweep for soft cost-weighted Borda")
-    print(f"# (penalty = λ · log(1 + mean_wall / (n_trials · eval_time)))\n")
-    print(f"# Each cell shows (naive_match% / cost_aware_match%) at (eval_time, λ).")
-    print(f"# λ=0 reproduces the current recommender. "
-          f"Cost-aware oracle uses overhead_budget={overhead_budget}.\n")
+    print("\n# Table 4: λ sweep for soft cost-weighted Borda")
+    print("# (penalty = λ · log(1 + mean_wall / (n_trials · eval_time)))\n")
+    print("# Each cell shows (naive_match% / cost_aware_match%) at (eval_time, λ).")
+    print(
+        f"# λ=0 reproduces the current recommender. "
+        f"Cost-aware oracle uses overhead_budget={overhead_budget}.\n"
+    )
 
     headers = ["eval_time"] + [f"λ={lam}" for lam in LAMBDA_SWEEP]
     widths = [10] + [12 for _ in LAMBDA_SWEEP]
@@ -424,8 +467,10 @@ def soft_borda_sweep(grid: dict, overhead_budget: float = 1.0) -> None:
     # Example switches at λ*.
     if best_lam and best_lam > 0:
         print(f"\n# Example switches at λ* = {best_lam} (eval_time=10µs):\n")
-        print(f"  {'cell':>10s}  {'λ=0 pick':>22s}  {'λ=λ* pick':>22s}  "
-              f"{'cost-aware oracle':>22s}")
+        print(
+            f"  {'cell':>10s}  {'λ=0 pick':>22s}  {'λ=λ* pick':>22s}  "
+            f"{'cost-aware oracle':>22s}"
+        )
         shown = 0
         for ck, cell in cells.items():
             if shown >= 8:
@@ -448,10 +493,12 @@ def schedule_evaluation(grid: dict, overhead_budget: float = 1.0) -> None:
     (best λ at each eval time), so it can't lose — but the table shows
     by how much."""
     cells = grid["cells"]
-    print(f"\n# Table 5: Per-eval-time λ schedule vs single λ choices\n")
-    print(f"  {'eval_time':>10s}  {'λ from schedule':>16s}  "
-          f"{'schedule cost-aware':>20s}  {'best single λ':>14s}  "
-          f"{'best cost-aware':>16s}")
+    print("\n# Table 5: Per-eval-time λ schedule vs single λ choices\n")
+    print(
+        f"  {'eval_time':>10s}  {'λ from schedule':>16s}  "
+        f"{'schedule cost-aware':>20s}  {'best single λ':>14s}  "
+        f"{'best cost-aware':>16s}"
+    )
     print("  " + "-" * 88)
 
     schedule_matches: list[float] = []
@@ -509,19 +556,26 @@ def schedule_evaluation(grid: dict, overhead_budget: float = 1.0) -> None:
         sched_match = cost_m / n
         schedule_matches.append(sched_match)
 
-        best_lam_here = max(single_lam_match_per_et[label],
-                            key=single_lam_match_per_et[label].get)
+        best_lam_here = max(
+            single_lam_match_per_et[label], key=single_lam_match_per_et[label].get
+        )
         best_lam_match = single_lam_match_per_et[label][best_lam_here]
-        print(f"  {label:>10s}  {sched_lam:>16.1f}  "
-              f"{sched_match:>20.0%}  {best_lam_here:>14.1f}  "
-              f"{best_lam_match:>16.0%}")
+        print(
+            f"  {label:>10s}  {sched_lam:>16.1f}  "
+            f"{sched_match:>20.0%}  {best_lam_here:>14.1f}  "
+            f"{best_lam_match:>16.0%}"
+        )
 
-    print(f"\n  Mean across eval times:")
+    print("\n  Mean across eval times:")
     print(f"    Schedule:                {mean(schedule_matches):>5.1%}")
-    print(f"    Best single λ ({best_single_lam_overall}):    "
-          f"{best_single_lam_score:>5.1%}")
-    print(f"    Current recommender λ=0: "
-          f"{mean(single_lam_match_per_et[lbl][0.0] for lbl, _ in EVAL_TIMES if 0.0 in single_lam_match_per_et[lbl]):>5.1%}")
+    print(
+        f"    Best single λ ({best_single_lam_overall}):    "
+        f"{best_single_lam_score:>5.1%}"
+    )
+    print(
+        f"    Current recommender λ=0: "
+        f"{mean(single_lam_match_per_et[lbl][0.0] for lbl, _ in EVAL_TIMES if 0.0 in single_lam_match_per_et[lbl]):>5.1%}"
+    )
 
 
 def make_figures(grid: dict, overhead_budget: float = 1.0) -> None:
@@ -531,6 +585,7 @@ def make_figures(grid: dict, overhead_budget: float = 1.0) -> None:
     Figure 2: Pareto frontier — naive match vs cost-aware match across λ.
     """
     import matplotlib
+
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
     import numpy as np
@@ -579,8 +634,15 @@ def make_figures(grid: dict, overhead_budget: float = 1.0) -> None:
             v = cost_arr[i, j]
             if np.isnan(v):
                 continue
-            ax.text(j, i, f"{v:.0%}", ha="center", va="center",
-                    color="white" if v < 0.5 else "black", fontsize=8)
+            ax.text(
+                j,
+                i,
+                f"{v:.0%}",
+                ha="center",
+                va="center",
+                color="white" if v < 0.5 else "black",
+                fontsize=8,
+            )
     fig.tight_layout()
     out1 = FIGURES / "fig1_cost_aware_heatmap.pdf"
     fig.savefig(out1)
@@ -595,20 +657,35 @@ def make_figures(grid: dict, overhead_budget: float = 1.0) -> None:
         x = naive_arr[i, :]
         y = cost_arr[i, :]
         ax.plot(x, y, "-", color=colors[i], alpha=0.5, linewidth=1)
-        ax.scatter(x, y, s=40, color=colors[i], marker=markers[i],
-                   label=label, edgecolor="black", linewidth=0.5)
+        ax.scatter(
+            x,
+            y,
+            s=40,
+            color=colors[i],
+            marker=markers[i],
+            label=label,
+            edgecolor="black",
+            linewidth=0.5,
+        )
         for j, lam in enumerate(lambdas):
             if not (np.isnan(x[j]) or np.isnan(y[j])):
-                ax.annotate(f"{lam:g}", (x[j], y[j]),
-                            textcoords="offset points", xytext=(5, 5),
-                            fontsize=7, color=colors[i])
+                ax.annotate(
+                    f"{lam:g}",
+                    (x[j], y[j]),
+                    textcoords="offset points",
+                    xytext=(5, 5),
+                    fontsize=7,
+                    color=colors[i],
+                )
     ax.plot([0, 1], [0, 1], "k:", alpha=0.3, linewidth=1)
     ax.set_xlim(-0.02, 1.02)
     ax.set_ylim(-0.02, 1.02)
     ax.set_xlabel("Naive match rate (solution quality, ignoring cost)")
     ax.set_ylabel("Cost-aware match rate")
-    ax.set_title("$\\lambda$ trades naive match for cost-aware match\n"
-                 "(annotations are $\\lambda$ values; lines connect a single eval_time)")
+    ax.set_title(
+        "$\\lambda$ trades naive match for cost-aware match\n"
+        "(annotations are $\\lambda$ values; lines connect a single eval_time)"
+    )
     ax.legend(title="eval_time", loc="lower left", fontsize=9)
     ax.grid(alpha=0.2)
     fig.tight_layout()

--- a/tests/test_eligibility.py
+++ b/tests/test_eligibility.py
@@ -342,6 +342,125 @@ def _write_grid_legacy(tmp_path, cells: dict) -> "Path":
     return p
 
 
+# -----------------------------------------------------------------------------
+# Cost-aware recommender (papers/dfo_recommender/ §4)
+# -----------------------------------------------------------------------------
+
+
+def test_cost_weight_zero_reproduces_quality_only(tmp_path):
+    """cost_weight=0.0 should give exactly the same pick as the default."""
+    p = _write_grid(
+        tmp_path,
+        {
+            "5/200": {
+                "DifferentialEvolution": {"borda_score": 2.0, "mean_wall": 0.001},
+                "CMAEvolutionStrategy": {"borda_score": 1.0, "mean_wall": 0.05},
+            }
+        },
+    )
+    a = E.recommend(n_dim=5, n_trials=200, eval_time=1.0, grid_path=p)
+    b = E.recommend(n_dim=5, n_trials=200, eval_time=1.0, grid_path=p, cost_weight=0.0)
+    assert a == b == "CMAEvolutionStrategy"
+
+
+def test_cost_weight_penalises_heavy_algorithm_on_cheap_objective(tmp_path):
+    """At an eval_time where the quality-only filter admits both algorithms,
+    cost_weight > 0 should still penalise the heavy one enough that the
+    lighter algorithm wins despite a worse raw Borda."""
+    p = _write_grid(
+        tmp_path,
+        {
+            "5/200": {
+                # Heavy algorithm: small Borda edge but huge mean_wall.
+                "CMAEvolutionStrategy": {"borda_score": 1.5, "mean_wall": 10.0},
+                # Light algorithm: slightly worse Borda, near-zero overhead.
+                "Powell": {"borda_score": 2.5, "mean_wall": 0.001},
+            }
+        },
+    )
+    # eval_time = 1ms (above tier-3 threshold so quality-only admits CMA-ES).
+    quality_pick = E.recommend(
+        n_dim=5, n_trials=200, eval_time=1e-3, grid_path=p, cost_weight=0.0
+    )
+    # cost_weight=10: CMA's mean_wall=10s vs baseline=0.2s gives a big
+    # penalty; Powell's penalty is tiny. Cost-aware should switch to Powell.
+    cost_aware_pick = E.recommend(
+        n_dim=5, n_trials=200, eval_time=1e-3, grid_path=p, cost_weight=10.0
+    )
+    assert quality_pick == "CMAEvolutionStrategy"
+    assert cost_aware_pick == "Powell"
+
+
+def test_cost_weight_auto_picks_from_schedule(tmp_path):
+    """cost_weight='auto' should use the per-eval-time schedule."""
+    p = _write_grid(
+        tmp_path,
+        {
+            "5/200": {
+                "CMAEvolutionStrategy": {"borda_score": 1.5, "mean_wall": 1.0},
+                "Powell": {"borda_score": 2.5, "mean_wall": 0.001},
+            }
+        },
+    )
+    # At eval_time = 1µs the schedule's λ = 3.0 (the ≤10µs bucket), so
+    # auto should match cost_weight=3.0.
+    auto_pick = E.recommend(
+        n_dim=5, n_trials=200, eval_time=1e-6, grid_path=p, cost_weight="auto"
+    )
+    fixed_pick = E.recommend(
+        n_dim=5, n_trials=200, eval_time=1e-6, grid_path=p, cost_weight=3.0
+    )
+    assert auto_pick == fixed_pick == "Powell"
+
+
+def test_cost_weight_schedule_collapses_to_quality_at_expensive(tmp_path):
+    """At eval_time ≥ 1s the schedule sets λ = 0, so cost_weight='auto'
+    should give the same pick as the quality-only recommender."""
+    p = _write_grid(
+        tmp_path,
+        {
+            "5/200": {
+                "CMAEvolutionStrategy": {"borda_score": 1.5, "mean_wall": 1.0},
+                "Powell": {"borda_score": 2.5, "mean_wall": 0.001},
+            }
+        },
+    )
+    auto_pick = E.recommend(
+        n_dim=5, n_trials=200, eval_time=1.0, grid_path=p, cost_weight="auto"
+    )
+    quality_pick = E.recommend(
+        n_dim=5, n_trials=200, eval_time=1.0, grid_path=p, cost_weight=0.0
+    )
+    assert auto_pick == quality_pick == "CMAEvolutionStrategy"
+
+
+def test_cost_weight_bypasses_hard_tier_filter(tmp_path):
+    """When cost_weight > 0 the hard tier-eval-time filter is bypassed —
+    the soft penalty replaces it. Without bypass, a high-overhead
+    algorithm could never be picked at sub-µs eval_time even if it's the
+    Borda winner; the soft penalty lets it compete on a continuous
+    scale instead."""
+    p = _write_grid(
+        tmp_path,
+        {
+            "5/200": {
+                # CMA-ES is tier 3 (1ms threshold); at eval_time=1µs the
+                # hard filter would normally drop it. With cost_weight=0.001
+                # (tiny penalty) it should make it through because the
+                # filter is bypassed.
+                "CMAEvolutionStrategy": {"borda_score": 1.0, "mean_wall": 0.0001},
+                "Powell": {"borda_score": 5.0, "mean_wall": 0.0001},
+            }
+        },
+    )
+    pick = E.recommend(
+        n_dim=5, n_trials=200, eval_time=1e-6, grid_path=p, cost_weight=0.001
+    )
+    # With tiny penalty and identical overheads, Borda dominates and
+    # CMA-ES wins despite being below its tier threshold.
+    assert pick == "CMAEvolutionStrategy"
+
+
 def test_recommend_uses_grid_when_present(tmp_path):
     """When a grid is on disk, the recommender picks the eligible algorithm
     with the smallest median_best on the matching cell — not the rule top."""


### PR DESCRIPTION
Wires the soft cost-weighted Borda variant from #236 into the production recommender as an opt-in mode. The paper's algorithmic contribution becomes a usable product feature.

**Stacked on #236.** Merge #235 then #236 first; this PR's base will auto-retarget.

## What ships

\`humpday.eligibility.recommend\` gains a \`cost_weight\` parameter:

| Value | Behavior |
|--|--|
| \`0.0\` (default) | Quality-only recommender. **No behavioral change for existing users.** |
| Positive float | Fixed λ across all eval-times. |
| \`"auto"\` | Per-eval-time schedule from Table 5 of the paper: λ = 3.0 at ≤ 10 µs, λ = 1.0 in the µs–ms band, λ = 0 at ≥ 1 s. |

When \`cost_weight > 0\` the hard eval-time tier filter is bypassed — the soft penalty replaces it. Dimensional cap + minimum-trials filters still apply. Score becomes \`borda + cost_weight·log(1 + mean_wall/(n_trials·eval_time))\`.

\`humpday.minimize\` reads it from \`options={"cost_weight": ...}\`:

\`\`\`python
result = humpday.minimize(
    expensive_objective, bounds=[(-5, 5)] * 8,
    options={"cost_weight": "auto"},
)
\`\`\`

## End-to-end smoke at n_dim=10, n_trials=200

| eval_time | λ from schedule | quality pick | cost-aware pick |
|--|--|--|--|
| 1 µs | 3.0 | RandomSearch | Powell |
| 10 µs | 3.0 | Powell | Powell |
| 100 µs | 1.0 | PRIMA_NEWUOA | **Powell** |
| 1 ms | 1.0 | PRIMA_NEWUOA | **PRIMA_UOBYQA** |
| 10 ms | 1.0 | PRIMA_NEWUOA | PRIMA_NEWUOA |
| 1 s | 0.0 | PRIMA_NEWUOA | PRIMA_NEWUOA |

Exactly the schedule transitions the paper predicted: in the µs–ms band where the 100 µs gap lives, cost-aware mode picks lighter algorithms (Powell, PRIMA_UOBYQA) over the quality-only PRIMA_NEWUOA.

## Test plan

- [x] **5 focused tests** in tests/test_eligibility.py covering: cost_weight=0 reproduces quality-only; cost_weight > 0 flips picks toward lighter algorithms; "auto" matches the fixed-λ pick at the same eval_time; "auto" collapses to quality-only at ≥ 1s; cost_weight > 0 bypasses the hard tier filter
- [x] **JS parity test** (tests/test_js_eligibility_parity.py) still passes — the JS port hasn't picked up cost-aware mode yet, and the \`cost_weight=0\` default keeps both ports in lockstep
- [x] **Full Python suite: 388 passed, 3 skipped** — no regressions
- [x] \`ruff format --check .\` and \`ruff check .\` both clean

## Open question for v0.22.0

Should \`"auto"\` become the default? **Arguments for**: strictly better on the wall-clock-aware metric (+18.6 pp), no degradation at expensive eval-times (schedule collapses to λ = 0 there). **Arguments against**: a user who genuinely doesn't care about wall-clock gets a worse solution-quality pick at the 10 µs – 100 µs band.

My read: leave \`"auto"\` opt-in for v0.22 and revisit after a release cycle of user feedback. Easy to flip later, hard to un-flip if it breaks someone's workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)