### PR TITLE
v0.22.0 version bump (Python + npm in lockstep)

### DIFF
--- a/docs/js/modules/CHANGELOG.md
+++ b/docs/js/modules/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.22.0
+
+First published npm release. The full 23-optimizer roster including Alloy,
+matching Python humpday 0.22.0, gated on the Python-JS parity suite.
+
 ## 0.21.0
 
 First npm release: the full 23-optimizer roster, including Alloy, matching

--- a/docs/js/modules/package.json
+++ b/docs/js/modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "humpday",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "23 derivative-free optimizers in zero-dependency JavaScript: the browser/Node twin of the Python humpday package, held in agreement by parity tests. Includes Alloy, a machine-designed optimizer validated on held-out problems.",
   "main": "./index.js",
   "exports": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "humpday"
-version = "0.21.0"
+version = "0.22.0"
 description = "Taking the pain out of choosing a Python global optimizer"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps pyproject and the npm package.json together ahead of the v0.22.0 release, which triggers both the PyPI and npm publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)