### PR TITLE
contest: clarify the Mixed challenge cycles function types (no behaviour change)

### DIFF
--- a/docs/js/contest-controller.js
+++ b/docs/js/contest-controller.js
@@ -497,7 +497,7 @@
                 'rastrigin': 'Highly multimodal, regular local optima (50 frequency/scale variants)',
                 'ackley': 'Multimodal with global structure, steep near optimum (50 parameter variants)',
                 'griewank': 'Multimodal, product structure, scale-dependent (50 rotation/scale variants)',
-                'mixed': 'Tests robustness across all function types (10 of each: sphere, rastrigin, rosenbrock, ackley, griewank)',
+                'mixed': 'Tests robustness across all function types — cycles sphere → rastrigin → rosenbrock → ackley → griewank, so every type is sampled within the first five trials',
                 'noisy': 'Function evaluations corrupted with noise (50 variants with different noise levels)'
             };
 
@@ -791,7 +791,7 @@
                 'rastrigin': 'Highly multimodal, regular local optima (50 frequency/scale variants)',
                 'ackley': 'Multimodal with global structure, steep near optimum (50 parameter variants)',
                 'griewank': 'Multimodal, product structure, scale-dependent (50 rotation/scale variants)',
-                'mixed': 'Tests robustness across all function types (10 of each: sphere, rastrigin, rosenbrock, ackley, griewank)',
+                'mixed': 'Tests robustness across all function types — cycles sphere → rastrigin → rosenbrock → ackley → griewank, so every type is sampled within the first five trials',
                 'noisy': 'Function evaluations corrupted with noise (50 variants with different noise levels)'
             };
 


### PR DESCRIPTION
## Context

A user reported the contest appeared to run "all griewank first" on the **Mixed** challenge.

## Finding (verified)

The Mixed contest **already cycles** function types. `runRealContest` builds its 50 surfaces with `['sphere','rastrigin','rosenbrock','ackley','griewank'][i % 5]` and runs them in index order, so the first five surfaces are one of each type and griewank lands at positions 5, 10, 15, … — never grouped. Confirmed by hooking the surface generator headlessly:

```
generation order: Sphere Rastrigin Rosenbrock Ackley Griewank Sphere Rastrigin Rosenbrock Ackley Griewank …
```

This interleaving has been on `main` since commit 13f88ed, so the grouping the user saw is most likely a **stale GitHub Pages build**; merging this (or any pending PR) rebuilds Pages.

## Change

Only the tooltip wording. It said *"10 of each: sphere, rastrigin, rosenbrock, ackley, griewank"* — technically a count, but it reads as grouped. Reworded to state the cycling order explicitly. **No behaviour change** (`node --check` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)