### PR TITLE
dfo_recommender: disguised benchmark + scoring driver + algo-dev loop

### DIFF
--- a/example_applications/DEMOS_SHORTLIST.md
+++ b/example_applications/DEMOS_SHORTLIST.md
@@ -38,7 +38,10 @@ auto-collected, verified against known optima where one exists.
 
 **Disguise harness:** `humpday/transforms/cube_disguise.py` wraps any objective in a seeded
 random cube→cube diffeomorphism, relocating the optimum per seed so algorithm development
-against these demos can't memorise optimum *locations*. Use many seeds per problem.
+against these demos can't memorise optimum *locations*. Wired into the benchmark via
+`papers/dfo_recommender/example_demos.py`: `disguised_demos()` expands the 52 problems into
+260 non-memorisable instances (5 seeds each by default); `disguise_demo(demo, seed)` for one.
+Run `python papers/dfo_recommender/example_demos.py` to see the relocation verification.
 
 ## Deferred / different home
 

--- a/papers/dfo_recommender/algo_dev.py
+++ b/papers/dfo_recommender/algo_dev.py
@@ -1,0 +1,235 @@
+"""
+Goal-based optimizer development — evolve a black-box optimizer against the
+disguised benchmark.
+
+This is the capstone of the disguised-benchmark stack:
+
+  example_applications/*  →  example_demos.disguised_demos()  →  fitness here
+
+A *candidate optimizer* is produced from a small genome of behavioural knobs
+(`make_candidate`). Its **fitness** is its mean rank against a fixed baseline
+panel across many *disguised* instances (`candidate_fitness`) — disguised so the
+candidate can't win by memorising optimum locations; it must genuinely search.
+A simple (1 + λ) evolution strategy (`evolve`) mutates genomes to drive that
+fitness down. Swap in a richer template or a real meta-optimizer later; the loop
+and the memorisation-proof fitness are what matter.
+
+    python papers/dfo_recommender/algo_dev.py --quick
+    python papers/dfo_recommender/algo_dev.py --generations 12 --lam 6
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+from pathlib import Path
+from statistics import mean
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent
+for p in (str(REPO_ROOT), str(HERE)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from example_demos import DEMOS, disguise_demo  # noqa: E402
+
+from humpday.optimizers.alloptimizers import pure_optimize  # noqa: E402
+
+INF = float("inf")
+GENOME_LEN = 6
+
+# Baseline panel the candidate is ranked against (kept small so a genome
+# evaluation — which reruns the whole panel per instance — stays affordable).
+PANEL = ["NelderMead", "DifferentialEvolution", "CMAEvolutionStrategy"]
+
+
+def _clip01(x):
+    return min(1.0, max(0.0, x))
+
+
+def make_candidate(genome):
+    """Build a concrete optimizer from a genome in [0,1]^6.
+
+    The template is a real, general strategy: differential evolution with an
+    occasional Gaussian local move around the incumbent and a one-shot restart
+    of the worst half. The genome sets population size, F, crossover rate, the
+    local-move probability, the local step, and when to restart."""
+    g = [_clip01(v) for v in genome]
+    pop = 4 + int(g[0] * 16)
+    F = 0.3 + g[1] * 0.7
+    CR = 0.1 + g[2] * 0.9
+    p_local = g[3]
+    sigma = 0.02 + g[4] * 0.28
+    restart_at = 0.4 + g[5] * 0.5
+
+    def optimize(objective, n_trials, n_dim, with_count=False):
+        state = {"evals": 0, "best_f": INF, "best_x": None}
+
+        def ev(x):
+            x = [_clip01(xi) for xi in x]
+            f = objective(x)
+            state["evals"] += 1
+            if f < state["best_f"]:
+                state["best_f"], state["best_x"] = f, x[:]
+            return f
+
+        P = [[random.random() for _ in range(n_dim)] for _ in range(pop)]
+        fit = [ev(p) for p in P]
+        restarted = False
+        while state["evals"] < n_trials:
+            for i in range(pop):
+                if state["evals"] >= n_trials:
+                    break
+                if state["best_x"] is not None and random.random() < p_local:
+                    trial = [
+                        state["best_x"][j] + random.gauss(0, sigma)
+                        for j in range(n_dim)
+                    ]
+                else:
+                    a, b, c = random.sample(range(pop), 3) if pop >= 3 else (0, 0, 0)
+                    trial = [
+                        P[a][j] + F * (P[b][j] - P[c][j])
+                        if random.random() < CR
+                        else P[i][j]
+                        for j in range(n_dim)
+                    ]
+                ft = ev(trial)
+                if ft < fit[i]:
+                    P[i], fit[i] = trial, ft
+            if not restarted and state["evals"] > restart_at * n_trials:
+                order = sorted(range(pop), key=lambda k: fit[k])
+                for k in order[pop // 2 :]:
+                    if state["evals"] >= n_trials:
+                        break
+                    P[k] = [random.random() for _ in range(n_dim)]
+                    fit[k] = ev(P[k])
+                restarted = True
+        if with_count:
+            return state["best_f"], state["best_x"], state["evals"]
+        return state["best_f"], state["best_x"]
+
+    return optimize
+
+
+def _panel_best(algo, demo, n_trials, run_seed):
+    random.seed(run_seed)
+    try:
+        import numpy as np
+
+        np.random.seed(run_seed)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        f_best, _ = pure_optimize(demo.objective, algo, n_trials, demo.n_dim)
+        return float(f_best)
+    except Exception:  # noqa: BLE001
+        return INF
+
+
+def _candidate_best(candidate, demo, n_trials, run_seed):
+    random.seed(run_seed)
+    try:
+        f_best, _ = candidate(demo.objective, n_trials, demo.n_dim)
+        return float(f_best)
+    except Exception:  # noqa: BLE001
+        return INF
+
+
+def candidate_fitness(genome, base_demos, seeds, n_trials, panel=PANEL):
+    """Mean rank (lower = better) of the candidate vs the baseline panel across
+    the disguised instances of `base_demos`. This is the fitness to minimise."""
+    candidate = make_candidate(genome)
+    ranks = []
+    for i, demo in enumerate(base_demos):
+        for s in seeds:
+            inst = disguise_demo(demo, s)
+            seed = 5000 + 31 * i + s
+            cand = _candidate_best(candidate, inst, n_trials, seed)
+            others = [_panel_best(a, inst, n_trials, seed) for a in panel]
+            # rank of candidate among [candidate] + panel (1 = best)
+            rank = 1 + sum(1 for v in others if v < cand)
+            ranks.append(rank)
+    return mean(ranks) if ranks else INF
+
+
+def evolve(generations, lam, base_demos, seeds, n_trials, rng_seed=0):
+    """(1 + λ) evolution strategy over the genome. Returns (best_genome,
+    best_fitness, history)."""
+    random.seed(rng_seed)
+    parent = [random.random() for _ in range(GENOME_LEN)]
+    parent_fit = candidate_fitness(parent, base_demos, seeds, n_trials)
+    history = [parent_fit]
+    step = 0.25
+    print(f"  gen 0: parent fitness (mean rank) = {parent_fit:.3f}", flush=True)
+    for gen in range(1, generations + 1):
+        best_child, best_child_fit = None, INF
+        for _ in range(lam):
+            child = [
+                _clip01(parent[j] + random.gauss(0, step)) for j in range(GENOME_LEN)
+            ]
+            fit = candidate_fitness(child, base_demos, seeds, n_trials)
+            if fit < best_child_fit:
+                best_child, best_child_fit = child, fit
+        if best_child_fit < parent_fit:
+            parent, parent_fit = best_child, best_child_fit
+            step = min(0.4, step * 1.15)  # success: explore a bit wider
+        else:
+            step = max(0.05, step * 0.8)  # stall: tighten
+        history.append(parent_fit)
+        print(
+            f"  gen {gen}: best fitness = {parent_fit:.3f}  (child tried {best_child_fit:.3f}, step {step:.2f})",
+            flush=True,
+        )
+    return parent, parent_fit, history
+
+
+def _describe(genome):
+    g = [_clip01(v) for v in genome]
+    return {
+        "pop": 4 + int(g[0] * 16),
+        "F": round(0.3 + g[1] * 0.7, 3),
+        "CR": round(0.1 + g[2] * 0.9, 3),
+        "p_local": round(g[3], 3),
+        "sigma": round(0.02 + g[4] * 0.28, 3),
+        "restart_at": round(0.4 + g[5] * 0.5, 3),
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--generations", type=int, default=8)
+    ap.add_argument("--lam", type=int, default=4)
+    ap.add_argument("--seeds", default="0,1")
+    ap.add_argument("--trials", type=int, default=80)
+    ap.add_argument(
+        "--n-demos", type=int, default=8, help="how many base demos to score on"
+    )
+    ap.add_argument("--quick", action="store_true")
+    args = ap.parse_args()
+
+    generations, lam, trials = args.generations, args.lam, args.trials
+    seeds = tuple(int(s) for s in args.seeds.split(","))
+    n_demos = args.n_demos
+    if args.quick:
+        generations, lam, trials, n_demos, seeds = 4, 3, 50, 5, (0, 1)
+
+    base = DEMOS[:n_demos]
+    print(
+        f"Evolving an optimizer: (1+{lam}) ES, {generations} generations, fitness = mean rank\n"
+        f"vs {PANEL} across {len(base)} demos x {len(seeds)} disguised seeds, {trials} trials each.\n"
+    )
+    best_genome, best_fit, _ = evolve(generations, lam, base, seeds, trials)
+    print("\n=== Evolved optimizer ===")
+    print(f"  fitness (mean rank vs panel of {len(PANEL)}): {best_fit:.3f}")
+    print(f"  genome: {_describe(best_genome)}")
+    print(
+        "\nLower mean rank = the evolved optimizer beats more of the baseline panel\n"
+        "on the (memorisation-proof) disguised instances. Widen --generations/--lam/\n"
+        "--n-demos and enrich make_candidate to push further."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/papers/dfo_recommender/disguise_bench.py
+++ b/papers/dfo_recommender/disguise_bench.py
@@ -1,0 +1,185 @@
+"""
+Disguised-benchmark scoring driver — a fitness function for goal-based
+development of optimization algorithms.
+
+Score optimizers across the *disguised* example-application suite: every problem
+is expanded into several instances by a seeded cube->cube diffeomorphism
+(`example_demos.disguised_demos`), so the optimum sits somewhere different on
+each instance and an algorithm cannot win by memorising locations — it has to
+search.
+
+Because the problems live on wildly different scales (a Δv of 0.19, a gearbox
+weight of ~3000, a cluster energy of -9), raw best-values can't be averaged
+across problems. We score scale-free, per instance:
+  - rank the optimizers (1 = best best-value on that instance), then
+  - average each optimizer's rank over all instances (lower = better), and
+  - report a win rate (fraction of instances it ranks first).
+Mean rank across the disguised suite is the single fitness an algorithm-
+development loop can maximise (minimise) for a candidate optimizer.
+
+    python papers/dfo_recommender/disguise_bench.py            # default panel
+    python papers/dfo_recommender/disguise_bench.py --quick    # fast smoke
+    python papers/dfo_recommender/disguise_bench.py --optimizers NelderMead,CMAEvolutionStrategy,DifferentialEvolution
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+from pathlib import Path
+from statistics import mean
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
+
+from example_demos import DEMOS, disguised_demos  # noqa: E402
+
+from humpday.optimizers.alloptimizers import (  # noqa: E402
+    PURE_OPTIMIZERS,
+    pure_optimize,
+)
+
+# A representative cross-section (one local, trust-region, several population,
+# Bayesian, annealing) — the default panel to rank a candidate against.
+DEFAULT_PANEL = [
+    "NelderMead",
+    "Powell",
+    "PRIMA_BOBYQA",
+    "DifferentialEvolution",
+    "ParticleSwarm",
+    "CMAEvolutionStrategy",
+    "BayesianOpt",
+    "SimulatedAnnealing",
+]
+
+INF = float("inf")
+
+
+def _set_seed(seed: int) -> None:
+    random.seed(seed)
+    try:
+        import numpy as np
+
+        np.random.seed(seed)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _best_value(algo: str, demo, n_trials: int, run_seed: int) -> float:
+    """Best objective `algo` finds on `demo` in n_trials (lower = better)."""
+    _set_seed(run_seed)  # reproducible, and seeds any stochastic objective
+    try:
+        f_best, _ = pure_optimize(demo.objective, algo, n_trials, demo.n_dim)
+        return float(f_best)
+    except Exception as e:  # noqa: BLE001
+        print(f"    ! {algo} on {demo.name}: {e}", flush=True)
+        return INF
+
+
+def benchmark(optimizers, demos=None, seeds=(0, 1, 2), n_trials=120, base_demos=None):
+    """Run every optimizer on every disguised instance.
+
+    Returns {instance_name: {optimizer: best_value}}."""
+    base = DEMOS if base_demos is None else base_demos
+    instances = disguised_demos(base, seeds=tuple(seeds))
+    results: dict[str, dict[str, float]] = {}
+    for i, inst in enumerate(instances):
+        row: dict[str, float] = {}
+        for algo in optimizers:
+            row[algo] = _best_value(algo, inst, n_trials, run_seed=1000 + i)
+        results[inst.name] = row
+        best = min(row.values())
+        winner = min(row, key=row.get)
+        print(
+            f"  [{i + 1}/{len(instances)}] {inst.name:28s} best={best:.4g} ({winner})",
+            flush=True,
+        )
+    return results
+
+
+def leaderboard(results, optimizers):
+    """Scale-free aggregation: per-instance ranks -> mean rank + win rate."""
+    ranks = {a: [] for a in optimizers}
+    wins = dict.fromkeys(optimizers, 0)
+    for _, row in results.items():
+        order = sorted(optimizers, key=lambda a: row.get(a, INF))
+        # competition ranking with ties shared
+        last_val, last_rank = None, 0
+        for pos, a in enumerate(order, start=1):
+            v = row.get(a, INF)
+            r = pos if v != last_val else last_rank
+            ranks[a].append(r)
+            last_val, last_rank = v, r
+        best = min(row.values()) if row else INF
+        for a in optimizers:
+            if row.get(a, INF) == best:
+                wins[a] += 1
+    n = max(1, len(results))
+    table = [(a, mean(ranks[a]), wins[a] / n) for a in optimizers]
+    table.sort(key=lambda t: t[1])
+    return table
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--optimizers",
+        default=",".join(DEFAULT_PANEL),
+        help="comma-separated optimizer names (or 'all')",
+    )
+    ap.add_argument("--seeds", default="0,1,2", help="disguise seeds (comma-separated)")
+    ap.add_argument("--trials", type=int, default=120)
+    ap.add_argument(
+        "--demos", default="", help="comma-separated subset of base demo names"
+    )
+    ap.add_argument(
+        "--quick", action="store_true", help="fast smoke: 6 demos, 2 seeds, 40 trials"
+    )
+    args = ap.parse_args()
+
+    if args.optimizers == "all":
+        optimizers = list(PURE_OPTIMIZERS.keys())
+    else:
+        optimizers = [a.strip() for a in args.optimizers.split(",") if a.strip()]
+    optimizers = [a for a in optimizers if a in PURE_OPTIMIZERS]
+
+    base = DEMOS
+    if args.demos:
+        wanted = {d.strip() for d in args.demos.split(",")}
+        base = [d for d in DEMOS if d.name in wanted]
+    seeds = tuple(int(s) for s in args.seeds.split(","))
+    trials = args.trials
+
+    if args.quick:
+        base = base[:6]
+        seeds = (0, 1)
+        trials = 40
+
+    print(
+        f"Disguised benchmark: {len(base)} base demos x {len(seeds)} seeds "
+        f"= {len(base) * len(seeds)} instances, {len(optimizers)} optimizers, "
+        f"{trials} trials each\n"
+    )
+    results = benchmark(optimizers, base_demos=base, seeds=seeds, n_trials=trials)
+
+    print(
+        "\n=== Leaderboard (mean rank across disguised instances; lower = better) ==="
+    )
+    print(f"{'optimizer':<24}  {'mean rank':>9}  {'win rate':>8}")
+    print("-" * 48)
+    for a, mr, wr in leaderboard(results, optimizers):
+        print(f"  {a:<22}  {mr:>9.3f}  {wr:>7.1%}")
+    print(
+        f"\n{len(results)} instances scored. Mean rank is the scale-free fitness "
+        "an\nalgorithm-development loop maximises for a candidate optimizer."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/papers/dfo_recommender/example_demos.py
+++ b/papers/dfo_recommender/example_demos.py
@@ -18,8 +18,14 @@ from dataclasses import dataclass
 from typing import Callable
 
 import example_applications
+from humpday.transforms.cube_disguise import disguise
 
 DEFAULT_N_TRIALS = 200
+
+# Default number of disguised instances generated per problem. Each instance
+# applies a different seeded cube->cube diffeomorphism, relocating the optimum
+# so an optimizer (or its meta-tuning) cannot score by memorising a location.
+DISGUISE_SEEDS = (0, 1, 2, 3, 4)
 
 # Demos we deliberately exclude. chess_piece_values plays several depth-2 chess
 # games per evaluation; at 200 trials × ~21 algos × 3 seeds it runs for ~14 hours.
@@ -59,3 +65,66 @@ def _collect_example_demos() -> list[Demo]:
 
 
 DEMOS: list[Demo] = _collect_example_demos()
+
+
+# --------------------------------------------------------------------------
+# Disguised instances: wrap each objective in a seeded cube->cube diffeomorphism
+# so the optimum is relocated to an unpredictable, instance-specific point. The
+# landscape (difficulty, critical-point structure, optimal value) is unchanged,
+# but no algorithm can win by remembering WHERE the optimum is — it must search.
+# Use this when developing/meta-tuning optimizers against the suite.
+# --------------------------------------------------------------------------
+
+
+def disguise_demo(demo: Demo, seed: int, rotate: bool = False) -> Demo:
+    """Return a disguised copy of `demo`: same n_dim / budget, objective wrapped
+    in the seed's cube->cube diffeomorphism. Name is suffixed `#<seed>`."""
+    return Demo(
+        name=f"{demo.name}#{seed}",
+        n_dim=demo.n_dim,
+        suggested_n_trials=demo.suggested_n_trials,
+        objective=disguise(demo.objective, demo.n_dim, seed, rotate=rotate),
+    )
+
+
+def disguised_demos(
+    demos: list[Demo] | None = None,
+    seeds=DISGUISE_SEEDS,
+    rotate: bool = False,
+) -> list[Demo]:
+    """Expand `demos` (default: all DEMOS) into len(seeds) disguised instances
+    each — a benchmark on which optimum locations cannot be memorised."""
+    demos = DEMOS if demos is None else demos
+    return [disguise_demo(d, s, rotate) for d in demos for s in seeds]
+
+
+if __name__ == "__main__":
+    import random
+
+    print(f"{len(DEMOS)} base demos")
+    print(
+        f"{len(disguised_demos())} disguised instances ({len(DISGUISE_SEEDS)} seeds each)\n"
+    )
+
+    # Verify the disguise is a faithful relocation: for a wrapped objective g and
+    # any cube point p, g(phi^{-1}(p)) must equal the raw objective f(p) — i.e. the
+    # value at p simply moved to phi^{-1}(p). Also show the optimum moves per seed.
+    base = {d.name: d for d in DEMOS}
+    probe = base.get("multi_exponential_fit") or DEMOS[0]
+    f = probe.objective
+    print(f"verifying relocation on '{probe.name}' (n_dim={probe.n_dim}):")
+    for seed in DISGUISE_SEEDS:
+        g = disguise_demo(probe, seed)
+        dis = g.objective.disguise
+        random.seed(seed)
+        worst = 0.0
+        for _ in range(200):
+            p = [random.random() for _ in range(probe.n_dim)]
+            worst = max(worst, abs(g.objective(dis.inverse(p)) - f(p)))
+        # where a fixed reference point's value now lives in disguised coords
+        ref = [0.5] * probe.n_dim
+        moved = dis.inverse(ref)
+        print(
+            f"  seed {seed}:  max |g(phi^-1 p) - f(p)| = {worst:.2e}   "
+            f"u=½ relocated to {[round(x, 3) for x in moved[:4]]}"
+        )


### PR DESCRIPTION
A complete, **memorisation-proof benchmark stack for goal-based optimizer development.**

**1. Disguise harness** (`example_demos.py`): `disguised_demos()` expands the 52
base problems into **260 non-memorisable instances** (5 seeds each); each wraps
the objective in a seeded cube→cube diffeomorphism (`humpday/transforms/cube_disguise.py`)
— same landscape/difficulty/optimal value, but the optimum *location* moves per
seed. Raw `DEMOS` unchanged. `python example_demos.py` verifies relocation is
faithful (`max |g(phi^-1 p) - f(p)| ~ 1e-14`).

**2. Scoring driver** (`disguise_bench.py`): ranks optimizers per instance and
averages to a **scale-free mean rank** (+ win rate). `benchmark(...)` /
`leaderboard(...)`; CLI `--optimizers/--seeds/--trials/--demos/--quick`.

**3. Algo-dev loop** (`algo_dev.py`): a candidate optimizer is built from a
6-gene genome (`make_candidate` — a DE + Gaussian-local + restart hybrid); its
**fitness** is its mean rank vs a baseline panel across disguised instances; a
`(1+λ)` ES (`evolve`) mutates genomes to drive that rank down. Closes the loop:
propose → score on the disguised suite → iterate. `python algo_dev.py --quick`.

The template + ES are deliberately simple stubs to swap a richer optimizer
family or a real meta-optimizer into. Together with the +19 demos already on
`main` (PR #275), this is the foundation for evolving novel optimizers that
have to *search*, not memorise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)