### PR TITLE
Fix: include linalg.js on all pages running CMA-ES / PRIMA optimizers

### DIFF
--- a/docs/algorithms/adaptive-random-search.html
+++ b/docs/algorithms/adaptive-random-search.html
@@ -225,6 +225,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/ant-colony-optimization.html
+++ b/docs/algorithms/ant-colony-optimization.html
@@ -211,6 +211,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/bayesian-optimization.html
+++ b/docs/algorithms/bayesian-optimization.html
@@ -213,6 +213,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/bobyqa.html
+++ b/docs/algorithms/bobyqa.html
@@ -212,6 +212,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/cma-evolution-strategy.html
+++ b/docs/algorithms/cma-evolution-strategy.html
@@ -213,6 +213,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/coordinate-descent.html
+++ b/docs/algorithms/coordinate-descent.html
@@ -225,6 +225,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/differential-evolution.html
+++ b/docs/algorithms/differential-evolution.html
@@ -212,6 +212,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/evolution-strategy.html
+++ b/docs/algorithms/evolution-strategy.html
@@ -212,6 +212,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/firefly-algorithm.html
+++ b/docs/algorithms/firefly-algorithm.html
@@ -225,6 +225,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/genetic-algorithm.html
+++ b/docs/algorithms/genetic-algorithm.html
@@ -213,6 +213,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/harmony-search.html
+++ b/docs/algorithms/harmony-search.html
@@ -211,6 +211,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/hill-climbing.html
+++ b/docs/algorithms/hill-climbing.html
@@ -225,6 +225,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/lbfgsb.html
+++ b/docs/algorithms/lbfgsb.html
@@ -213,6 +213,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/nelder-mead.html
+++ b/docs/algorithms/nelder-mead.html
@@ -212,6 +212,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/newuoa.html
+++ b/docs/algorithms/newuoa.html
@@ -214,6 +214,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/particle-swarm.html
+++ b/docs/algorithms/particle-swarm.html
@@ -382,6 +382,7 @@
 
     <!-- Load JavaScript for any interactive elements -->
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/pattern-search.html
+++ b/docs/algorithms/pattern-search.html
@@ -213,6 +213,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/powell.html
+++ b/docs/algorithms/powell.html
@@ -213,6 +213,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/random-search.html
+++ b/docs/algorithms/random-search.html
@@ -373,6 +373,7 @@
 
     <!-- Load JavaScript for any interactive elements -->
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/simulated-annealing.html
+++ b/docs/algorithms/simulated-annealing.html
@@ -213,6 +213,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/algorithms/uobyqa.html
+++ b/docs/algorithms/uobyqa.html
@@ -213,6 +213,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
     <script src="../js/modules/base-optimizer.js"></script>
+    <script src="../js/modules/linalg.js"></script>
     <script src="../js/modules/prima-algorithms.js"></script>
     <script src="../js/modules/scipy-algorithms.js"></script>
     <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/battery-dispatch.html
+++ b/docs/applications/battery-dispatch.html
@@ -274,6 +274,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/bowling.html
+++ b/docs/applications/bowling.html
@@ -309,6 +309,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/brachistochrone.html
+++ b/docs/applications/brachistochrone.html
@@ -260,6 +260,7 @@ and create a project skill from it.</pre>
 
 <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/bridge-truss.html
+++ b/docs/applications/bridge-truss.html
@@ -265,6 +265,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/cart-pole.html
+++ b/docs/applications/cart-pole.html
@@ -281,6 +281,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/curling.html
+++ b/docs/applications/curling.html
@@ -287,6 +287,7 @@ and create a project skill from it.</pre>
 
 <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/free-kick.html
+++ b/docs/applications/free-kick.html
@@ -263,6 +263,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/hvac-nyc.html
+++ b/docs/applications/hvac-nyc.html
@@ -284,6 +284,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/mini-golf.html
+++ b/docs/applications/mini-golf.html
@@ -245,6 +245,7 @@ and create a project skill from it.</pre>
 
 <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/pool.html
+++ b/docs/applications/pool.html
@@ -274,6 +274,7 @@ and create a project skill from it.</pre>
 
 <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/reactor-tprofile.html
+++ b/docs/applications/reactor-tprofile.html
@@ -271,6 +271,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/robot-arm.html
+++ b/docs/applications/robot-arm.html
@@ -270,6 +270,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/rocket-landing.html
+++ b/docs/applications/rocket-landing.html
@@ -277,6 +277,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/slingshot.html
+++ b/docs/applications/slingshot.html
@@ -275,6 +275,7 @@ and create a project skill from it.</pre>
 
 <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/trebuchet.html
+++ b/docs/applications/trebuchet.html
@@ -290,6 +290,7 @@ and create a project skill from it.</pre>
 
 <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/welded-beam.html
+++ b/docs/applications/welded-beam.html
@@ -288,6 +288,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>

--- a/docs/applications/wind-farm.html
+++ b/docs/applications/wind-farm.html
@@ -286,6 +286,7 @@ and create a project skill from it.</pre>
 </div>
 
 <script src="../js/modules/base-optimizer.js"></script>
+<script src="../js/modules/linalg.js"></script>
 <script src="../js/modules/prima-algorithms.js"></script>
 <script src="../js/modules/scipy-algorithms.js"></script>
 <script src="../js/modules/evolutionary-algorithms.js"></script>


### PR DESCRIPTION
## Problem

Selecting **CMA-Evolution Strategy** (or any PRIMA method) on `wind-farm.html` threw `CMAEvolutionStrategy threw an error: Linalg is not defined`.

**Root cause:** `prima-algorithms.js` and `evolutionary-algorithms.js` reference a global `Linalg` for their matrix math. In Node they `require('./linalg.js')`; in the browser they rely on `window.Linalg`, set by `linalg.js`. But `linalg.js` was never included via a `<script>` tag, so the global was undefined. Only optimizers that touch linear algebra (CMA-ES, UOBYQA/NEWUOA/BOBYQA, Powell, LBFGSB) failed — pure-search methods were unaffected, which masked the bug.

## Audit ("check all names")

Checked every page loading a `Linalg`-dependent module:

- **38 pages broken** — 17 application demos + 21 algorithm pages, all missing the include.
- **5 pages already correct** (`contest`, `contest-modular`, `debug-modules`, `test-modular`, `algorithm-visualization-demo`).
- `index.html` / `algorithms.html` only *link* to the files on GitHub (not real `<script>` includes) — no fix needed.

## Fix

Inserted `<script src="../js/modules/linalg.js"></script>` immediately before the first dependent module on each of the 38 pages (path/indentation derived from each page's own include line). One line per file.

## Verification

- Re-audit: **0 pages** remain missing/misordered.
- Simulated the browser `<script>` load path (no `require`/`module`, only `window`) and confirmed `window.Linalg` is populated with every method CMA-ES and PRIMA call (`cholesky`, `eigh`, `matvec`, `householderQR`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)