### PR TITLE
Fix FireflyAlgorithm infinite loop (root cause) + regression test + rankcorr watchdog

### DIFF
--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -944,6 +944,7 @@ class FireflyAlgorithm(BaseOptimizer):
         intensities = [self.evaluate(f) for f in fireflies]
 
         while self.evaluations < firefly_budget:
+            evals_at_sweep_start = self.evaluations
             for i in range(n_fireflies):
                 for j in range(n_fireflies):
                     if self.evaluations >= firefly_budget:
@@ -968,6 +969,15 @@ class FireflyAlgorithm(BaseOptimizer):
             # Anneal α at the end of each outer (i, j) sweep, matching
             # mealpy FFA's `dyn_alpha = alpha_damp * alpha`.
             alpha *= alpha_damp
+
+            # Termination guard. evaluate() is reached only when some firefly is
+            # strictly brighter than another; if a whole sweep makes no call, all
+            # intensities are equal — the swarm has collapsed onto one point (a
+            # common end state, since fireflies attract and clip to shared cube
+            # corners) or the region is flat. No future sweep can differ, so the
+            # loop would spin forever without consuming budget. Stop and polish.
+            if self.evaluations == evals_at_sweep_start:
+                break
 
         # Polish stage: L-BFGS-B from the firefly best.
         self._lbfgs_polish()

--- a/papers/dfo_recommender/rankcorr.py
+++ b/papers/dfo_recommender/rankcorr.py
@@ -17,6 +17,7 @@ import json
 import math
 import os
 import random
+import signal
 import sys
 import tempfile
 from pathlib import Path
@@ -38,6 +39,22 @@ from humpday.optimizers.alloptimizers import (  # noqa: E402
 INF = float("inf")
 SYNTH = ["sphere", "ellipsoid", "cigar", "rastrigin", "rosenbrock"]
 
+# Per-call watchdog: a runaway optimizer that ignores its eval budget would spin a
+# core forever and wedge the whole run (one wedged once for 3.5 days). SIGALRM (main
+# thread, subprocess) interrupts the offending pure-Python call so we score it INF
+# (worst) and move on. Set high enough that a genuinely slow-but-finite call (slow
+# optimizers on high-dim demos at the largest budget have been seen near ~2 min) is
+# never falsely killed, since a false INF would bias that optimizer's rank.
+PER_CALL_TIMEOUT = int(os.environ.get("RANKCORR_CALL_TIMEOUT", "600"))
+
+
+class _Timeout(Exception):
+    pass
+
+
+def _on_alarm(signum, frame):
+    raise _Timeout()
+
 
 def run_ngcma(objective, n_trials, n_dim, seed):
     param = ng.p.Array(shape=(n_dim,), lower=0.0, upper=1.0)
@@ -57,13 +74,25 @@ def run_ngcma(objective, n_trials, n_dim, seed):
 def run_opt(name, objective, n_dim, n_trials, seed):
     random.seed(seed)
     np.random.seed(seed)
+    old = signal.signal(signal.SIGALRM, _on_alarm)
+    signal.alarm(PER_CALL_TIMEOUT)
     try:
         if name == "ngCMA":
             return run_ngcma(objective, n_trials, n_dim, seed)
         bv, _ = pure_optimize(objective, name, n_trials, n_dim)
         return float(bv)
+    except _Timeout:
+        print(
+            f"    !! {name} exceeded {PER_CALL_TIMEOUT}s "
+            f"(n_dim={n_dim}, budget={n_trials}) -> INF",
+            flush=True,
+        )
+        return INF
     except Exception:  # noqa: BLE001
         return INF
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old)
 
 
 def make_synth(name, n, seed):

--- a/tests/test_optimizer_termination.py
+++ b/tests/test_optimizer_termination.py
@@ -1,0 +1,143 @@
+"""Every optimizer must TERMINATE and respect its evaluation budget.
+
+This is a regression guard for a class of bug where an optimizer's main loop is
+gated on its own progress: e.g. FireflyAlgorithm only called evaluate() when one
+firefly was strictly brighter than another, so once the swarm collapsed onto a
+single point (identical, hence equal-intensity, after clipping to a cube corner)
+or the objective was flat, no evaluation ever happened and `while
+self.evaluations < budget` spun forever. That wedged a downstream study for 3.5
+days before it was noticed.
+
+Two invariants are checked for every optimizer in the registry:
+  1. optimize() returns within a wall-clock bound on adversarial objectives
+     (flat, corner-optimum, plateau-with-well) that provoke degenerate states.
+  2. optimize() never exceeds the n_trials budget (arguments propagate and cap
+     the work actually done).
+"""
+
+import sys
+
+try:
+    import pytest
+except ImportError:  # allow running the __main__ self-check without pytest
+    pytest = None
+
+from humpday.optimizers.alloptimizers import PURE_OPTIMIZERS, create_optimizer_function
+
+try:
+    import numpy as np
+except Exception:  # noqa: BLE001
+    np = None
+
+# SIGALRM is POSIX-only; on Windows we skip the wall-clock half of the suite.
+try:
+    import signal
+
+    _HAS_ALARM = hasattr(signal, "SIGALRM")
+except Exception:  # noqa: BLE001
+    _HAS_ALARM = False
+
+ALL = sorted(PURE_OPTIMIZERS)
+
+# Objectives engineered to drive optimizers into degenerate states. A correct
+# optimizer must still terminate on every one of them.
+ADVERSARIAL = {
+    "flat": lambda x: 1.0,  # every point equal -> no "improvement" anywhere
+    "corner": lambda x: float(
+        sum((xi - 1.0) ** 2 for xi in x)
+    ),  # optimum at a cube corner
+    "plateau_well": lambda x: (
+        -1.0 if max(abs(xi - 0.5) for xi in x) <= 0.2 else 0.0
+    ),  # huge flat plateau around a small well
+    "sphere": lambda x: float(sum((xi - 0.3) ** 2 for xi in x)),  # benign control
+}
+
+
+class _Timeout(Exception):
+    pass
+
+
+def _run_with_timeout(name, objective, n_trials, n_dim, seconds):
+    """Run one optimizer; raise _Timeout if it does not return in `seconds`."""
+    import random
+
+    random.seed(0)
+    if np is not None:
+        np.random.seed(0)
+    fn = create_optimizer_function(PURE_OPTIMIZERS[name])
+
+    if not _HAS_ALARM:
+        return fn(objective, n_dim, n_trials=n_trials, with_count=True)
+
+    old = signal.signal(signal.SIGALRM, lambda s, f: (_ for _ in ()).throw(_Timeout()))
+    signal.alarm(seconds)
+    try:
+        return fn(objective, n_dim, n_trials=n_trials, with_count=True)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old)
+
+
+def _check_terminates(name, oname):
+    objective = ADVERSARIAL[oname]
+    try:
+        best_value, best_x, evals = _run_with_timeout(
+            name, objective, n_trials=200, n_dim=3, seconds=30
+        )
+    except _Timeout:
+        raise AssertionError(
+            f"{name} did not terminate within 30s on the '{oname}' objective "
+            f"(likely a progress-gated loop that stops consuming budget)"
+        )
+    assert best_x is not None
+    # never blow the budget (polish stages may add a bounded margin)
+    assert evals <= 200 * 1.25 + 10, f"{name} used {evals} evals for a budget of 200"
+
+
+def _check_budget(name):
+    objective = ADVERSARIAL["sphere"]
+    for n_trials in (40, 120):
+        _bv, _bx, evals = _run_with_timeout(
+            name, objective, n_trials=n_trials, n_dim=4, seconds=30
+        )
+        assert evals <= n_trials * 1.25 + 10, (
+            f"{name} used {evals} evals for budget {n_trials} (budget not respected)"
+        )
+
+
+if pytest is not None:
+
+    @pytest.mark.parametrize("name", ALL)
+    @pytest.mark.parametrize("oname", list(ADVERSARIAL))
+    def test_optimizer_terminates(name, oname):
+        _check_terminates(name, oname)
+
+    @pytest.mark.parametrize("name", ALL)
+    def test_optimizer_respects_budget(name):
+        _check_budget(name)
+
+
+def _main():
+    failures = []
+    for name in ALL:
+        for oname in ADVERSARIAL:
+            try:
+                _check_terminates(name, oname)
+            except AssertionError as e:
+                failures.append(str(e))
+        try:
+            _check_budget(name)
+        except AssertionError as e:
+            failures.append(str(e))
+        print(f"  {name:24s} ok")
+    if failures:
+        print("\nFAILURES:")
+        for f in failures:
+            print("  -", f)
+        return 1
+    print(f"\nall {len(ALL)} optimizers terminate + respect budget")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())


### PR DESCRIPTION
## What happened
The weekend rank-correlation study (`papers/dfo_recommender/rankcorr.py`) silently wedged for **3.5 days** at 100% CPU on a single instance. Root cause: a shipped humpday optimizer infinite-loops.

## Root cause — `FireflyAlgorithm` infinite loop
`FireflyAlgorithm.optimize()` calls `self.evaluate()` **only** when one firefly is strictly brighter than another (`intensities[j] < intensities[i]`). Once the swarm collapses onto a single point — the normal end state, since fireflies attract and `clip` to shared cube corners, producing identical coordinates and thus exactly-equal intensities — or whenever the objective is flat, no pair is ever "brighter". So `self.evaluate()` is never called, `self.evaluations` never advances, and `while self.evaluations < firefly_budget` spins forever.

Reproduced directly:
```python
pure_optimize(lambda x: 1.0, "FireflyAlgorithm", 240, 3)   # hung forever; now returns immediately
```

**Fix:** detect a full `(i,j)` sweep that made zero evaluations and break to the polish stage. A converged/flat swarm has nothing left to compute, so each loop iteration now either consumes budget or terminates. Healthy runs are unchanged (they keep evaluating until the budget, so the guard never trips). No other optimizer in the registry has this bug (verified by the new test).

## Regression test — `tests/test_optimizer_termination.py`
For **every** optimizer in the registry, assert: (1) `optimize()` returns within a wall-clock bound on adversarial objectives (flat / corner-optimum / plateau-with-well), and (2) it never exceeds `n_trials`. `FireflyAlgorithm` on the flat objective hangs without the fix, so this test would have caught it. Also confirms argument/budget propagation: `n_trials` caps the work actually done for all 22 optimizers.

## Defense in depth — `rankcorr.py` watchdog
A `SIGALRM` per-call watchdog so that even a future runaway optimizer can't wedge the whole pipeline: a call exceeding the timeout (default 600s, well above the slowest legit call ~2min) is scored `INF` and the run continues.

## Note (not fixed here)
`cube_minimize` reports `result.nfev = maxiter` (the budget), not the real `optimizer.evaluations`, which is tracked but discarded by `pure_optimize`. Cosmetic — doesn't affect optimization — flagging for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)