### PR TITLE
Portable PRNG: PCG32 with bit-exact cross-language streams

### DIFF
--- a/docs/js/modules/prng.js
+++ b/docs/js/modules/prng.js
@@ -1,0 +1,153 @@
+/**
+ * Portable PRNG: the JavaScript twin of humpday/_prng.py.
+ *
+ * PCG32 core (O'Neill 2014) with portable distributions. The Python
+ * module is the reference; tests/test_prng_parity.py verifies these
+ * streams are bit-for-bit identical. State arithmetic uses BigInt
+ * (exact 64-bit); doubles are built from two 32-bit draws, and normals
+ * use the Marsaglia polar method with portableLog (fixed IEEE-754
+ * operation order) instead of Math.log, whose last-ulp behaviour is
+ * runtime-specific. See the Python docstring for the full spec.
+ */
+
+const MASK64 = (1n << 64n) - 1n;
+const PCG_MULT = 6364136223846793005n;
+
+const LN2 = 0.6931471805599453;
+const SQRT2 = 1.4142135623730951;
+const INV_SQRT2 = 0.7071067811865476;
+const LOG_TERMS = 25;
+
+function portableLog(x) {
+    if (x <= 0.0) {
+        throw new Error("portableLog requires x > 0");
+    }
+    let m = x;
+    let e = 0;
+    while (m >= SQRT2) {
+        m = m / 2.0;
+        e += 1;
+    }
+    while (m < INV_SQRT2) {
+        m = m * 2.0;
+        e -= 1;
+    }
+    const t = (m - 1.0) / (m + 1.0);
+    const t2 = t * t;
+    let s = 0.0;
+    let p = t;
+    let k = 0;
+    while (k < LOG_TERMS) {
+        s = s + p / (2.0 * k + 1.0);
+        p = p * t2;
+        k += 1;
+    }
+    return 2.0 * s + e * LN2;
+}
+
+class PCG32 {
+    constructor(seed, seq = 0) {
+        this.inc = ((BigInt(seq) << 1n) | 1n) & MASK64;
+        this.state = 0n;
+        this._step();
+        this.state = (this.state + (BigInt(seed) & MASK64)) & MASK64;
+        this._step();
+        this._cachedGauss = 0.0;
+        this._hasCachedGauss = false;
+    }
+
+    _step() {
+        this.state = (this.state * PCG_MULT + this.inc) & MASK64;
+    }
+
+    nextU32() {
+        const old = this.state;
+        this._step();
+        const xorshifted = (((old >> 18n) ^ old) >> 27n) & 0xFFFFFFFFn;
+        const rot = old >> 59n;
+        const out = ((xorshifted >> rot) | (xorshifted << ((-rot) & 31n))) & 0xFFFFFFFFn;
+        return Number(out);
+    }
+
+    random() {
+        const hi = this.nextU32() >>> 5;
+        const lo = this.nextU32() >>> 6;
+        return (hi * 67108864.0 + lo) / 9007199254740992.0;
+    }
+
+    uniform(a, b) {
+        return a + (b - a) * this.random();
+    }
+
+    randbelow(n) {
+        if (n <= 0) {
+            throw new Error("randbelow requires n >= 1");
+        }
+        const threshold = Number((1n << 32n) % BigInt(n));
+        for (;;) {
+            const r = this.nextU32();
+            if (r >= threshold) {
+                return r % n;
+            }
+        }
+    }
+
+    randrange(low, high = null) {
+        if (high === null) {
+            return this.randbelow(low);
+        }
+        return low + this.randbelow(high - low);
+    }
+
+    gauss() {
+        if (this._hasCachedGauss) {
+            this._hasCachedGauss = false;
+            return this._cachedGauss;
+        }
+        let u, v, s;
+        for (;;) {
+            u = 2.0 * this.random() - 1.0;
+            v = 2.0 * this.random() - 1.0;
+            s = u * u + v * v;
+            if (s > 0.0 && s < 1.0) {
+                break;
+            }
+        }
+        const f = Math.sqrt(-2.0 * portableLog(s) / s);
+        this._cachedGauss = v * f;
+        this._hasCachedGauss = true;
+        return u * f;
+    }
+
+    shuffle(seq) {
+        for (let i = seq.length - 1; i >= 1; i--) {
+            const j = this.randbelow(i + 1);
+            const tmp = seq[i];
+            seq[i] = seq[j];
+            seq[j] = tmp;
+        }
+    }
+
+    choice(seq) {
+        return seq[this.randbelow(seq.length)];
+    }
+
+    sample(seq, k) {
+        const pool = Array.from(seq);
+        const n = pool.length;
+        if (k < 0 || k > n) {
+            throw new Error("sample size out of range");
+        }
+        for (let i = 0; i < k; i++) {
+            const j = i + this.randbelow(n - i);
+            const tmp = pool[i];
+            pool[i] = pool[j];
+            pool[j] = tmp;
+        }
+        return pool.slice(0, k);
+    }
+}
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = { PCG32, portableLog };
+}

--- a/humpday/_prng.py
+++ b/humpday/_prng.py
@@ -31,6 +31,8 @@ Nothing here is cryptographic; the goal is cross-language determinism
 for optimizer trajectories and parity vectors.
 """
 
+import math as _math
+
 _MASK64 = (1 << 64) - 1
 _PCG_MULT = 6364136223846793005
 
@@ -133,7 +135,10 @@ class PCG32:
             s = u * u + v * v
             if 0.0 < s < 1.0:
                 break
-        f = (-2.0 * portable_log(s) / s) ** 0.5
+        # math.sqrt is IEEE-754 correctly rounded on every platform;
+        # `** 0.5` (libm pow) is NOT — glibc's pow differs from sqrt by
+        # one ulp on rare inputs, which the CI bit-comparison caught.
+        f = _math.sqrt(-2.0 * portable_log(s) / s)
         self._cached_gauss = v * f
         self._has_cached_gauss = True
         return u * f

--- a/humpday/_prng.py
+++ b/humpday/_prng.py
@@ -1,0 +1,167 @@
+"""Portable PRNG: bit-exact random streams across languages.
+
+This module is the *reference implementation* of humpday's portable
+random number generator. The JavaScript twin is
+`docs/js/modules/prng.js`; Rust/Julia/R ports must reproduce these
+streams bit-for-bit (verified by `tests/test_prng_parity.py`). Every
+operation below is specified so that a faithful implementation in any
+language with IEEE-754 doubles produces identical outputs:
+
+- The core is PCG32 (O'Neill 2014, `pcg32_random_r`): 64-bit LCG state,
+  32-bit XSH-RR output. Integer arithmetic is exact in every language
+  (Python ints, JS BigInt, Rust u64, Julia UInt64; R needs a two-limb
+  emulation).
+- Doubles in [0, 1) are built from exactly two 32-bit draws giving a
+  53-bit mantissa: (hi27 * 2**26 + lo26) / 2**53. Integer-valued doubles
+  below 2**53 and division by a power of two are exact in IEEE-754.
+- Bounded integers use the unbiased threshold-rejection method
+  (OpenBSD arc4random_uniform), consuming a variable but deterministic
+  number of 32-bit draws.
+- Normals use the Marsaglia polar method with sqrt (correctly rounded
+  by IEEE-754, hence portable) and `portable_log` below — NOT the
+  platform libm log, whose last-ulp behaviour differs between runtimes.
+  The second normal of each polar pair is cached and returned by the
+  next call.
+- `portable_log` is an atanh-series evaluation with a fixed operation
+  order: only +, -, *, / on doubles, so it is bit-exact everywhere. It
+  agrees with libm log to ~1 ulp, but its exact value is defined by the
+  algorithm, not by any libm.
+
+Nothing here is cryptographic; the goal is cross-language determinism
+for optimizer trajectories and parity vectors.
+"""
+
+_MASK64 = (1 << 64) - 1
+_PCG_MULT = 6364136223846793005
+
+# Fixed double constants (their exact IEEE-754 values are part of the spec).
+_LN2 = 0.6931471805599453
+_SQRT2 = 1.4142135623730951
+_INV_SQRT2 = 0.7071067811865476
+_LOG_TERMS = 25
+
+
+def portable_log(x):
+    """Natural log of a positive finite double, computed with a fixed
+    sequence of IEEE-754 +,-,*,/ operations so every language gets the
+    same bits. Range-reduce x = m * 2^e with m in [sqrt(1/2), sqrt(2)),
+    then ln m = 2 * atanh((m-1)/(m+1)) by series."""
+    if x <= 0.0:
+        raise ValueError("portable_log requires x > 0")
+    m = x
+    e = 0
+    while m >= _SQRT2:
+        m = m / 2.0
+        e += 1
+    while m < _INV_SQRT2:
+        m = m * 2.0
+        e -= 1
+    t = (m - 1.0) / (m + 1.0)
+    t2 = t * t
+    s = 0.0
+    p = t
+    k = 0
+    while k < _LOG_TERMS:
+        s = s + p / (2.0 * k + 1.0)
+        p = p * t2
+        k += 1
+    return 2.0 * s + e * _LN2
+
+
+class PCG32:
+    """PCG32 with portable distributions on top. Seeding follows
+    O'Neill's pcg32_srandom_r: given (initstate, initseq), set
+    state = 0, inc = (initseq << 1) | 1, step, add initstate, step."""
+
+    def __init__(self, seed, seq=0):
+        self.inc = ((int(seq) << 1) | 1) & _MASK64
+        self.state = 0
+        self._step()
+        self.state = (self.state + (int(seed) & _MASK64)) & _MASK64
+        self._step()
+        self._cached_gauss = None
+        self._has_cached_gauss = False
+
+    def _step(self):
+        self.state = (self.state * _PCG_MULT + self.inc) & _MASK64
+
+    def next_u32(self):
+        """One 32-bit output (XSH-RR on the pre-step state)."""
+        old = self.state
+        self._step()
+        xorshifted = (((old >> 18) ^ old) >> 27) & 0xFFFFFFFF
+        rot = old >> 59
+        return ((xorshifted >> rot) | (xorshifted << ((-rot) & 31))) & 0xFFFFFFFF
+
+    def random(self):
+        """Uniform double in [0, 1) with 53 random bits (two u32 draws:
+        high word first)."""
+        hi = self.next_u32() >> 5
+        lo = self.next_u32() >> 6
+        return (hi * 67108864.0 + lo) / 9007199254740992.0
+
+    def uniform(self, a, b):
+        """Uniform double in [a, b): a + (b - a) * random(), in that order."""
+        return a + (b - a) * self.random()
+
+    def randbelow(self, n):
+        """Unbiased integer in [0, n) (threshold rejection; n in [1, 2^32])."""
+        if n <= 0:
+            raise ValueError("randbelow requires n >= 1")
+        threshold = (1 << 32) % n
+        while True:
+            r = self.next_u32()
+            if r >= threshold:
+                return r % n
+
+    def randrange(self, low, high=None):
+        """Integer in [low, high); randrange(n) means [0, n)."""
+        if high is None:
+            return self.randbelow(low)
+        return low + self.randbelow(high - low)
+
+    def gauss(self):
+        """Standard normal via the Marsaglia polar method. Each accepted
+        pair (u, v) consumes exactly four u32 draws (two doubles) plus
+        rejections; the v-normal is cached for the next call."""
+        if self._has_cached_gauss:
+            self._has_cached_gauss = False
+            return self._cached_gauss
+        while True:
+            u = 2.0 * self.random() - 1.0
+            v = 2.0 * self.random() - 1.0
+            s = u * u + v * v
+            if 0.0 < s < 1.0:
+                break
+        f = (-2.0 * portable_log(s) / s) ** 0.5
+        self._cached_gauss = v * f
+        self._has_cached_gauss = True
+        return u * f
+
+    def shuffle(self, seq):
+        """In-place Fisher-Yates, descending: for i = len-1 .. 1,
+        j = randbelow(i + 1), swap seq[i], seq[j]."""
+        i = len(seq) - 1
+        while i >= 1:
+            j = self.randbelow(i + 1)
+            seq[i], seq[j] = seq[j], seq[i]
+            i -= 1
+
+    def choice(self, seq):
+        """One element: seq[randbelow(len(seq))]."""
+        return seq[self.randbelow(len(seq))]
+
+    def sample(self, seq, k):
+        """k distinct elements by partial front Fisher-Yates: copy seq;
+        for i = 0 .. k-1, j = i + randbelow(len - i), swap; return the
+        first k."""
+        pool = list(seq)
+        n = len(pool)
+        if not 0 <= k <= n:
+            raise ValueError("sample size out of range")
+        i = 0
+        while i < k:
+            j = i + self.randbelow(n - i)
+            pool[i], pool[j] = pool[j], pool[i]
+            i += 1
+        return pool[:k]

--- a/tests/js_prng_runner.js
+++ b/tests/js_prng_runner.js
@@ -1,0 +1,55 @@
+// Node runner for the portable-PRNG parity test.
+//
+// Usage: node js_prng_runner.js <seed> <seq> <n>
+//
+// Emits one JSON object with parallel streams drawn from independent
+// PCG32 instances (one per stream, all seeded with <seed>/<seq>).
+// Doubles are reported as big-endian IEEE-754 bit patterns (16 hex
+// chars) so the Python side can compare exact bits, not decimal
+// round-trips.
+
+const path = require("path");
+const { PCG32 } = require(path.resolve(__dirname, "../docs/js/modules/prng.js"));
+
+const seed = BigInt(process.argv[2]);
+const seq = BigInt(process.argv[3]);
+const n = parseInt(process.argv[4], 10);
+
+function bits(x) {
+    const buf = new ArrayBuffer(8);
+    new DataView(buf).setFloat64(0, x, false);
+    return Array.from(new Uint8Array(buf))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+}
+
+const out = {};
+
+let g = new PCG32(seed, seq);
+out.u32 = Array.from({ length: n }, () => g.nextU32());
+
+g = new PCG32(seed, seq);
+out.random = Array.from({ length: n }, () => bits(g.random()));
+
+g = new PCG32(seed, seq);
+out.gauss = Array.from({ length: n }, () => bits(g.gauss()));
+
+g = new PCG32(seed, seq);
+out.uniform = Array.from({ length: n }, () => bits(g.uniform(-3.5, 11.25)));
+
+g = new PCG32(seed, seq);
+out.randbelow = [];
+for (let i = 0; i < n; i++) {
+    const m = [1, 2, 3, 7, 10, 100, 1000, 4294967295][i % 8];
+    out.randbelow.push(g.randbelow(m));
+}
+
+g = new PCG32(seed, seq);
+const arr = Array.from({ length: 30 }, (_, i) => i);
+g.shuffle(arr);
+out.shuffle = arr;
+
+g = new PCG32(seed, seq);
+out.sample = g.sample(Array.from({ length: 30 }, (_, i) => i), 12);
+
+process.stdout.write(JSON.stringify(out));

--- a/tests/test_prng_parity.py
+++ b/tests/test_prng_parity.py
@@ -1,0 +1,137 @@
+"""Bit-exact parity between humpday/_prng.py and docs/js/modules/prng.js.
+
+The Python module is the reference; the JS twin must reproduce every
+stream exactly. Doubles are compared as IEEE-754 bit patterns, so a
+single-ulp libm difference would fail loudly (that's the point — the
+generator avoids libm transcendentals entirely).
+
+Also pins Python-side golden values so the reference itself can't drift:
+these constants ARE the cross-language spec, and every future port
+(Rust, Julia, R) must reproduce them.
+"""
+
+import json
+import math
+import shutil
+import struct
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from humpday._prng import PCG32, portable_log
+
+NODE = shutil.which("node")
+RUNNER = Path(__file__).parent / "js_prng_runner.js"
+
+SEEDS = [(42, 54), (0, 0), (123456789, 987654321), (2**63, 2**31)]
+N = 500
+
+
+def _bits(x: float) -> str:
+    return struct.pack(">d", x).hex()
+
+
+def _python_streams(seed, seq, n):
+    out = {}
+    g = PCG32(seed, seq)
+    out["u32"] = [g.next_u32() for _ in range(n)]
+    g = PCG32(seed, seq)
+    out["random"] = [_bits(g.random()) for _ in range(n)]
+    g = PCG32(seed, seq)
+    out["gauss"] = [_bits(g.gauss()) for _ in range(n)]
+    g = PCG32(seed, seq)
+    out["uniform"] = [_bits(g.uniform(-3.5, 11.25)) for _ in range(n)]
+    g = PCG32(seed, seq)
+    mods = [1, 2, 3, 7, 10, 100, 1000, 4294967295]
+    out["randbelow"] = [g.randbelow(mods[i % 8]) for i in range(n)]
+    g = PCG32(seed, seq)
+    arr = list(range(30))
+    g.shuffle(arr)
+    out["shuffle"] = arr
+    g = PCG32(seed, seq)
+    out["sample"] = g.sample(list(range(30)), 12)
+    return out
+
+
+# ---- Python-side golden values (the spec) --------------------------------
+
+
+def test_pcg32_reference_vector():
+    # O'Neill's own demo seeding (42, 54): first outputs of the official
+    # pcg32 C implementation.
+    g = PCG32(42, 54)
+    first = [g.next_u32() for _ in range(6)]
+    assert first == [
+        0xA15C02B7,
+        0x7B47F409,
+        0xBA1D3330,
+        0x83D2F293,
+        0xBFA4784B,
+        0xCBED606E,
+    ]
+
+
+def test_double_and_gauss_golden():
+    # Golden values pinned at spec time; any change means the portable
+    # algorithms changed and every port must be re-verified.
+    g = PCG32(42, 54)
+    assert _bits(g.random()) == "3fe42b8055ed1fd0"
+    g = PCG32(42, 54)
+    assert _bits(g.gauss()) == "3fe9a1fbd078a681"
+
+
+def test_portable_log_close_to_libm():
+    for x in [1e-300, 1e-9, 0.1, 0.5, 1.0, 1.5, 2.0, math.pi, 1e9, 1e300]:
+        assert math.isclose(portable_log(x), math.log(x), rel_tol=1e-14, abs_tol=1e-14)
+    with pytest.raises(ValueError):
+        portable_log(0.0)
+
+
+def test_distribution_sanity():
+    g = PCG32(7, 1)
+    xs = [g.gauss() for _ in range(20000)]
+    mean = sum(xs) / len(xs)
+    var = sum((x - mean) ** 2 for x in xs) / len(xs)
+    assert abs(mean) < 0.03
+    assert abs(var - 1.0) < 0.05
+    g = PCG32(7, 1)
+    us = [g.random() for _ in range(20000)]
+    assert 0.49 < sum(us) / len(us) < 0.51
+    assert all(0.0 <= u < 1.0 for u in us)
+
+
+def test_randbelow_unbiased_range():
+    g = PCG32(11, 3)
+    draws = [g.randbelow(7) for _ in range(7000)]
+    assert set(draws) == set(range(7))
+    counts = [draws.count(i) for i in range(7)]
+    assert max(counts) - min(counts) < 300
+
+
+def test_sample_and_shuffle_are_permutations():
+    g = PCG32(5, 9)
+    arr = list(range(50))
+    g.shuffle(arr)
+    assert sorted(arr) == list(range(50))
+    s = g.sample(list(range(50)), 20)
+    assert len(set(s)) == 20 and set(s) <= set(range(50))
+
+
+# ---- JS bit-exactness -----------------------------------------------------
+
+
+@pytest.mark.skipif(not NODE, reason="node not on PATH")
+@pytest.mark.parametrize("seed,seq", SEEDS)
+def test_js_streams_bit_identical(seed, seq):
+    result = subprocess.run(
+        [NODE, str(RUNNER), str(seed), str(seq), str(N)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    js = json.loads(result.stdout)
+    py = _python_streams(seed, seq, N)
+    for key in ["u32", "random", "gauss", "uniform", "randbelow", "shuffle", "sample"]:
+        assert js[key] == py[key], f"stream {key!r} diverged for seed={seed}"


### PR DESCRIPTION
PCG32 + distributions specified to the bit: `humpday/_prng.py` (reference) and `docs/js/modules/prng.js` (twin), proven identical stream-for-stream as IEEE-754 bit patterns. Normals avoid libm via a fixed-order atanh-series log. This is the contract Rust/Julia/R ports will implement, and the prerequisite for transition-level optimizer parity vectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)