### PR TITLE
Online optimizers: generator inversion (pilot: DE + NelderMead)

### DIFF
--- a/humpday/optimizers/base.py
+++ b/humpday/optimizers/base.py
@@ -89,12 +89,10 @@ class BaseOptimizer:
         self.path = []
         self._at = None  # ask/tell driver state (lazy; see suggest_next)
 
-    def evaluate(self, x) -> float:
-        """Evaluate objective with tracking. `x` may be a numpy array, a
-        `_Vec`, or any sequence of floats — `_A.clip` normalises it."""
-        self.evaluations += 1
-        x_clipped = _A.clip(x, 0, 1)
-        value = self.objective(x_clipped)
+    def _bookkeep(self, x_clipped, value):
+        """Shared post-evaluation bookkeeping (path sampling, best tracking).
+        The counter increment happens BEFORE the objective call — see
+        evaluate() and the generator drivers, which replicate its order."""
 
         # Track path for visualization. Sample at ~20 evenly-spaced points
         # across the run by default; always record the first evaluation.
@@ -110,6 +108,43 @@ class BaseOptimizer:
             self.best_x = x_clipped.copy()
 
         return value
+
+    def evaluate(self, x) -> float:
+        """Evaluate objective with tracking. `x` may be a numpy array, a
+        `_Vec`, or any sequence of floats — `_A.clip` normalises it."""
+        self.evaluations += 1
+        x_clipped = _A.clip(x, 0, 1)
+        value = self.objective(x_clipped)
+        return self._bookkeep(x_clipped, value)
+
+    # ------------------------------------------------------------------ #
+    # Online (generator) protocol. A converted optimizer defines          #
+    #   def _run(self):  ...  value = yield point  ...                    #
+    # yielding candidate points and receiving their objective values.     #
+    # The driver owns clipping, counting, path and best tracking, in      #
+    # exactly evaluate()'s order, so trajectories match the loop-owning   #
+    # form statement for statement. optimize() below drives _run with     #
+    # self.objective; the ask/tell methods drive it with caller-supplied  #
+    # values and no worker thread.                                        #
+    # ------------------------------------------------------------------ #
+    def optimize(self):
+        run = getattr(type(self), "_run", None)
+        if run is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} defines neither optimize() nor _run()"
+            )
+        gen = self._run()
+        try:
+            x = next(gen)
+            while True:
+                self.evaluations += 1
+                x_clipped = _A.clip(x, 0, 1)
+                value = self.objective(x_clipped)
+                self._bookkeep(x_clipped, value)
+                x = gen.send(value)
+        except StopIteration:
+            pass
+        return self.best_value, self.best_x
 
     def evaluate_batch(self, points):
         """Evaluate several points as one group. In a direct optimize() run this is
@@ -143,6 +178,43 @@ class BaseOptimizer:
     # call evaluate_batch() emit their whole generation. Use a FRESH     #
     # instance per ask/tell run; don't mix views or a direct optimize(). #
     # ------------------------------------------------------------------ #
+    class _GenDrive:
+        """Threadless ask/tell state for optimizers that define _run()."""
+
+        __slots__ = ("gen", "pending_raw", "pending", "awaiting", "done", "mode")
+
+        def __init__(self, gen):
+            self.gen = gen
+            self.pending_raw = None
+            self.pending = None
+            self.awaiting = False
+            self.done = False
+            self.mode = None
+
+    def _gen_start(self):
+        if self.evaluations > 0:
+            raise RuntimeError(
+                "ask/tell on an instance that has already evaluated; "
+                "construct a fresh optimizer."
+            )
+        gd = self._gd = BaseOptimizer._GenDrive(self._run())
+        try:
+            gd.pending_raw = next(gd.gen)
+            gd.pending = _A.clip(gd.pending_raw, 0, 1)
+        except StopIteration:
+            gd.done = True
+        return gd
+
+    def _gen_advance(self, gd, value):
+        self.evaluations += 1
+        self._bookkeep(gd.pending, float(value))
+        try:
+            gd.pending_raw = gd.gen.send(float(value))
+            gd.pending = _A.clip(gd.pending_raw, 0, 1)
+        except StopIteration:
+            gd.done = True
+            gd.pending = None
+
     def _asktell_start(self):
         if self.evaluations > 0:
             raise RuntimeError(
@@ -170,6 +242,19 @@ class BaseOptimizer:
         """Scalar view: next point to evaluate (clipped [0,1]^n) or None when done.
         Works over synchronous population methods too — their generation is served
         one point at a time, and the values are handed back once the group fills."""
+        if getattr(type(self), "_run", None) is not None:
+            gd = getattr(self, "_gd", None) or self._gen_start()
+            if gd.mode == "batch":
+                raise RuntimeError("instance already driven via suggest_batch()")
+            gd.mode = "scalar"
+            if gd.done:
+                return None
+            if gd.awaiting:
+                raise RuntimeError(
+                    "suggest_next() called again before receive_update()"
+                )
+            gd.awaiting = True
+            return gd.pending
         at = self._at or self._asktell_start()
         if at.mode == "batch":
             raise RuntimeError("instance already driven via suggest_batch()")
@@ -190,6 +275,13 @@ class BaseOptimizer:
 
     def receive_update(self, value):
         """Scalar view: report the value for the most recent suggest_next() point."""
+        gd = getattr(self, "_gd", None)
+        if gd is not None:
+            if not gd.awaiting:
+                raise RuntimeError("receive_update() without a matching suggest_next()")
+            gd.awaiting = False
+            self._gen_advance(gd, value)
+            return
         at = self._at
         if at is None or not at.awaiting:
             raise RuntimeError("receive_update() without a matching suggest_next()")
@@ -204,6 +296,17 @@ class BaseOptimizer:
         """Batch view: the next group of points to evaluate together (size 1 for
         sequential algorithms, the generation size for synchronous population
         methods), or None when done. Pair with tell_batch()."""
+        if getattr(type(self), "_run", None) is not None:
+            gd = getattr(self, "_gd", None) or self._gen_start()
+            if gd.mode == "scalar":
+                raise RuntimeError("instance already driven via suggest_next()")
+            gd.mode = "batch"
+            if gd.done:
+                return None
+            if gd.awaiting:
+                raise RuntimeError("suggest_batch() called again before tell_batch()")
+            gd.awaiting = True
+            return [gd.pending]
         at = self._at or self._asktell_start()
         if at.mode == "scalar":
             raise RuntimeError("instance already driven via suggest_next()")
@@ -221,6 +324,16 @@ class BaseOptimizer:
 
     def tell_batch(self, values):
         """Batch view: report values for the most recent suggest_batch() group."""
+        gd = getattr(self, "_gd", None)
+        if gd is not None:
+            if not gd.awaiting:
+                raise RuntimeError("tell_batch() without a matching suggest_batch()")
+            values = [float(v) for v in values]
+            if len(values) != 1:
+                raise ValueError(f"tell_batch expected 1 value, got {len(values)}")
+            gd.awaiting = False
+            self._gen_advance(gd, values[0])
+            return
         at = self._at
         if at is None or not at.awaiting_batch:
             raise RuntimeError("tell_batch() without a matching suggest_batch()")
@@ -235,6 +348,9 @@ class BaseOptimizer:
 
     def is_done(self):
         """True once the driven run has completed (or been closed)."""
+        gd = getattr(self, "_gd", None)
+        if gd is not None:
+            return gd.done
         return self._at is not None and self._at.done
 
     def best(self):
@@ -243,6 +359,13 @@ class BaseOptimizer:
 
     def close(self):
         """Abandon a partially-driven ask/tell run, unwinding the worker cleanly."""
+        gd = getattr(self, "_gd", None)
+        if gd is not None:
+            if not gd.done:
+                gd.gen.close()
+                gd.done = True
+                gd.awaiting = False
+            return
         at = self._at
         if at is not None and not at.done:
             at.resp.put(_ABORT)  # unblock the worker so optimize() can unwind
@@ -298,13 +421,25 @@ class BaseOptimizer:
     _LBFGS_EPS_MACH = 2.220446049250313e-16
     _LBFGS_MEMORY = 10  # scipy `maxcor` default
 
+    def _drive_gen(self, gen):
+        """Drive a point-yielding generator with self.evaluate (legacy path)."""
+        try:
+            x = next(gen)
+            while True:
+                x = gen.send(self.evaluate(x))
+        except StopIteration as st:
+            return st.value
+
     def _lbfgs_polish(self):
+        return self._drive_gen(self._lbfgs_polish_gen())
+
+    def _lbfgs_polish_gen(self):
         n = self.n_dim
         memory = min(self._LBFGS_MEMORY, max(1, n))
 
         x = self.best_x.copy()
         f = self.best_value
-        grad = self._fd_gradient_for_polish(x)
+        grad = yield from self._fd_gradient_polish_gen(x)
 
         s_list: list = []
         y_list: list = []
@@ -372,7 +507,7 @@ class BaseOptimizer:
                     0,
                     1,
                 )
-                cand_f = self.evaluate(candidate)
+                cand_f = yield candidate
                 if cand_f <= f + c1 * step * gd:
                     new_x = candidate
                     new_f = cand_f
@@ -390,7 +525,7 @@ class BaseOptimizer:
                 x, f = new_x, new_f
                 break
 
-            new_grad = self._fd_gradient_for_polish(new_x)
+            new_grad = yield from self._fd_gradient_polish_gen(new_x)
 
             # (7) L-BFGS memory update.
             s = _A.asarray([float(new_x[k]) - float(x[k]) for k in range(n)])
@@ -450,8 +585,11 @@ class BaseOptimizer:
         return m
 
     def _fd_gradient_for_polish(self, x):
-        """Central-difference gradient with budget guards (mirrors
-        LBFGSB._fd_gradient)."""
+        """Central-difference gradient with budget guards (legacy driver of
+        the generator twin below; mirrors LBFGSB._fd_gradient)."""
+        return self._drive_gen(self._fd_gradient_polish_gen(x))
+
+    def _fd_gradient_polish_gen(self, x):
         n = self.n_dim
         h = 1e-6
         grad = [0.0] * n
@@ -460,12 +598,12 @@ class BaseOptimizer:
                 break
             x_plus = x.copy()
             x_plus[i] = min(1.0, float(x[i]) + h)
-            f_plus = self.evaluate(x_plus)
+            f_plus = yield x_plus
             if self.evaluations >= self.n_trials:
                 break
             x_minus = x.copy()
             x_minus[i] = max(0.0, float(x[i]) - h)
-            f_minus = self.evaluate(x_minus)
+            f_minus = yield x_minus
             denom = float(x_plus[i]) - float(x_minus[i])
             if denom > 0:
                 grad[i] = (f_plus - f_minus) / denom

--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -21,7 +21,13 @@ class DifferentialEvolution(BaseOptimizer):
     Population stored as a Python list of 1-D vectors.
     """
 
-    def optimize(self):
+    def _run(self):
+        # Online (generator) form: yields candidate points, receives their
+        # values; the BaseOptimizer driver owns clipping and bookkeeping.
+        # Statement order matches the pre-conversion optimize() exactly,
+        # so seeded trajectories are identical (see
+        # tests/test_online_pilot.py against the frozen reference).
+        #
         # Match scipy.optimize.differential_evolution defaults: `best1bin`
         # mutation strategy (mutate around the population's best member,
         # not a random one), dither-mutation F drawn per-generation in
@@ -53,7 +59,9 @@ class DifferentialEvolution(BaseOptimizer):
         CR = 0.7  # scipy default recombination probability.
 
         population = [_A.random_uniform(self.n_dim) for _ in range(pop_size)]
-        fitness = [self.evaluate(ind) for ind in population]
+        fitness = []
+        for ind in population:
+            fitness.append((yield ind))
 
         while self.evaluations < de_budget:
             # Dither: pick F uniformly in [0.5, 1.0] per generation. This
@@ -95,7 +103,7 @@ class DifferentialEvolution(BaseOptimizer):
                         trial[j] = mutant[j]
 
                 # (1+1) selection.
-                trial_fitness = self.evaluate(trial)
+                trial_fitness = yield trial
                 if trial_fitness < fitness[i]:
                     population[i] = trial
                     fitness[i] = trial_fitness
@@ -107,9 +115,7 @@ class DifferentialEvolution(BaseOptimizer):
         # + FD gradient + Armijo line search the LBFGSB optimizer uses.
         # Closes the residual sphere gap that coord descent couldn't
         # reach.
-        self._lbfgs_polish()
-
-        return self.best_value, self.best_x
+        yield from self._lbfgs_polish_gen()
 
 
 class ParticleSwarm(BaseOptimizer):

--- a/humpday/optimizers/scipy_algorithms.py
+++ b/humpday/optimizers/scipy_algorithms.py
@@ -26,7 +26,9 @@ class NelderMead(BaseOptimizer):
     `sorted(range(...), key=fsim.__getitem__)`.
     """
 
-    def optimize(self):
+    def _run(self):
+        # Online (generator) form; see DifferentialEvolution._run for the
+        # protocol. Statement order matches the pre-conversion optimize().
         n = self.n_dim
 
         # SciPy parameter values.
@@ -88,7 +90,7 @@ class NelderMead(BaseOptimizer):
             for k in range(n + 1):
                 if self.evaluations >= self.n_trials:
                     break
-                fsim[k] = self.evaluate(sim[k])
+                fsim[k] = yield sim[k]
             order = sorted(range(n + 1), key=fsim.__getitem__)
             sim = [sim[i] for i in order]
             fsim = [fsim[i] for i in order]
@@ -120,14 +122,14 @@ class NelderMead(BaseOptimizer):
                 xr = _A.clip((1 + rho) * xbar - rho * sim[-1], 0, 1)
                 if self.evaluations >= self.n_trials:
                     break
-                fxr = self.evaluate(xr)
+                fxr = yield xr
 
                 if fxr < fsim[0]:
                     # Expansion.
                     xe = _A.clip((1 + rho * chi) * xbar - rho * chi * sim[-1], 0, 1)
                     if self.evaluations >= self.n_trials:
                         break
-                    fxe = self.evaluate(xe)
+                    fxe = yield xe
                     if fxe < fxr:
                         sim[-1] = xe
                         fsim[-1] = fxe
@@ -148,7 +150,7 @@ class NelderMead(BaseOptimizer):
 
                     if self.evaluations >= self.n_trials:
                         break
-                    fxc = self.evaluate(xc)
+                    fxc = yield xc
 
                     if fxc < min(fxr, fsim[-1]):
                         sim[-1] = xc
@@ -158,7 +160,7 @@ class NelderMead(BaseOptimizer):
                         for j in range(1, n + 1):
                             sim[j] = _A.clip(sim[0] + sigma * (sim[j] - sim[0]), 0, 1)
                             if self.evaluations < self.n_trials:
-                                fsim[j] = self.evaluate(sim[j])
+                                fsim[j] = yield sim[j]
 
                 # Re-sort by fitness.
                 order = sorted(range(n + 1), key=fsim.__getitem__)
@@ -178,8 +180,6 @@ class NelderMead(BaseOptimizer):
                 seed_point = sim[0].copy()
             else:
                 seed_point = _A.random_uniform(n)
-
-        return self.best_value, self.best_x
 
 
 class Powell(BaseOptimizer):

--- a/notes/online-optimizers.md
+++ b/notes/online-optimizers.md
@@ -1,0 +1,74 @@
+# Online optimizers: the generator inversion
+
+Every optimizer becomes natively online — accepting one observation at a
+time — by inverting who owns the loop. This note records the design, the
+migration protocol, and why it precedes the Julia/Rust/R ports.
+
+## The protocol
+
+A converted optimizer defines `_run()`, a generator:
+
+    def _run(self):
+        ...
+        value = yield point          # was: value = self.evaluate(point)
+        ...
+
+The driver (BaseOptimizer) owns clipping, the evaluation counter, path
+sampling and best tracking, in exactly `evaluate()`'s historical order, so
+a converted algorithm's seeded trajectory is *identical* to its
+loop-owning form — statement for statement, RNG draw for RNG draw. Nested
+helpers convert with `yield from` (see `_lbfgs_polish_gen`, whose legacy
+`_lbfgs_polish()` is now a thin driver, upgrading every optimizer that
+polishes).
+
+Three drive modes share the protocol:
+
+- `optimize()` — the classic API, now a loop over `_run` in BaseOptimizer.
+- `suggest_next()/receive_update()` and `suggest_batch()/tell_batch()` —
+  the existing public ask/tell surface, served without a worker thread
+  for converted classes. The thread-handshake shim remains only for
+  unconverted classes and is retired class by class.
+- Parity vectors (planned) — the ports check every `(value in) -> (point
+  out)` transition, far tighter than endpoint comparisons.
+
+## Two tiers
+
+**Tier 1 — native.** Anything we own converts mechanically:
+`self.evaluate(x)` becomes `(yield x)`; list comprehensions over evaluate
+expand to loops (yield is illegal in comprehensions); helpers become
+sub-generators. Pilot: DifferentialEvolution (easy, with polish) and
+NelderMead (nested restart/shrink control flow). Both proved
+trajectory-identical against frozen pre-conversion copies
+(`tests/reference_impls_pre_online.py`, `tests/test_online_pilot.py`).
+
+**Tier 2 — buffered facade.** For cores we can't yield-ify (foreign
+libraries, future ports wrapping batch routines): `ask()` serves from a
+queue of planned points, `tell()` banks results, and the inner batch code
+advances only when its plan is exhausted. Same interface, documented
+"plans in chunks" semantics. No current roster member needs this, but the
+tier is part of the contract so ports may use it where a language lacks
+coroutines.
+
+## Migration gates
+
+Each conversion ships with its proof: freeze the pre-conversion class
+verbatim in `tests/reference_impls_pre_online.py`, and require exact
+trajectory equality across seeds x dimensions x objectives x budgets,
+plus native-ask/tell == optimize equality. A conversion that changes any
+trajectory is wrong by definition, whatever the leaderboards say.
+
+## Why now
+
+The Rust/Julia/R ports multiply the cost of the loop-owning architecture:
+the thread shim does not port (WASM has no threads; R neither), and
+inverting five codebases later is five times this work. Ports written
+against the online form — and its transition-level parity vectors — never
+know the loop-owning era existed.
+
+## Remaining roster
+
+Converted: DifferentialEvolution, NelderMead (+ the shared L-BFGS polish
+used by SA/PSO/BayesianOpt/LBFGSB). To convert: the remaining 21, in
+roughly ascending order of control-flow nesting; PRIMA_* last (deepest
+nesting, Tier 2 acceptable as an interim). Alloy converts trivially (its
+loop already has propose/observe shape).

--- a/tests/reference_impls_pre_online.py
+++ b/tests/reference_impls_pre_online.py
@@ -1,0 +1,277 @@
+"""Frozen pre-conversion copies of DifferentialEvolution and NelderMead.
+
+Captured verbatim from the loop-owning implementations immediately before
+the online (generator) conversion. The equivalence tests in
+test_online_pilot.py require the converted optimizers to reproduce these
+trajectories exactly (same RNG stream, same points, same values).
+
+Do not modernise this file: its value is that it does not change.
+"""
+
+from humpday import _array as _A
+from humpday.optimizers.base import BaseOptimizer
+
+
+class FrozenDifferentialEvolution(BaseOptimizer):
+    """Differential Evolution.
+
+    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    Population stored as a Python list of 1-D vectors.
+    """
+
+    def optimize(self):
+        # Match scipy.optimize.differential_evolution defaults: `best1bin`
+        # mutation strategy (mutate around the population's best member,
+        # not a random one), dither-mutation F drawn per-generation in
+        # [0.5, 1.0], recombination probability 0.7, and a local-search
+        # polish stage after DE (scipy uses `polish=True` by default,
+        # which calls minimize with L-BFGS-B). The closest
+        # derivative-free polish HumpDay can use is coordinate descent
+        # with a shrinking step — same pattern SimulatedAnnealing's
+        # stage 2 uses, which matches scipy.dual_annealing.
+        #
+        # Reference: scipy/optimize/_differentialevolution.py.
+        # Without the polish, humpday DE was ~7e6× worse than scipy DE
+        # on the sphere benchmark at n_trials=200 — the reference's
+        # L-BFGS-B polish converges to machine precision in tens of
+        # function evals, while humpday DE alone hits a noise floor
+        # around 1e-5 at that budget.
+        # Allocate half the budget to the L-BFGS-B polish — scipy
+        # DE's polish=True runs `_minimize_lbfgsb` unbudgeted, so its
+        # polish gets analytic-gradient convergence regardless of the
+        # DE budget. Our polish uses FD gradients (2·n_dim evals per
+        # gradient) so it needs proportionally more budget to reach
+        # the same precision. Sweep on 2-D Rosenbrock at n_trials=200:
+        # 25% → 2.2e-4, 40% → 2.5e-8, 50% → 3.5e-10 (matches scipy),
+        # 60% → 2.7e-6 (DE stage no longer finds the basin).
+        polish_budget = max(15, self.n_trials // 2)
+        de_budget = self.n_trials - polish_budget
+
+        pop_size = max(10, min(20, de_budget // 5))
+        CR = 0.7  # scipy default recombination probability.
+
+        population = [_A.random_uniform(self.n_dim) for _ in range(pop_size)]
+        fitness = [self.evaluate(ind) for ind in population]
+
+        while self.evaluations < de_budget:
+            # Dither: pick F uniformly in [0.5, 1.0] per generation. This
+            # is scipy's default `mutation=(0.5, 1)` behaviour, which
+            # helps the population avoid stagnation by varying the
+            # mutation scale.
+            F = 0.5 + 0.5 * _A.random_scalar()
+
+            for i in range(pop_size):
+                if self.evaluations >= de_budget:
+                    break
+
+                # `best1bin`: base point is the current population best,
+                # not a random member. Find best index.
+                best_idx = min(range(pop_size), key=fitness.__getitem__)
+
+                # Two donors distinct from i and best_idx.
+                candidates = [k for k in range(pop_size) if k != i and k != best_idx]
+                if len(candidates) < 2:
+                    candidates = [k for k in range(pop_size) if k != i]
+                if len(candidates) < 2:
+                    b, c = _A.random_choice(candidates, k=2, replace=True)
+                else:
+                    b, c = _A.random_choice(candidates, k=2, replace=False)
+                b, c = int(b), int(c)
+
+                # Mutation: v = x_best + F * (x_b - x_c), clipped to bounds.
+                mutant = _A.clip(
+                    population[best_idx] + F * (population[b] - population[c]),
+                    0,
+                    1,
+                )
+
+                # Binomial crossover with at least one guaranteed coord.
+                trial = population[i].copy()
+                j_guaranteed = _A.random_int(self.n_dim)
+                for j in range(self.n_dim):
+                    if _A.random_scalar() < CR or j == j_guaranteed:
+                        trial[j] = mutant[j]
+
+                # (1+1) selection.
+                trial_fitness = self.evaluate(trial)
+                if trial_fitness < fitness[i]:
+                    population[i] = trial
+                    fitness[i] = trial_fitness
+
+        # --- Polish stage: L-BFGS from the best DE point ---------------
+        # Matches scipy.differential_evolution's `polish=True` exactly —
+        # scipy uses L-BFGS-B. SimulatedAnnealing got the same upgrade
+        # in the previous commit (#188); same inlined two-loop recursion
+        # + FD gradient + Armijo line search the LBFGSB optimizer uses.
+        # Closes the residual sphere gap that coord descent couldn't
+        # reach.
+        self._lbfgs_polish()
+
+        return self.best_value, self.best_x
+
+
+class FrozenNelderMead(BaseOptimizer):
+    """Nelder-Mead simplex algorithm (faithful to SciPy implementation).
+
+    Pure-Python via the `humpday._array` shim — no direct numpy use.
+    The simplex is stored as a Python list of n+1 vectors (each a `_Vec`
+    or numpy.ndarray, depending on backend) instead of as a 2-D array;
+    row operations become list comprehensions, fancy indexing becomes
+    explicit `[sim[i] for i in order]`, and `np.argsort` becomes
+    `sorted(range(...), key=fsim.__getitem__)`.
+    """
+
+    def optimize(self):
+        n = self.n_dim
+
+        # SciPy parameter values.
+        rho = 1.0  # reflection
+        chi = 2.0  # expansion
+        psi = 0.5  # contraction
+        sigma = 0.5  # shrinkage
+
+        # SciPy simplex-initialization constants.
+        zdelt = 0.00025
+
+        # Convergence tolerances. scipy's defaults are 1e-4, but those
+        # cause termination well before the budget is exhausted on easy
+        # landscapes — on sphere this stops at f ≈ 1e-9 after ~45 evals
+        # of a 200-budget. Tightening to 1e-12 lets the algorithm use its
+        # budget where the landscape permits, with no downside on hard
+        # problems (it just stays in the contraction phase a little
+        # longer before terminating on its own at the budget cap).
+        xatol = 1e-12
+        fatol = 1e-12
+
+        # Kelley (1999, "Detection and Remediation of Stagnation in the
+        # Nelder-Mead Algorithm", SIAM J. Optim. 10(1)) showed that
+        # vanilla NM can converge to a non-stationary point when the
+        # simplex collapses into a degenerate shape. The fix in practice
+        # is to reseed the simplex around the current best each time
+        # convergence is reached and continue until the budget is gone.
+        # Without this, NM hands back unused budget on smooth landscapes
+        # while leaving plenty of room for improvement on multimodal
+        # ones. The per-restart perturbation magnitude is alternated so
+        # the new simplex isn't a scaled copy of the collapsed one.
+        nonzdelt_schedule = [0.05, 0.15, 0.30, 0.10, 0.50, 0.20]
+
+        # Initial seed point (used for restart 0; later restarts re-seed
+        # from a fresh uniform draw when the budget is large enough for
+        # the global behavior to matter, and from sim[0] otherwise — see
+        # below).
+        seed_point = 0.3 + 0.4 * _A.random_uniform(n)
+        sim = None  # populated by the (re)build below
+
+        restart_count = 0
+        while self.evaluations < self.n_trials:
+            # Build (or rebuild) the simplex around `seed_point`. The
+            # NM init uses one perturbation per coordinate; the schedule
+            # gives each restart a different perturbation magnitude.
+            nonzdelt = nonzdelt_schedule[restart_count % len(nonzdelt_schedule)]
+            sim = [seed_point.copy()]
+            for k in range(n):
+                y = seed_point.copy()
+                if y[k] != 0:
+                    y[k] = (1 + nonzdelt) * y[k]
+                else:
+                    y[k] = zdelt
+                sim.append(y)
+            sim = [_A.clip(v, 0, 1) for v in sim]
+
+            # Evaluate the new simplex.
+            fsim = [0.0] * (n + 1)
+            for k in range(n + 1):
+                if self.evaluations >= self.n_trials:
+                    break
+                fsim[k] = self.evaluate(sim[k])
+            order = sorted(range(n + 1), key=fsim.__getitem__)
+            sim = [sim[i] for i in order]
+            fsim = [fsim[i] for i in order]
+
+            # Standard NM inner loop until budget exhausted or simplex
+            # collapses.
+            while self.evaluations < self.n_trials:
+                # SciPy convergence check, restated without numpy broadcasting:
+                # max over all (i, k) of |sim[i][k] - sim[0][k]| <= xatol AND
+                # max over i of |fsim[0] - fsim[i]| <= fatol.
+                x_max = max(
+                    abs(sim[i][k] - sim[0][k])
+                    for i in range(1, n + 1)
+                    for k in range(n)
+                )
+                f_max = max(abs(fsim[0] - fsim[i]) for i in range(1, n + 1))
+                if x_max <= xatol and f_max <= fatol:
+                    # Simplex collapsed — break the inner loop so the
+                    # outer restart loop reseeds and continues.
+                    break
+
+                # Centroid of the best n vertices (sum-of-rows / n).
+                xbar = _A.zeros(n)
+                for v in sim[:-1]:
+                    xbar = xbar + v
+                xbar = xbar / n
+
+                # Reflection.
+                xr = _A.clip((1 + rho) * xbar - rho * sim[-1], 0, 1)
+                if self.evaluations >= self.n_trials:
+                    break
+                fxr = self.evaluate(xr)
+
+                if fxr < fsim[0]:
+                    # Expansion.
+                    xe = _A.clip((1 + rho * chi) * xbar - rho * chi * sim[-1], 0, 1)
+                    if self.evaluations >= self.n_trials:
+                        break
+                    fxe = self.evaluate(xe)
+                    if fxe < fxr:
+                        sim[-1] = xe
+                        fsim[-1] = fxe
+                    else:
+                        sim[-1] = xr
+                        fsim[-1] = fxr
+                elif fxr < fsim[-2]:
+                    # Accept reflection.
+                    sim[-1] = xr
+                    fsim[-1] = fxr
+                else:
+                    # Contraction (outside if fxr < fsim[-1], else inside).
+                    if fxr < fsim[-1]:
+                        xc = (1 + psi * rho) * xbar - psi * rho * sim[-1]
+                    else:
+                        xc = (1 - psi) * xbar + psi * sim[-1]
+                    xc = _A.clip(xc, 0, 1)
+
+                    if self.evaluations >= self.n_trials:
+                        break
+                    fxc = self.evaluate(xc)
+
+                    if fxc < min(fxr, fsim[-1]):
+                        sim[-1] = xc
+                        fsim[-1] = fxc
+                    else:
+                        # Shrink: every non-best vertex moves toward sim[0].
+                        for j in range(1, n + 1):
+                            sim[j] = _A.clip(sim[0] + sigma * (sim[j] - sim[0]), 0, 1)
+                            if self.evaluations < self.n_trials:
+                                fsim[j] = self.evaluate(sim[j])
+
+                # Re-sort by fitness.
+                order = sorted(range(n + 1), key=fsim.__getitem__)
+                sim = [sim[i] for i in order]
+                fsim = [fsim[i] for i in order]
+
+            # Inner loop ended — either budget exhausted or simplex
+            # collapsed. If budget remains, alternate restart seeds: even
+            # restarts reseed around the current best (intensification);
+            # odd restarts reseed from a fresh uniform draw
+            # (diversification). This mirrors the "two-phase" restart
+            # heuristic widely used in NM++ implementations.
+            restart_count += 1
+            if self.evaluations >= self.n_trials:
+                break
+            if restart_count % 2 == 1:
+                seed_point = sim[0].copy()
+            else:
+                seed_point = _A.random_uniform(n)
+
+        return self.best_value, self.best_x

--- a/tests/test_online_pilot.py
+++ b/tests/test_online_pilot.py
@@ -1,0 +1,148 @@
+"""Equivalence proofs for the online (generator) conversion pilot.
+
+The converted DifferentialEvolution and NelderMead must reproduce the
+frozen pre-conversion implementations' trajectories exactly: same points
+in the same order with the same values, across seeds, dimensions,
+objectives and budgets. The native ask/tell drive must match optimize()
+just as exactly, and close() must abandon a run without threads or hangs.
+"""
+
+import math
+import random
+
+import pytest
+
+from humpday.optimizers.evolutionary_algorithms import DifferentialEvolution
+from humpday.optimizers.scipy_algorithms import NelderMead
+
+from .reference_impls_pre_online import (
+    FrozenDifferentialEvolution,
+    FrozenNelderMead,
+)
+
+try:
+    import numpy as np
+except ImportError:  # pure backend
+    np = None
+
+
+def _seed(seed):
+    random.seed(seed)
+    if np is not None:
+        np.random.seed(seed)
+
+
+def sphere(x):
+    return sum((float(v) - 0.3) ** 2 for v in x)
+
+
+def rastriginish(x):
+    return sum(
+        (float(v) - 0.7) ** 2 - 0.1 * math.cos(6 * math.pi * (float(v) - 0.7))
+        for v in x
+    )
+
+
+OBJECTIVES = [sphere, rastriginish]
+CASES = [(0, 2, 60), (1, 2, 200), (2, 5, 120), (3, 5, 200)]
+PAIRS = [
+    (FrozenDifferentialEvolution, DifferentialEvolution),
+    (FrozenNelderMead, NelderMead),
+]
+
+
+def _traj_optimize(cls, objective, seed, n_dim, n_trials):
+    _seed(seed)
+    log = []
+
+    def obj(x):
+        v = float(objective(x))
+        log.append((tuple(float(c) for c in x), v))
+        return v
+
+    opt = cls(obj, n_trials, n_dim)
+    best_value, _ = opt.optimize()
+    return log, float(best_value), opt.evaluations
+
+
+def _traj_asktell_scalar(cls, objective, seed, n_dim, n_trials):
+    _seed(seed)
+    log = []
+    opt = cls(objective, n_trials, n_dim)
+    while True:
+        x = opt.suggest_next()
+        if x is None:
+            break
+        v = float(objective(x))
+        log.append((tuple(float(c) for c in x), v))
+        opt.receive_update(v)
+    return log, float(opt.best_value), opt.evaluations
+
+
+def _traj_asktell_batch(cls, objective, seed, n_dim, n_trials):
+    _seed(seed)
+    log = []
+    opt = cls(objective, n_trials, n_dim)
+    while True:
+        xs = opt.suggest_batch()
+        if xs is None:
+            break
+        vs = []
+        for x in xs:
+            v = float(objective(x))
+            log.append((tuple(float(c) for c in x), v))
+            vs.append(v)
+        opt.tell_batch(vs)
+    return log, float(opt.best_value), opt.evaluations
+
+
+@pytest.mark.parametrize("frozen_cls,new_cls", PAIRS)
+@pytest.mark.parametrize("objective", OBJECTIVES)
+@pytest.mark.parametrize("seed,n_dim,n_trials", CASES)
+def test_trajectory_identical_to_frozen(
+    frozen_cls, new_cls, objective, seed, n_dim, n_trials
+):
+    ref = _traj_optimize(frozen_cls, objective, seed, n_dim, n_trials)
+    new = _traj_optimize(new_cls, objective, seed, n_dim, n_trials)
+    assert new == ref
+
+
+@pytest.mark.parametrize("frozen_cls,new_cls", PAIRS)
+@pytest.mark.parametrize("seed,n_dim,n_trials", CASES[:2])
+def test_native_asktell_scalar_matches_optimize(
+    frozen_cls, new_cls, seed, n_dim, n_trials
+):
+    ref = _traj_optimize(new_cls, sphere, seed, n_dim, n_trials)
+    driven = _traj_asktell_scalar(new_cls, sphere, seed, n_dim, n_trials)
+    assert driven == ref
+
+
+@pytest.mark.parametrize("frozen_cls,new_cls", PAIRS)
+def test_native_asktell_batch_matches_optimize(frozen_cls, new_cls):
+    ref = _traj_optimize(new_cls, sphere, 0, 2, 60)
+    driven = _traj_asktell_batch(new_cls, sphere, 0, 2, 60)
+    assert driven == ref
+
+
+@pytest.mark.parametrize("frozen_cls,new_cls", PAIRS)
+def test_native_asktell_uses_no_thread(frozen_cls, new_cls):
+    _seed(0)
+    opt = new_cls(sphere, 50, 2)
+    x = opt.suggest_next()
+    assert x is not None
+    assert opt._at is None  # never fell back to the worker-thread shim
+    opt.receive_update(sphere(x))
+    opt.close()
+    assert opt.is_done()
+
+
+@pytest.mark.parametrize("frozen_cls,new_cls", PAIRS)
+def test_close_midway_is_clean(frozen_cls, new_cls):
+    _seed(1)
+    opt = new_cls(sphere, 200, 3)
+    for _ in range(7):
+        x = opt.suggest_next()
+        opt.receive_update(sphere(x))
+    opt.close()
+    assert opt.is_done()
+    assert opt.suggest_next() is None


### PR DESCRIPTION
The architectural inversion ahead of the Julia/Rust/R ports: optimizers own a `_run()` generator, the base drives it, and ask/tell runs threadless for converted classes — with exact trajectory-equivalence proofs against frozen pre-conversion implementations as the migration gate. Pilot converts DifferentialEvolution and NelderMead plus the shared L-BFGS polish. Design note in notes/online-optimizers.md, including the buffered-facade tier for non-yieldable cores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)