### PR TITLE
Shim: portable-RNG mode

### DIFF
--- a/humpday/_array.py
+++ b/humpday/_array.py
@@ -67,3 +67,138 @@ else:
 # can introspect what's available without caring which backend it is.
 # `linalg` is the submodule namespace; `numpy.linalg`-shaped API lives there.
 __all__ = ["BACKEND", "linalg", *_impl.__all__]
+
+
+# ---------------------------------------------------------------------------
+# Portable RNG mode
+# ---------------------------------------------------------------------------
+# By default (legacy mode) the random primitives below delegate to the live
+# backend (numpy's global RNG or the pure backend's random.Random), and the
+# rng_* facade delegates to the stdlib global `random` module — preserving
+# every historical seeded trajectory. After use_portable_rng(seed), ALL of
+# them draw from one PCG32 stream (humpday._prng), which is bit-identical
+# across languages — the basis for cross-language optimizer parity vectors.
+
+import random as _stdlib_random  # noqa: E402
+
+_backend_random_uniform = random_uniform  # noqa: F405
+_backend_random_normal = random_normal  # noqa: F405
+_backend_random_scalar = random_scalar  # noqa: F405
+_backend_random_int = random_int  # noqa: F405
+_backend_random_choice = random_choice  # noqa: F405
+_backend_seed = seed  # noqa: F405
+
+_portable = None
+
+
+def use_portable_rng(s, seq=0):
+    """Switch all humpday randomness to a portable PCG32 stream."""
+    global _portable
+    from ._prng import PCG32
+
+    _portable = PCG32(s, seq)
+    return _portable
+
+
+def use_legacy_rng():
+    """Return to the historical backend/stdlib random sources."""
+    global _portable
+    _portable = None
+
+
+def random_uniform(n):
+    if _portable is None:
+        return _backend_random_uniform(n)
+    return asarray([_portable.random() for _ in range(int(n))])  # noqa: F405
+
+
+def random_normal(n):
+    if _portable is None:
+        return _backend_random_normal(n)
+    return asarray([_portable.gauss() for _ in range(int(n))])  # noqa: F405
+
+
+def random_scalar():
+    if _portable is None:
+        return _backend_random_scalar()
+    return _portable.random()
+
+
+def random_int(low, high=None):
+    if _portable is None:
+        return _backend_random_int(low, high)
+    return _portable.randrange(int(low), None if high is None else int(high))
+
+
+def random_choice(seq, k=None, replace=True):
+    if _portable is None:
+        return _backend_random_choice(seq, k=k, replace=replace)
+    if isinstance(seq, int):
+        seq = list(range(seq))
+    if k is None:
+        return _portable.choice(seq)
+    if replace:
+        return [_portable.choice(seq) for _ in range(k)]
+    return _portable.sample(seq, k)
+
+
+def seed(s):
+    if _portable is None:
+        return _backend_seed(s)
+    return use_portable_rng(s)
+
+
+# Stdlib-shaped facade for optimizers that historically called the global
+# `random` module directly (Alloy, HarmonySearch, NEWUOA/BOBYQA restarts).
+# Legacy mode delegates to the SAME stdlib global instance, so rewiring an
+# optimizer from `random.x(...)` to `_A.rng_x(...)` leaves its seeded
+# trajectory bit-for-bit unchanged.
+
+
+def rng_random():
+    return _portable.random() if _portable is not None else _stdlib_random.random()
+
+
+def rng_gauss():
+    return (
+        _portable.gauss() if _portable is not None else _stdlib_random.gauss(0.0, 1.0)
+    )
+
+
+def rng_uniform(a, b):
+    return (
+        _portable.uniform(a, b)
+        if _portable is not None
+        else _stdlib_random.uniform(a, b)
+    )
+
+
+def rng_choice(seq):
+    return (
+        _portable.choice(seq) if _portable is not None else _stdlib_random.choice(seq)
+    )
+
+
+def rng_shuffle(seq):
+    if _portable is not None:
+        _portable.shuffle(seq)
+    else:
+        _stdlib_random.shuffle(seq)
+
+
+def rng_randrange(n):
+    return (
+        _portable.randrange(n) if _portable is not None else _stdlib_random.randrange(n)
+    )
+
+
+__all__ += [
+    "use_portable_rng",
+    "use_legacy_rng",
+    "rng_random",
+    "rng_gauss",
+    "rng_uniform",
+    "rng_choice",
+    "rng_shuffle",
+    "rng_randrange",
+]

--- a/tests/test_portable_rng_mode.py
+++ b/tests/test_portable_rng_mode.py
@@ -1,0 +1,102 @@
+"""The shim's portable-RNG mode: same optimizer, same seed, same trajectory
+regardless of backend or platform — and legacy mode untouched by default."""
+
+import random
+
+import pytest
+
+from humpday import _array as _A
+from humpday.optimizers.evolutionary_algorithms import DifferentialEvolution
+from humpday.optimizers.scipy_algorithms import NelderMead
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
+
+@pytest.fixture(autouse=True)
+def _restore_legacy():
+    yield
+    _A.use_legacy_rng()
+
+
+def sphere(x):
+    return sum((float(v) - 0.3) ** 2 for v in x)
+
+
+def _run(cls, n_trials=80, n_dim=3):
+    opt = cls(sphere, n_trials, n_dim)
+    best_value, best_x = opt.optimize()
+    return float(best_value), [float(v) for v in best_x], opt.evaluations
+
+
+@pytest.mark.parametrize("cls", [DifferentialEvolution, NelderMead])
+def test_portable_mode_is_reproducible(cls):
+    _A.use_portable_rng(42, 54)
+    a = _run(cls)
+    _A.use_portable_rng(42, 54)
+    b = _run(cls)
+    assert a == b
+
+
+@pytest.mark.parametrize("cls", [DifferentialEvolution, NelderMead])
+def test_portable_mode_ignores_stdlib_and_numpy_state(cls):
+    _A.use_portable_rng(7)
+    random.seed(0)
+    if np is not None:
+        np.random.seed(0)
+    a = _run(cls)
+    _A.use_portable_rng(7)
+    random.seed(999)
+    if np is not None:
+        np.random.seed(999)
+    b = _run(cls)
+    assert a == b
+
+
+def test_legacy_facade_matches_stdlib_exactly():
+    random.seed(123)
+    expected = [
+        random.random(),
+        random.gauss(0.0, 1.0),
+        random.uniform(-2.0, 5.0),
+        random.choice([10, 20, 30]),
+        random.randrange(17),
+    ]
+    random.seed(123)
+    got = [
+        _A.rng_random(),
+        _A.rng_gauss(),
+        _A.rng_uniform(-2.0, 5.0),
+        _A.rng_choice([10, 20, 30]),
+        _A.rng_randrange(17),
+    ]
+    assert got == expected
+    random.seed(5)
+    a = list(range(9))
+    random.shuffle(a)
+    random.seed(5)
+    b = list(range(9))
+    _A.rng_shuffle(b)
+    assert a == b
+
+
+def test_seed_reseeds_portable_stream():
+    _A.use_portable_rng(1)
+    _A.seed(42)
+    xs = [_A.random_scalar() for _ in range(3)]
+    _A.seed(42)
+    assert xs == [_A.random_scalar() for _ in range(3)]
+
+
+def test_portable_primitives_shapes():
+    _A.use_portable_rng(3)
+    v = _A.random_uniform(5)
+    assert len(v) == 5 and all(0.0 <= float(x) < 1.0 for x in v)
+    assert len(_A.random_normal(4)) == 4
+    assert 0 <= _A.random_int(10) < 10
+    assert 3 <= _A.random_int(3, 6) < 6
+    assert _A.random_choice([1, 2, 3]) in (1, 2, 3)
+    pick = _A.random_choice(10, k=4, replace=False)
+    assert len(set(pick)) == 4


### PR DESCRIPTION
Second step of the parity chain: `_A.use_portable_rng(seed)` puts all humpday randomness on the portable PCG32 stream; legacy default preserves every historical trajectory. Includes the stdlib-shaped `rng_*` facade so direct `random.*` call sites can be rewired without changing seeded runs. 7 new tests; suite 965 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)