### PR TITLE
JS exactness batch 1: first bit-exact cross-language optimizers

### DIFF
--- a/docs/js/modules/base-optimizer.js
+++ b/docs/js/modules/base-optimizer.js
@@ -5,9 +5,53 @@
  * and path visualization support shared by all optimization algorithms.
  */
 
+// Portable RNG plumbing. Legacy default is Math.random (unseedable,
+// fine for demos); usePortableRng(seed, seq) switches every converted
+// optimizer onto the cross-language PCG32 stream (prng.js), which is
+// what the transition-vector replay uses. Mirrors humpday._array's
+// use_portable_rng / use_legacy_rng.
+const _PCG32 = (typeof module !== 'undefined' && module.exports)
+    ? require('./prng.js').PCG32
+    : (typeof PCG32 !== 'undefined' ? PCG32 : null);
+
+let _portableRng = null;
+
+function usePortableRng(seed, seq = 0) {
+    _portableRng = new _PCG32(seed, seq);
+    return _portableRng;
+}
+
+function useLegacyRng() {
+    _portableRng = null;
+}
+
 // Mathematical utility functions
 const MathUtils = {
     random: () => Math.random(),
+
+    randomScalar() {
+        return _portableRng !== null ? _portableRng.random() : Math.random();
+    },
+
+    randomUniform(n) {
+        const out = new Array(n);
+        for (let i = 0; i < n; i++) out[i] = MathUtils.randomScalar();
+        return out;
+    },
+
+    gaussScalar() {
+        if (_portableRng !== null) return _portableRng.gauss();
+        // Legacy fallback: Box-Muller on Math.random (statistical use only).
+        const u1 = Math.max(Math.random(), 1e-300);
+        const u2 = Math.random();
+        return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+    },
+
+    randomNormal(n) {
+        const out = new Array(n);
+        for (let i = 0; i < n; i++) out[i] = MathUtils.gaussScalar();
+        return out;
+    },
 
     norm(vec) {
         return Math.sqrt(vec.reduce((sum, x) => sum + x * x, 0));
@@ -46,27 +90,97 @@ class Optimizer {
         this.nDim = nDim;
         this.evaluations = 0;
         this.bestValue = Infinity;
-        this.bestX = Array(nDim).fill(0).map(() => Math.random());
+        // Same stream position as Python: BaseOptimizer.__init__ draws
+        // best_x from the RNG (n draws) before the run starts.
+        this.bestX = MathUtils.randomUniform(nDim);
         this.trackPath = false;
         this.path = [];
+    }
+
+    _bookkeep(clippedX, value) {
+        // Track path for visualization (sample every few evaluations to avoid clutter)
+        if (this.trackPath && (this.evaluations % Math.max(1, Math.floor(this.nTrials / 20)) === 0 || this.evaluations === 1)) {
+            this.path.push([...clippedX]);
+        }
+        if (value < this.bestValue) {
+            this.bestValue = value;
+            this.bestX = [...clippedX];
+        }
+        return value;
     }
 
     evaluate(x) {
         this.evaluations++;
         const clippedX = MathUtils.clipArray(x, 0, 1);
         const value = this.objective(clippedX);
+        return this._bookkeep(clippedX, value);
+    }
 
-        // Track path for visualization (sample every few evaluations to avoid clutter)
-        if (this.trackPath && (this.evaluations % Math.max(1, Math.floor(this.nTrials / 20)) === 0 || this.evaluations === 1)) {
-            this.path.push([...clippedX]);
+    // ------------------------------------------------------------------ //
+    // Online (generator) protocol — the JS twin of BaseOptimizer._run    //
+    // driving in humpday/optimizers/base.py. A converted class defines   //
+    // *_run() and drops its optimize() override; the driver owns the     //
+    // increment/clip/objective/bookkeep order so trajectories replay the //
+    // Python transition vectors bit-for-bit under usePortableRng().      //
+    // ------------------------------------------------------------------ //
+    optimize() {
+        if (typeof this._run !== 'function') {
+            throw new Error(`${this.constructor.name} defines neither optimize() nor _run()`);
         }
-
-        if (value < this.bestValue) {
-            this.bestValue = value;
-            this.bestX = [...clippedX];
+        const gen = this._run();
+        let res = gen.next();
+        while (!res.done) {
+            this.evaluations++;
+            const clippedX = MathUtils.clipArray(res.value, 0, 1);
+            const value = this.objective(clippedX);
+            this._bookkeep(clippedX, value);
+            res = gen.next(value);
         }
+        return {
+            bestValue: this.bestValue,
+            bestX: this.bestX,
+            evaluations: this.evaluations,
+            success: true,
+            path: this.trackPath ? this.path : null
+        };
+    }
 
-        return value;
+    // Threadless scalar ask/tell over _run (subset of the Python surface;
+    // batch view arrives with the CMA-ES conversion).
+    suggestNext() {
+        if (typeof this._run !== 'function') {
+            throw new Error(`${this.constructor.name} has no _run(); ask/tell unavailable`);
+        }
+        if (!this._gd) {
+            const gen = this._run();
+            const res = gen.next();
+            this._gd = {
+                gen,
+                done: res.done,
+                pending: res.done ? null : MathUtils.clipArray(res.value, 0, 1),
+                awaiting: false,
+            };
+        }
+        const gd = this._gd;
+        if (gd.done) return null;
+        if (gd.awaiting) throw new Error('suggestNext() called again before receiveUpdate()');
+        gd.awaiting = true;
+        return gd.pending;
+    }
+
+    receiveUpdate(value) {
+        const gd = this._gd;
+        if (!gd || !gd.awaiting) throw new Error('receiveUpdate() without a matching suggestNext()');
+        gd.awaiting = false;
+        this.evaluations++;
+        this._bookkeep(gd.pending, value);
+        const res = gd.gen.next(value);
+        if (res.done) {
+            gd.done = true;
+            gd.pending = null;
+        } else {
+            gd.pending = MathUtils.clipArray(res.value, 0, 1);
+        }
     }
 
     // ------------------------------------------------------------------ //
@@ -247,9 +361,11 @@ class Optimizer {
 // Export for use in other modules
 if (typeof module !== 'undefined' && module.exports) {
     // Node.js environment
-    module.exports = { Optimizer, MathUtils };
+    module.exports = { Optimizer, MathUtils, usePortableRng, useLegacyRng };
 } else {
     // Browser environment
     window.Optimizer = Optimizer;
     window.MathUtils = MathUtils;
+    window.usePortableRng = usePortableRng;
+    window.useLegacyRng = useLegacyRng;
 }

--- a/docs/js/modules/evolutionary-algorithms.js
+++ b/docs/js/modules/evolutionary-algorithms.js
@@ -447,19 +447,12 @@ class RandomSearch extends Optimizer {
         this.name = 'RandomSearch';
     }
 
-    optimize() {
+    *_run() {
+        // Statement-for-statement twin of RandomSearch._run in
+        // humpday/optimizers/evolutionary_algorithms.py.
         while (this.evaluations < this.nTrials) {
-            const x = Array(this.nDim).fill(0).map(() => Math.random());
-            this.evaluate(x);
+            yield MathUtils.randomUniform(this.nDim);
         }
-
-        return {
-            bestValue: this.bestValue,
-            bestX: this.bestX,
-            evaluations: this.evaluations,
-            success: true,
-            path: this.trackPath ? this.path : null
-        };
     }
 }
 

--- a/docs/js/modules/prng.js
+++ b/docs/js/modules/prng.js
@@ -150,4 +150,7 @@ class PCG32 {
 
 if (typeof module !== "undefined" && module.exports) {
     module.exports = { PCG32, portableLog };
+} else {
+    window.PCG32 = PCG32;
+    window.portableLog = portableLog;
 }

--- a/docs/js/modules/search-algorithms.js
+++ b/docs/js/modules/search-algorithms.js
@@ -28,42 +28,38 @@ class Rechenberg extends Optimizer {
         this.name = 'Rechenberg';
     }
 
-    optimize() {
-        let x = Array(this.nDim).fill(0).map(() => Math.random());
-        let fx = this.evaluate(x);
-
-        let sigma = 0.1;
-        const stepMin = 1e-12;
+    *_run() {
+        // Statement-for-statement twin of Rechenberg._run in
+        // humpday/optimizers/search_algorithms.py (same draw order:
+        // one uniform vector, then per-iteration one normal vector).
         const stepMax = 1.0;
-        const window = [];
+        const stepMin = 1e-12;
         const windowSize = 10;
 
-        // Box-Muller for componentwise standard normal samples.
-        const gaussian = () => {
-            const u1 = Math.max(Math.random(), 1e-300);
-            const u2 = Math.random();
-            return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
-        };
+        let x = MathUtils.randomUniform(this.nDim);
+        let f = yield x;
+        let sigma = 0.1;
+        const window = [];
 
         while (this.evaluations < this.nTrials) {
-            // Componentwise Gaussian perturbation — sigma * z with
-            // z ~ N(0, I). Canonical (1+1)-ES, mirrors Python port.
-            const candidate = x.map(xi =>
-                MathUtils.clip(xi + sigma * gaussian(), 0, 1)
-            );
+            const z = MathUtils.randomNormal(this.nDim);
+            const xNew = MathUtils.clipArray(x.map((xi, i) => xi + sigma * z[i]), 0, 1);
 
-            const candidateFx = this.evaluate(candidate);
-            const accepted = candidateFx < fx;
+            if (this.evaluations >= this.nTrials) break;
+            const fNew = yield xNew;
+
+            const accepted = fNew < f;
             if (accepted) {
-                x = candidate;
-                fx = candidateFx;
+                x = xNew;
+                f = fNew;
             }
-            window.push(accepted ? 1 : 0);
+            window.push(accepted);
             if (window.length > windowSize) window.shift();
 
-            // Strict 1/5-rule on the rolling window.
             if (window.length >= windowSize) {
-                const rate = window.reduce((s, v) => s + v, 0) / windowSize;
+                let rate = 0.0;
+                for (const w of window) rate += w ? 1.0 : 0.0;
+                rate /= windowSize;
                 if (rate > 1 / 5) {
                     sigma = Math.min(stepMax, sigma * 1.5);
                 } else if (rate < 1 / 5) {
@@ -71,14 +67,6 @@ class Rechenberg extends Optimizer {
                 }
             }
         }
-
-        return {
-            bestValue: this.bestValue,
-            bestX: this.bestX,
-            evaluations: this.evaluations,
-            success: true,
-            path: this.trackPath ? this.path : null
-        };
     }
 }
 
@@ -338,13 +326,13 @@ class GridSearch extends Optimizer {
         this.name = 'GridSearch';
     }
 
-    optimize() {
+    *_run() {
+        // Twin of GridSearch._run in humpday/optimizers/search_algorithms.py.
         const n = this.nDim;
         const nPerAxis = Math.max(2, Math.round(Math.pow(this.nTrials, 1.0 / n)));
         const indices = new Array(n).fill(0);
         while (this.evaluations < this.nTrials) {
-            const x = indices.map(i => (i + 0.5) / nPerAxis);
-            this.evaluate(x);
+            yield indices.map(i => (i + 0.5) / nPerAxis);
             let d = n - 1;
             while (d >= 0) {
                 indices[d]++;
@@ -354,13 +342,6 @@ class GridSearch extends Optimizer {
             }
             if (d < 0) break;
         }
-        return {
-            bestValue: this.bestValue,
-            bestX: this.bestX,
-            evaluations: this.evaluations,
-            success: true,
-            path: this.trackPath ? this.path : null
-        };
     }
 }
 

--- a/tests/js_vector_replay_runner.js
+++ b/tests/js_vector_replay_runner.js
@@ -1,0 +1,90 @@
+// Replays parity/transition_vectors.json against the JS optimizer roster.
+//
+// Usage: node js_vector_replay_runner.js <Algo1,Algo2,...>
+//
+// For each vector case whose optimizer is in the given list, seeds the
+// portable PCG32 stream, drives the JS optimizer via suggestNext /
+// receiveUpdate, and compares every point and value as IEEE-754 bit
+// patterns. Emits one JSON verdict array on stdout.
+
+const fs = require("fs");
+const path = require("path");
+
+const modules = require(path.resolve(__dirname, "../docs/js/modules/index.js"));
+const { usePortableRng } = require(path.resolve(__dirname, "../docs/js/modules/base-optimizer.js"));
+
+const VECTORS = JSON.parse(
+    fs.readFileSync(path.resolve(__dirname, "../parity/transition_vectors.json"), "utf8")
+);
+
+const ALGOS = new Set(process.argv[2].split(","));
+
+function bits(x) {
+    const buf = new ArrayBuffer(8);
+    new DataView(buf).setFloat64(0, x, false);
+    return Array.from(new Uint8Array(buf))
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
+}
+
+const OBJECTIVES = {
+    sphere03: (x) => {
+        let s = 0.0;
+        for (const v of x) {
+            const d = v - 0.3;
+            s = s + d * d;
+        }
+        return s;
+    },
+    rosen01: (x) => {
+        let s = 0.0;
+        for (let i = 0; i < x.length - 1; i++) {
+            const a = x[i + 1] - x[i] * x[i];
+            const b = 1.0 - x[i];
+            s = s + 100.0 * (a * a) + b * b;
+        }
+        return s;
+    },
+};
+
+const verdicts = [];
+for (const c of VECTORS.cases) {
+    if (!ALGOS.has(c.optimizer)) continue;
+    const id = `${c.optimizer}-${c.objective}-d${c.n_dim}`;
+    const objective = OBJECTIVES[c.objective];
+    usePortableRng(BigInt(c.seed), BigInt(c.seq));
+    const opt = new modules[c.optimizer](objective, c.n_trials, c.n_dim);
+    let ok = true;
+    let detail = "";
+    let i = 0;
+    for (;;) {
+        const x = opt.suggestNext();
+        if (x === null) break;
+        if (i >= c.x.length) {
+            ok = false;
+            detail = `extra transition ${i}`;
+            break;
+        }
+        const got = x.map(bits);
+        if (JSON.stringify(got) !== JSON.stringify(c.x[i])) {
+            ok = false;
+            detail = `point ${i}: ${got} != ${c.x[i]}`;
+            break;
+        }
+        const v = objective(x);
+        if (bits(v) !== c.f[i]) {
+            ok = false;
+            detail = `value ${i}: ${bits(v)} != ${c.f[i]}`;
+            break;
+        }
+        opt.receiveUpdate(v);
+        i++;
+    }
+    if (ok && i !== c.x.length) {
+        ok = false;
+        detail = `ended early: ${i} < ${c.x.length}`;
+    }
+    verdicts.push({ id, ok, detail });
+}
+
+process.stdout.write(JSON.stringify(verdicts));

--- a/tests/test_js_vector_replay.py
+++ b/tests/test_js_vector_replay.py
@@ -1,0 +1,40 @@
+"""JS optimizers replay the Python transition vectors bit-for-bit.
+
+JS_EXACT lists the optimizers whose JavaScript implementations have been
+upgraded to statement-level twins of the Python `_run()` generators,
+drawing from the shared portable PCG32 stream. The runner drives each
+one via suggestNext/receiveUpdate and compares every point and value as
+IEEE-754 bit patterns against parity/transition_vectors.json. The list
+grows batch by batch until it covers the whole roster.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+NODE = shutil.which("node")
+RUNNER = Path(__file__).parent / "js_vector_replay_runner.js"
+
+JS_EXACT = [
+    "RandomSearch",
+    "GridSearch",
+    "Rechenberg",
+]
+
+
+@pytest.mark.skipif(not NODE, reason="node not on PATH")
+def test_js_replays_transition_vectors_bit_exactly():
+    result = subprocess.run(
+        [NODE, str(RUNNER), ",".join(JS_EXACT)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr
+    verdicts = json.loads(result.stdout)
+    assert len(verdicts) == 4 * len(JS_EXACT)
+    failures = [v for v in verdicts if not v["ok"]]
+    assert not failures, failures


### PR DESCRIPTION
RandomSearch, GridSearch and Rechenberg in JavaScript now replay the Python-recorded transition vectors bit-for-bit (12/12 cases), via the portable PCG32 stream and a JS twin of the generator driver. Existing win-rate parity and demos untouched. The JS_EXACT list in tests/test_js_vector_replay.py grows batch by batch from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)