### PR TITLE
bridge-truss: restore stranded deflection fix (stop the sinking-bridge look)

### DIFF
--- a/docs/applications/bridge-truss.html
+++ b/docs/applications/bridge-truss.html
@@ -608,21 +608,28 @@ function drawScene(evalResult, loadFrac, hudText) {
     ctx.stroke();
   }
 
-  // Displaced node positions (scale displacements for visibility).
-  // Real displacements at ~95 kg / 50 kN are sub-mm — we exaggerate by
-  // a fixed factor so the deformed shape is visible.
-  const DEFLECT_SCALE = 800;
+  // Displaced node positions. Real axial strains on a feasible truss at
+  // 20 kN are sub-mm, so we exaggerate them — but cap the visual offset
+  // so a light-area design's huge displacements don't turn the bridge
+  // into a sinking-spaghetti silhouette (user feedback: "I don't
+  // understand what I'm looking at, a sinking bridge?"). Cap at 14 px
+  // per node, which reads as "the bridge is loaded" without misleading
+  // the viewer into thinking it's collapsing.
+  const DEFLECT_SCALE = 200;
+  const MAX_VISUAL_PX = 14;
   const nodesPx = NODES.map((nd, i) => {
-    let dx = 0, dy = 0;
+    let dxPx = 0, dyPx = 0;
     if (evalResult && evalResult.displacements) {
-      dx = evalResult.displacements[2 * i] * DEFLECT_SCALE;
-      dy = evalResult.displacements[2 * i + 1] * DEFLECT_SCALE;
+      dxPx = evalResult.displacements[2 * i] * DEFLECT_SCALE * PX_PER_M * loadFrac;
+      dyPx = -evalResult.displacements[2 * i + 1] * DEFLECT_SCALE * PX_PER_M * loadFrac;
+      const mag = Math.hypot(dxPx, dyPx);
+      if (mag > MAX_VISUAL_PX) {
+        const k = MAX_VISUAL_PX / mag;
+        dxPx *= k; dyPx *= k;
+      }
     }
     const base = physToPx(nd.x, nd.y);
-    return {
-      px: base.px + dx * PX_PER_M * loadFrac,
-      py: base.py - dy * PX_PER_M * loadFrac,
-    };
+    return { px: base.px + dxPx, py: base.py + dyPx };
   });
 
   // Members.
@@ -715,7 +722,7 @@ function drawScene(evalResult, loadFrac, hudText) {
     ctx.closePath();
     ctx.fill();
     ctx.font = 'bold 12px -apple-system, Helvetica, Arial, sans-serif';
-    ctx.fillText('50 kN', np.px - 18, np.py - arrowLen - 14);
+    ctx.fillText('20 kN', np.px - 18, np.py - arrowLen - 14);
   }
 
   // Constraint readout strip at the bottom.


### PR DESCRIPTION
## What

Restores commit `bd15144` (authored by @microprediction on the `add-bridge-truss-demo` branch) which **never merged to main** — the original demo landed via #139's squash, but this follow-up fix on the same branch was left stranded. Classic squash-merge drop.

## Symptom

On main, the bridge-truss canvas draws nodes sinking far below the support line (the loaded node overlapped the status strip), reading as "the bridge is collapsing" even for feasible designs. The load arrow was also labelled `50 kN` while everything else (the `LOAD = 20e3` constant, the prose) said 20 kN.

## Why it was wrong on main

Main is internally inconsistent: `LOAD = 20e3` and all prose say 20 kN, but the rendering still had the pre-fix `DEFLECT_SCALE = 800` (uncapped) and a hardcoded `'50 kN'` canvas label. The fix had simply never arrived.

## The fix (verbatim from bd15144)

- Drop `DEFLECT_SCALE` 800 → 200 and **cap visual deflection at 14 px/node**, so light-area designs don't render as a sagging silhouette.
- Correct the canvas load label `50 kN` → `20 kN` to match `LOAD`.

## Verification

Cherry-picked cleanly (current code matched the fix's "before" context). Headless render confirms the lower chord now rests on the support line and the structure reads as a loaded truss, not a collapse.

Not caused by the linalg PR (#242) — that branched from main and never had this commit to revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)