### PR TITLE
Portable RNG: rewire last stdlib call sites (roster fully portable)

### DIFF
--- a/humpday/optimizers/alloy.py
+++ b/humpday/optimizers/alloy.py
@@ -31,7 +31,8 @@ reheat and rebuild the simplex around the incumbent.
 """
 
 import math
-import random
+
+from humpday import _array as _A
 
 from .base import BaseOptimizer
 
@@ -64,7 +65,7 @@ class Alloy(BaseOptimizer):
         for _ in range(pop_size):
             if not budget_left():
                 break
-            x = [random.random() for _ in range(n_dim)]
+            x = [_A.rng_random() for _ in range(n_dim)]
             pop.append(x)
             pop_f.append((yield clip(x)))
         if not pop:
@@ -114,7 +115,7 @@ class Alloy(BaseOptimizer):
             if T <= 1e-12:
                 return False
             try:
-                return random.random() < math.exp(-(f_new - f_old) / T)
+                return _A.rng_random() < math.exp(-(f_new - f_old) / T)
             except OverflowError:
                 return False
 
@@ -127,7 +128,7 @@ class Alloy(BaseOptimizer):
             worst_f = simplex_f[worst_i]
             cen = centroid_of(simplex, worst_i)
 
-            r = random.random()
+            r = _A.rng_random()
             improved = False
 
             if r < 0.25:
@@ -172,10 +173,10 @@ class Alloy(BaseOptimizer):
             elif r < 0.50:
                 # --- Differential Evolution: rand/1 or current-to-best/1 ---
                 idxs = list(range(len(simplex)))
-                random.shuffle(idxs)
+                _A.rng_shuffle(idxs)
                 a, b, c = idxs[0], idxs[1 % len(idxs)], idxs[2 % len(idxs)]
                 target = worst_x
-                if random.random() < 0.5:
+                if _A.rng_random() < 0.5:
                     mutant = [
                         simplex[a][d] + F * (simplex[b][d] - simplex[c][d])
                         for d in range(n_dim)
@@ -187,9 +188,9 @@ class Alloy(BaseOptimizer):
                         + F * (simplex[b][d] - simplex[c][d])
                         for d in range(n_dim)
                     ]
-                jr = random.randrange(n_dim)
+                jr = _A.rng_randrange(n_dim)
                 trial = [
-                    mutant[d] if (random.random() < CR or d == jr) else target[d]
+                    mutant[d] if (_A.rng_random() < CR or d == jr) else target[d]
                     for d in range(n_dim)
                 ]
                 if not budget_left():
@@ -204,7 +205,7 @@ class Alloy(BaseOptimizer):
             elif r < 0.75:
                 # --- CMA-style Gaussian sampling with adaptive diagonal cov ---
                 cand = [
-                    best_x[d] + sigma * random.gauss(0.0, math.sqrt(cov_diag[d]))
+                    best_x[d] + sigma * (_A.rng_gauss() * math.sqrt(cov_diag[d]))
                     for d in range(n_dim)
                 ]
                 if not budget_left():
@@ -278,12 +279,12 @@ class Alloy(BaseOptimizer):
                     if not budget_left():
                         break
                     p = [
-                        min(1.0, max(0.0, keep[d] + random.uniform(-0.3, 0.3)))
+                        min(1.0, max(0.0, keep[d] + _A.rng_uniform(-0.3, 0.3)))
                         for d in range(n_dim)
                     ]
                     simplex.append(p)
                     simplex_f.append((yield clip(p)))
                 while len(simplex) < n_dim + 1 and budget_left():
-                    p = [random.random() for _ in range(n_dim)]
+                    p = [_A.rng_random() for _ in range(n_dim)]
                     simplex.append(p)
                     simplex_f.append((yield clip(p)))

--- a/humpday/optimizers/evolutionary_algorithms.py
+++ b/humpday/optimizers/evolutionary_algorithms.py
@@ -1207,7 +1207,7 @@ class HarmonySearch(BaseOptimizer):
             for j in range(self.n_dim):
                 if _A.random_scalar() < HMCR:
                     # Pick from harmony memory.
-                    selected = random.choice(harmony_memory)
+                    selected = _A.rng_choice(harmony_memory)
                     value = selected["harmony"][j]
 
                     # Pitch adjustment.

--- a/humpday/optimizers/prima_algorithms.py
+++ b/humpday/optimizers/prima_algorithms.py
@@ -17,7 +17,6 @@ Must match algorithmic behavior of reference, not use reference directly.
 """
 
 import math
-import random
 
 from humpday import _array as _A
 
@@ -1021,7 +1020,7 @@ class PRIMA_NEWUOA(BaseOptimizer):
             if self.evaluations < self.n_trials:
                 xseed = _A.clip(
                     [
-                        float(self.best_x[i]) + (random.random() - 0.5) * 2.0 * rhobeg
+                        float(self.best_x[i]) + (_A.rng_random() - 0.5) * 2.0 * rhobeg
                         for i in range(n)
                     ],
                     0,
@@ -1369,7 +1368,7 @@ class PRIMA_BOBYQA(BaseOptimizer):
             if self.evaluations < self.n_trials:
                 xseed = _A.clip(
                     [
-                        float(self.best_x[i]) + (random.random() - 0.5) * 2.0 * rhobeg
+                        float(self.best_x[i]) + (_A.rng_random() - 0.5) * 2.0 * rhobeg
                         for i in range(n)
                     ],
                     0.1,

--- a/tests/test_portable_rng_mode.py
+++ b/tests/test_portable_rng_mode.py
@@ -100,3 +100,20 @@ def test_portable_primitives_shapes():
     assert _A.random_choice([1, 2, 3]) in (1, 2, 3)
     pick = _A.random_choice(10, k=4, replace=False)
     assert len(set(pick)) == 4
+
+
+def test_entire_roster_reproducible_under_portable_mode():
+    """Every optimizer, run twice from the same portable seed with
+    scrambled stdlib/numpy state in between, reproduces its run exactly.
+    This is what makes cross-language transition vectors possible."""
+    from humpday.optimizers.alloptimizers import PURE_OPTIMIZERS
+
+    for cls in PURE_OPTIMIZERS.values():
+        _A.use_portable_rng(11, 3)
+        a = _run(cls, n_trials=60, n_dim=2)
+        random.seed(777)
+        if np is not None:
+            np.random.seed(777)
+        _A.use_portable_rng(11, 3)
+        b = _run(cls, n_trials=60, n_dim=2)
+        assert a == b, f"{cls.__name__} not reproducible under portable RNG"


### PR DESCRIPTION
Third step of the parity chain: Alloy, HarmonySearch and PRIMA restart jitter now draw through `_A.rng_*`. Trajectory-neutral by construction and by proof (299 frozen-twin tests unchanged). New all-roster test: all 23 optimizers reproduce exactly under `use_portable_rng` regardless of stdlib/numpy state. Suite 966 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)